### PR TITLE
[ACA-1029] Move action does not work for items in Favorites

### DIFF
--- a/src/app/common/directives/node-copy.directive.spec.ts
+++ b/src/app/common/directives/node-copy.directive.spec.ts
@@ -92,7 +92,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -112,7 +112,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.PLURAL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.PLURAL', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -131,7 +131,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.PARTIAL_SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.PARTIAL_SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -152,7 +152,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.PARTIAL_PLURAL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.PARTIAL_PLURAL', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -255,7 +255,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
 
             expect(nodesApiService.deleteNode).toHaveBeenCalledWith(createdItems[0].entry.id, { permanent: true });
@@ -279,7 +279,7 @@ describe('NodeCopyDirective', () => {
 
             expect(service.copyNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_COPY.PLURAL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_COPY.PLURAL', 'APP.ACTIONS.UNDO', 10000
             );
 
             expect(spyOnDeleteNode).toHaveBeenCalled();
@@ -300,7 +300,7 @@ describe('NodeCopyDirective', () => {
             expect(service.copyNodes).toHaveBeenCalled();
             expect(nodesApiService.deleteNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction['calls'].allArgs())
-            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'Undo', 10000],
+            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'APP.ACTIONS.UNDO', 10000],
                 ['APP.MESSAGES.ERRORS.GENERIC', '', 3000]]);
         });
 
@@ -317,7 +317,7 @@ describe('NodeCopyDirective', () => {
             expect(service.copyNodes).toHaveBeenCalled();
             expect(nodesApiService.deleteNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction['calls'].allArgs())
-            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'Undo', 10000],
+            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'APP.ACTIONS.UNDO', 10000],
                 ['APP.MESSAGES.ERRORS.GENERIC', '', 3000]]);
         });
 
@@ -334,7 +334,7 @@ describe('NodeCopyDirective', () => {
             expect(service.copyNodes).toHaveBeenCalled();
             expect(nodesApiService.deleteNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction['calls'].allArgs())
-            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'Undo', 10000],
+            .toEqual([['APP.MESSAGES.INFO.NODE_COPY.SINGULAR', 'APP.ACTIONS.UNDO', 10000],
                 ['APP.MESSAGES.ERRORS.PERMISSION', '', 3000]]);
         });
     });

--- a/src/app/common/directives/node-copy.directive.ts
+++ b/src/app/common/directives/node-copy.directive.ts
@@ -96,7 +96,7 @@ export class NodeCopyDirective {
             } catch (err) { /* Do nothing, keep the original message */ }
         }
 
-        const undo = (numberOfCopiedItems > 0) ? 'Undo' : '';
+        const undo = (numberOfCopiedItems > 0) ? this.translation.translate.instant('APP.ACTIONS.UNDO') : '';
         const withUndo = (numberOfCopiedItems > 0) ? '_WITH_UNDO' : '';
 
         this.translation.get(i18nMessageString, { success: numberOfCopiedItems, failed: failedItems }).subscribe(message => {

--- a/src/app/common/directives/node-move.directive.spec.ts
+++ b/src/app/common/directives/node-move.directive.spec.ts
@@ -107,7 +107,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -132,7 +132,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.PLURAL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.PLURAL', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -155,7 +155,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -180,7 +180,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.PLURAL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.PLURAL', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -204,7 +204,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.FAIL', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.FAIL', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -228,7 +228,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodes).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction).toHaveBeenCalledWith(
-                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.SINGULAR', 'Undo', 10000
+                'APP.MESSAGES.INFO.NODE_MOVE.SINGULAR APP.MESSAGES.INFO.NODE_MOVE.PARTIAL.SINGULAR', 'APP.ACTIONS.UNDO', 10000
             );
         });
 
@@ -348,7 +348,7 @@ describe('NodeMoveDirective', () => {
             expect(service.moveNodeAction)
                 .toHaveBeenCalledWith(movedItems.succeeded[0].itemMoved.entry, movedItems.succeeded[0].initialParentId);
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
         });
 
         it('should move node back to initial parent, after succeeded move of a single file', () => {
@@ -370,7 +370,7 @@ describe('NodeMoveDirective', () => {
 
             expect(service.moveNodeAction).toHaveBeenCalledWith(node.entry, initialParent);
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
         });
 
         it('should restore deleted folder back to initial parent, after succeeded moving all its files', () => {
@@ -396,7 +396,7 @@ describe('NodeMoveDirective', () => {
 
             expect(nodesApiService.restoreNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
         });
 
         it('should notify when error occurs on Undo Move action', () => {
@@ -422,7 +422,7 @@ describe('NodeMoveDirective', () => {
 
             expect(nodesApiService.restoreNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
             expect(notificationService.openSnackMessage)
                 .toHaveBeenCalledWith('APP.MESSAGES.ERRORS.GENERIC', 3000);
         });
@@ -449,7 +449,7 @@ describe('NodeMoveDirective', () => {
 
             expect(nodesApiService.restoreNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
             expect(notificationService.openSnackMessage)
                 .toHaveBeenCalledWith('APP.MESSAGES.ERRORS.GENERIC', 3000);
         });
@@ -477,7 +477,7 @@ describe('NodeMoveDirective', () => {
             expect(service.moveNodes).toHaveBeenCalled();
             expect(nodesApiService.restoreNode).toHaveBeenCalled();
             expect(notificationService.openSnackMessageAction)
-                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'Undo', 10000);
+                .toHaveBeenCalledWith('APP.MESSAGES.INFO.NODE_MOVE.SINGULAR', 'APP.ACTIONS.UNDO', 10000);
             expect(notificationService.openSnackMessage)
                 .toHaveBeenCalledWith('APP.MESSAGES.ERRORS.PERMISSION', 3000);
         });

--- a/src/app/common/directives/node-move.directive.ts
+++ b/src/app/common/directives/node-move.directive.ts
@@ -46,7 +46,7 @@ export class NodeMoveDirective {
     ) {}
 
     moveSelected() {
-        const permissionForMove: string = 'delete';
+        const permissionForMove = '!';
 
         Observable.zip(
             this.nodeActionsService.moveNodes(this.selection, permissionForMove),
@@ -110,7 +110,7 @@ export class NodeMoveDirective {
             errorMessage = this.getErrorMessage(info);
         }
 
-        const undo = (succeeded + partiallySucceeded > 0) ? 'Undo' : '';
+        const undo = (succeeded + partiallySucceeded > 0) ? this.translation.translate.instant('APP.ACTIONS.UNDO') : '';
         const withUndo = errorMessage ? '' : '_WITH_UNDO';
         failedMessage = errorMessage ?  errorMessage : failedMessage;
 

--- a/src/app/common/services/node-actions.service.ts
+++ b/src/app/common/services/node-actions.service.ts
@@ -170,7 +170,7 @@ export class NodeActionsService {
 
         let nodeEntryName = '';
         if (contentEntities.length === 1 && contentEntities[0].entry.name) {
-            nodeEntryName =  `${contentEntities[0].entry.name} `;
+            nodeEntryName =  `'${contentEntities[0].entry.name}' `;
         }
 
         const data: ContentNodeSelectorComponentData = {


### PR DESCRIPTION
-fix move on favorites
-ensure translation of 'Undo' from notification bar
-add '' to file name displayed on destination picker's title