### PR TITLE
[ACA-1137] Spike - Improving speed of unit tests 

### DIFF
--- a/src/app/common/directives/node-copy.directive.spec.ts
+++ b/src/app/common/directives/node-copy.directive.spec.ts
@@ -29,11 +29,20 @@ import { By } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs/Rx';
 
-import { TranslationService, NodesApiService, NotificationService } from '@alfresco/adf-core';
+import {
+    TranslationService, NodesApiService, NotificationService, AlfrescoApiService, TranslationMock,
+    AppConfigService, StorageService, CookieService, ContentService, AuthenticationService,
+    UserPreferencesService, LogService, ThumbnailService
+} from '@alfresco/adf-core';
+import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientModule } from '@angular/common/http';
 
-import { CommonModule } from '../common.module';
 import { NodeActionsService } from '../services/node-actions.service';
 import { NodeCopyDirective } from './node-copy.directive';
+import { ContentManagementService } from '../services/content-management.service';
+import { MatSnackBarModule, MatDialogModule, MatIconModule } from '@angular/material';
+import { DocumentListService } from '@alfresco/adf-content-services';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
     template: '<div [app-copy-node]="selection"></div>'
@@ -54,10 +63,33 @@ describe('NodeCopyDirective', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                CommonModule
+                NoopAnimationsModule,
+                HttpClientModule,
+                TranslateModule.forRoot(),
+                MatSnackBarModule,
+                MatDialogModule,
+                MatIconModule
             ],
             declarations: [
-                TestComponent
+                TestComponent,
+                NodeCopyDirective
+            ],
+            providers: [
+                AlfrescoApiService,
+                AuthenticationService,
+                AppConfigService,
+                StorageService,
+                ContentService,
+                UserPreferencesService,
+                LogService,
+                CookieService,
+                NotificationService,
+                NodesApiService,
+                NodeActionsService,
+                { provide: TranslationService, useClass: TranslationMock },
+                ContentManagementService,
+                DocumentListService,
+                ThumbnailService
             ]
         });
 

--- a/src/app/common/directives/node-copy.directive.ts
+++ b/src/app/common/directives/node-copy.directive.ts
@@ -104,7 +104,7 @@ export class NodeCopyDirective {
             } catch (err) { /* Do nothing, keep the original message */ }
         }
 
-        const undo = (numberOfCopiedItems > 0) ? this.translation.translate.instant('APP.ACTIONS.UNDO') : '';
+        const undo = (numberOfCopiedItems > 0) ? this.translation.instant('APP.ACTIONS.UNDO') : '';
         const withUndo = (numberOfCopiedItems > 0) ? '_WITH_UNDO' : '';
 
         this.translation.get(i18nMessageString, { success: numberOfCopiedItems, failed: failedItems }).subscribe(message => {

--- a/src/app/common/services/node-actions.service.spec.ts
+++ b/src/app/common/services/node-actions.service.spec.ts
@@ -24,15 +24,21 @@
  */
 
 import { TestBed, async } from '@angular/core/testing';
-import { MatDialog } from '@angular/material';
+import { MatDialog, MatDialogModule, MatIconModule } from '@angular/material';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { Observable } from 'rxjs/Rx';
-import { AlfrescoApiService, NodesApiService, TranslationService } from '@alfresco/adf-core';
+import {
+    TranslationMock, AlfrescoApiService, NodesApiService,
+    TranslationService, ContentService, AuthenticationService,
+    UserPreferencesService, AppConfigService, StorageService,
+    CookieService, LogService, ThumbnailService
+} from '@alfresco/adf-core';
 import { DocumentListService } from '@alfresco/adf-content-services';
 
-import { CommonModule } from '../common.module';
 import { NodeActionsService } from './node-actions.service';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
+import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientModule } from '@angular/common/http';
 
 class TestNode {
     entry?: MinimalNodeEntryEntity;
@@ -104,8 +110,26 @@ describe('NodeActionsService', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                CommonModule,
+                MatDialogModule,
+                MatIconModule,
+                HttpClientModule,
+                TranslateModule.forRoot(),
                 OverlayModule
+            ],
+            providers: [
+                AlfrescoApiService,
+                NodesApiService,
+                { provide: TranslationService, useClass: TranslationMock },
+                AuthenticationService,
+                UserPreferencesService,
+                AppConfigService,
+                CookieService,
+                LogService,
+                ThumbnailService,
+                StorageService,
+                ContentService,
+                DocumentListService,
+                NodeActionsService
             ]
         });
 

