### PR TITLE
integrate language picker

### DIFF
--- a/src/app.config.json
+++ b/src/app.config.json
@@ -1,18 +1,64 @@
 {
-  "ecmHost": "http://{hostname}:{port}",
-  "application": {
-      "name": "Alfresco Example Content Application",
-      "build": "1234"
-  },
-  "document-list": {
-      "supportedPageSizes": [25, 50, 100]
-  },
-  "files": {
-      "excluded": [
-          ".DS_Store",
-          "desktop.ini",
-          "thumbs.db",
-          ".git"
-      ]
-  }
+    "ecmHost": "http://{hostname}:{port}",
+    "application": {
+        "name": "Alfresco Example Content Application",
+        "build": "1234"
+    },
+    "document-list": {
+        "supportedPageSizes": [
+            25,
+            50,
+            100
+        ]
+    },
+    "files": {
+        "excluded": [
+            ".DS_Store",
+            "desktop.ini",
+            "thumbs.db",
+            ".git"
+        ]
+    },
+    "languages": [
+        {
+            "key": "de",
+            "label": "German"
+        },
+        {
+            "key": "en",
+            "label": "English"
+        },
+        {
+            "key": "es",
+            "label": "Spanish"
+        },
+        {
+            "key": "fr",
+            "label": "French"
+        },
+        {
+            "key": "it",
+            "label": "Italian"
+        },
+        {
+            "key": "ja",
+            "label": "Japanese"
+        },
+        {
+            "key": "nb",
+            "label": "Norwegian"
+        },
+        {
+            "key": "nl",
+            "label": "Dutch"
+        },
+        {
+            "key": "pt-BR",
+            "label": "Brazilian Portuguese"
+        },
+        {
+            "key": "ru",
+            "label": "Russian"
+        }
+    ]
 }

--- a/src/app/components/current-user/current-user.component.html
+++ b/src/app/components/current-user/current-user.component.html
@@ -11,8 +11,12 @@
     </div>
 
     <mat-menu #userMenu="matMenu" [overlapTrigger]="false">
+        <button mat-menu-item [matMenuTriggerFor]="langMenu">{{ 'APP.LANGUAGE' | translate }}</button>
         <button mat-menu-item adf-logout>
             {{ 'APP.SIGN_OUT' | translate }}
         </button>
+    </mat-menu>
+    <mat-menu #langMenu="matMenu">
+        <adf-lanugage-menu></adf-lanugage-menu>
     </mat-menu>
 </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,5 +1,6 @@
 {
     "APP": {
+        "LANGUAGE": "Language",
         "SIGN_IN": "Sign in",
         "SIGN_OUT": "Sign out",
         "NEW_MENU": {


### PR DESCRIPTION
Integrate ADF language picker with all the languages currently supported by the Content App

<img width="326" alt="screenshot 2017-10-24 18 43 00" src="https://user-images.githubusercontent.com/503991/31959681-44f4cb02-b8ed-11e7-8a97-872528a5c00d.png">

<img width="1432" alt="screenshot 2017-10-24 18 46 53" src="https://user-images.githubusercontent.com/503991/31959686-46c60626-b8ed-11e7-9c5d-fbaa1005485d.png">
 