### PR TITLE
[ACA-975] production build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+WORKDIR /usr/share/nginx/html
+COPY dist/ .
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+    app:
+        image: 'alfresco/content-app'
+        build: '.'
+        ports:
+            - 3000:80

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,27 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name  localhost;
+
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        include /etc/nginx/mime.types;
+
+        gzip on;
+        gzip_min_length 1000;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        location / {
+            # If you want to enable html5Mode(true) in your angularjs app for pretty URL
+            # then all request for your angularJS app will be through index.html
+            try_files $uri /index.html;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --open",
-    "build": "ng build",
+    "build": "ng build --prod",
+    "build:dev": "ng build && node postbuild-dev.js",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/postbuild-dev.js
+++ b/postbuild-dev.js
@@ -1,0 +1,26 @@
+/*!
+ * @license
+ * Copyright 2017 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var config = require('./dist/app.config.json');
+
+config.ecmHost = 'http://localhost:8080';
+
+fs.writeFileSync(
+    './dist/app.config.json',
+    JSON.stringify(config, null, 4)
+);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,6 @@ import { SidenavComponent } from './components/sidenav/sidenav.component';
     imports: [
         BrowserModule,
         RouterModule.forRoot(APP_ROUTES, {
-            useHash: true,
             enableTracing: false // enable for debug only
         }),
         AdfModule,


### PR DESCRIPTION
## Prerequisites:

- If using Bamboo: set the **Use an existing Dockerfile located in the task's working directory** option to "true"

## Running locally:

```sh
npm run build:dev
docker-compose up
```

Navigate to http://localhost:3000

## Teardown/Cleanup:

```sh
docker-compose down --rmi all
```

## Notes:

Docker compose file builds the local image for now and meant to be used for local runs.