--- a/src/app/components/preview/preview.component.spec.ts
+++ b/src/app/components/preview/preview.component.spec.ts
@@ -23,14 +23,15 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
-import { AlfrescoApiService, UserPreferencesService } from '@alfresco/adf-core';
+import { CoreModule, AlfrescoApiService, UserPreferencesService } from '@alfresco/adf-core';
 
-import { CommonModule } from '../../common/common.module';
 import { PreviewComponent } from './preview.component';
 import { Observable } from 'rxjs/Rx';
+import { ContentManagementService } from '../../common/services/content-management.service';
 
 describe('PreviewComponent', () => {
 
@@ -45,11 +46,15 @@ describe('PreviewComponent', () => {
         TestBed.configureTestingModule({
                 imports: [
                     RouterTestingModule,
-                    CommonModule
+                    CoreModule
+                ],
+                providers: [
+                    ContentManagementService
                 ],
                 declarations: [
                     PreviewComponent
-                ]
+                ],
+                schemas: [ NO_ERRORS_SCHEMA ]
         })
         .compileComponents().then(() => {
             fixture = TestBed.createComponent(PreviewComponent);

--- a/src/app/components/preview/preview.component.spec.ts
+++ b/src/app/components/preview/preview.component.spec.ts
@@ -27,11 +27,17 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
-import { CoreModule, AlfrescoApiService, UserPreferencesService } from '@alfresco/adf-core';
+import {
+    AlfrescoApiService, UserPreferencesService, TranslationService, TranslationMock,
+    AppConfigService, StorageService, CookieService, NotificationService
+} from '@alfresco/adf-core';
+import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientModule } from '@angular/common/http';
 
 import { PreviewComponent } from './preview.component';
 import { Observable } from 'rxjs/Rx';
 import { ContentManagementService } from '../../common/services/content-management.service';
+import { MatSnackBarModule } from '@angular/material';
 
 describe('PreviewComponent', () => {
 
@@ -45,10 +51,19 @@ describe('PreviewComponent', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
                 imports: [
+                    HttpClientModule,
                     RouterTestingModule,
-                    CoreModule
+                    TranslateModule.forRoot(),
+                    MatSnackBarModule
                 ],
                 providers: [
+                    { provide: TranslationService, useClass: TranslationMock },
+                    AlfrescoApiService,
+                    AppConfigService,
+                    StorageService,
+                    CookieService,
+                    NotificationService,
+                    UserPreferencesService,
                     ContentManagementService
                 ],
                 declarations: [


### PR DESCRIPTION
## Results of the research:

- tests need to references only the minimal required modules/services/etc.
- use `NO_ERRORS_SCHEMA` instead of recreating entire application tree for each test run
- avoid using CoreModule or any module that has massive sets of imports (i.e Material modules)

## Example results:

**SidenavComponent**

Before: Executed 6 of 299 (skipped 293) SUCCESS (22.266 secs / 21.643 secs)
After: Executed 6 of 299 (skipped 293) SUCCESS (7.888 secs / 7.607 secs)

**PreviewComponent**

Before: Executed 45 of 299 (skipped 254) SUCCESS (1 min 6.31 secs / 1 min 6.028 secs)
After: Executed 45 of 299 (skipped 254) SUCCESS (1.74 secs / 1.516 secs)

**NodeActionsService**

Before: Executed 62 of 299 (skipped 237) SUCCESS (1 min 38.092 secs / 1 min 37.774 secs)
After: Executed 62 of 299 (skipped 237) SUCCESS (1.425 secs / 1.215 secs)