### PR TITLE
Don't try to port map to 80 as it is < 1024 in docker docs

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -35,10 +35,10 @@ docker image build -t content-app .
 To run the image locally, you can use the following command:
 
 ```sh
-docker container run -p 80:80 --rm content-app
+docker container run -p 8888:80 --rm content-app
 ```
 
-Navigate to "http://localhost" to access the running application.
+Navigate to "http://localhost:8888" to access the running application.
 
 ## Docker Compose file
 


### PR DESCRIPTION
In the docker example we were proposing that folks map port 80 from the docker container to port 80 on localhost. Unless the user is running as root, they likely won't be able to bind to any port < 1024. As such, I am proposing we bind to the local port 8888. Could change it to 3000 to be in-line with the `docker compose` example; but to me the use cases are different so I like having different ports...