### PR TITLE
move empty folder UI into separate component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -51,6 +51,7 @@ import { SearchComponent } from './components/search/search.component';
 import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { AboutComponent } from './components/about/about.component';
 import { LocationLinkComponent } from './components/location-link/location-link.component';
+import { EmptyFolderComponent } from './components/empty-folder/empty-folder.component';
 
 @NgModule({
     imports: [
@@ -80,7 +81,8 @@ import { LocationLinkComponent } from './components/location-link/location-link.
         TrashcanComponent,
         PreviewComponent,
         AboutComponent,
-        LocationLinkComponent
+        LocationLinkComponent,
+        EmptyFolderComponent
     ],
     providers: [
         {

--- a/src/app/components/empty-folder/empty-folder.component.html
+++ b/src/app/components/empty-folder/empty-folder.component.html
@@ -1,0 +1,6 @@
+<div class="app-empty-folder">
+    <mat-icon class="app-empty-folder__icon">{{ icon }}</mat-icon>
+    <p class="app-empty-folder__title">{{ title | translate }}</p>
+    <p class="app-empty-folder__subtitle">{{ subtitle | translate }}</p>
+    <ng-content></ng-content>
+</div>

--- a/src/app/components/empty-folder/empty-folder.component.scss
+++ b/src/app/components/empty-folder/empty-folder.component.scss
@@ -1,0 +1,29 @@
+@import 'variables';
+
+.app-empty-folder {
+    color: $alfresco-secondary-text-color;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    &__icon {
+        font-size: 52px;
+        height: 52px;
+        width: 52px;
+    }
+
+    p {
+        line-height: 0;
+    }
+
+    &__title {
+        font-size: 18px;
+        font-weight: 600;
+    }
+
+    &__subtitle,
+    &__text {
+        font-size: 14px;
+        font-weight: 300;
+    }
+}

--- a/src/app/components/empty-folder/empty-folder.component.spec.ts
+++ b/src/app/components/empty-folder/empty-folder.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EmptyFolderComponent } from './empty-folder.component';
+
+describe('EmptyFolderComponent', () => {
+  let component: EmptyFolderComponent;
+  let fixture: ComponentFixture<EmptyFolderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ EmptyFolderComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EmptyFolderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/empty-folder/empty-folder.component.spec.ts
+++ b/src/app/components/empty-folder/empty-folder.component.spec.ts
@@ -1,25 +1,33 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { EmptyFolderComponent } from './empty-folder.component';
 
 describe('EmptyFolderComponent', () => {
-  let component: EmptyFolderComponent;
-  let fixture: ComponentFixture<EmptyFolderComponent>;
+    let component: EmptyFolderComponent;
+    let fixture: ComponentFixture<EmptyFolderComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ EmptyFolderComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                MatIconModule,
+                TranslateModule.forRoot()
+            ],
+            declarations: [
+                EmptyFolderComponent
+            ]
+        })
+        .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EmptyFolderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(EmptyFolderComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/components/empty-folder/empty-folder.component.ts
+++ b/src/app/components/empty-folder/empty-folder.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, ChangeDetectionStrategy, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-empty-folder',
+  templateUrl: './empty-folder.component.html',
+  styleUrls: ['./empty-folder.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  // tslint:disable-next-line:use-host-property-decorator
+  host: { class: 'app-empty-folder' }
+})
+export class EmptyFolderComponent {
+
+    @Input()
+    icon = 'cake';
+
+    @Input()
+    title = '';
+
+    @Input()
+    subtitle = '';
+}

--- a/src/app/components/favorites/favorites.component.html
+++ b/src/app/components/favorites/favorites.component.html
@@ -88,11 +88,11 @@
 
             <empty-folder-content>
                 <ng-template>
-                    <div class="empty-list__block">
-                        <mat-icon>star_rate</mat-icon>
-                        <p class="empty-list__title">{{ 'APP.BROWSE.FAVORITES.EMPTY_STATE.TITLE' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.FAVORITES.EMPTY_STATE.TEXT' | translate }}</p>
-                    </div>
+                    <app-empty-folder
+                        icon="star_rate"
+                        title="APP.BROWSE.FAVORITES.EMPTY_STATE.TITLE"
+                        subtitle="APP.BROWSE.FAVORITES.EMPTY_STATE.TEXT">
+                    </app-empty-folder>
                 </ng-template>
             </empty-folder-content>
 

--- a/src/app/components/libraries/libraries.component.html
+++ b/src/app/components/libraries/libraries.component.html
@@ -21,11 +21,11 @@
 
             <empty-folder-content>
                 <ng-template>
-                    <div class="empty-list__block">
-                        <mat-icon>group_work</mat-icon>
-                        <p class="empty-list__title">{{ 'APP.BROWSE.LIBRARIES.EMPTY_STATE.TITLE' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.LIBRARIES.EMPTY_STATE.TEXT' | translate }}</p>
-                    </div>
+                    <app-empty-folder
+                        icon="group_work"
+                        title="APP.BROWSE.LIBRARIES.EMPTY_STATE.TITLE"
+                        subtitle="APP.BROWSE.LIBRARIES.EMPTY_STATE.TEXT">
+                    </app-empty-folder>
                 </ng-template>
             </empty-folder-content>
 

--- a/src/app/components/recent-files/recent-files.component.html
+++ b/src/app/components/recent-files/recent-files.component.html
@@ -84,11 +84,11 @@
 
             <empty-folder-content>
                 <ng-template>
-                    <div class="empty-list__block">
-                        <mat-icon>access_time</mat-icon>
-                        <p class="empty-list__title">{{ 'APP.BROWSE.RECENT.EMPTY_STATE.TITLE' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.RECENT.EMPTY_STATE.TEXT' | translate }}</p>
-                    </div>
+                    <app-empty-folder
+                        icon="access_time"
+                        title="APP.BROWSE.RECENT.EMPTY_STATE.TITLE"
+                        subtitle="APP.BROWSE.RECENT.EMPTY_STATE.TEXT">
+                    </app-empty-folder>
                 </ng-template>
             </empty-folder-content>
 

--- a/src/app/components/shared-files/shared-files.component.html
+++ b/src/app/components/shared-files/shared-files.component.html
@@ -89,11 +89,11 @@
 
             <empty-folder-content>
                 <ng-template>
-                    <div class="empty-list__block">
-                        <mat-icon>people</mat-icon>
-                        <p class="empty-list__title">{{ 'APP.BROWSE.SHARED.EMPTY_STATE.TITLE' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.SHARED.EMPTY_STATE.TEXT' | translate }}</p>
-                    </div>
+                    <app-empty-folder
+                        icon="people"
+                        title="APP.BROWSE.SHARED.EMPTY_STATE.TITLE"
+                        subtitle="APP.BROWSE.SHARED.EMPTY_STATE.TEXT">
+                    </app-empty-folder>
                 </ng-template>
             </empty-folder-content>
 

--- a/src/app/components/trashcan/trashcan.component.html
+++ b/src/app/components/trashcan/trashcan.component.html
@@ -38,12 +38,12 @@
 
             <empty-folder-content>
                 <ng-template>
-                    <div class="empty-list__block">
-                        <mat-icon>delete</mat-icon>
-                        <p class="empty-list__title">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.TITLE' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.FIRST_TEXT' | translate }}</p>
-                        <p class="empty-list__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.SECOND_TEXT' | translate }}</p>
-                    </div>
+                    <app-empty-folder
+                        icon="delete"
+                        title="APP.BROWSE.RECENT.EMPTY_STATE.TITLE">
+                        <p class="app-empty-folder__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.FIRST_TEXT' | translate }}</p>
+                        <p class="app-empty-folder__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.SECOND_TEXT' | translate }}</p>
+                    </app-empty-folder>
                 </ng-template>
             </empty-folder-content>
 

--- a/src/app/ui/overrides/_alfresco-document-list.scss
+++ b/src/app/ui/overrides/_alfresco-document-list.scss
@@ -98,31 +98,4 @@ adf-document-list {
             cursor: default;
         }
     }
-
-    &__block {
-        color: $alfresco-secondary-text-color;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-
-        p {
-            line-height: 0;
-        }
-    }
-
-    &__title {
-        font-size: 18px;
-        font-weight: 600;
-    }
-
-    &__subtitle {
-        font-size: 14px;
-        font-weight: 300;
-    }
-
-    &__block > mat-icon {
-        font-size: 52px;
-        height: 52px;
-        width: 52px;
-    }
 }


### PR DESCRIPTION
- move "empty folder" to a separate component
- remove styles from the document list that are related to old "empty folder" implementation