### PR TITLE
[ACA-1145] File name incorrectly appears in the breadcrumb when opening the destination picker for a shared node when user does not have permissions on node's parent folder

### DIFF
--- a/src/app/common/directives/node-move.directive.ts
+++ b/src/app/common/directives/node-move.directive.ts
@@ -125,7 +125,7 @@ export class NodeMoveDirective {
         const beforePartialSuccessMessage = (successMessage && partialSuccessMessage) ? ' ' : '';
         const beforeFailedMessage = ((successMessage || partialSuccessMessage) && failedMessage) ? ' ' : '';
 
-        const initialParentId = this.nodeActionsService.getFirstParentId(this.selection);
+        const initialParentId = this.nodeActionsService.getEntryParentId(this.selection[0]);
 
         this.translation.get(
             [successMessage, partialSuccessMessage, failedMessage],

--- a/src/app/common/directives/node-move.directive.ts
+++ b/src/app/common/directives/node-move.directive.ts
@@ -125,7 +125,7 @@ export class NodeMoveDirective {
         const beforePartialSuccessMessage = (successMessage && partialSuccessMessage) ? ' ' : '';
         const beforeFailedMessage = ((successMessage || partialSuccessMessage) && failedMessage) ? ' ' : '';
 
-        const initialParentId = this.nodeActionsService.getEntryParentId(this.selection[0]);
+        const initialParentId = this.nodeActionsService.getEntryParentId(this.selection[0].entry);
 
         this.translation.get(
             [successMessage, partialSuccessMessage, failedMessage],

--- a/src/app/common/services/node-actions.service.spec.ts
+++ b/src/app/common/services/node-actions.service.spec.ts
@@ -223,36 +223,6 @@ describe('NodeActionsService', () => {
         }));
     });
 
-    describe('getFirstParentId', () => {
-        it('should give the parentId, if that exists on the node entry', () => {
-            const parentID = 'parent-id';
-            const contentEntities = [ {entry: {nodeId: '1234', parentId: parentID}} ];
-
-            expect(service.getFirstParentId(contentEntities)).toBe(parentID);
-        });
-
-        it('should give the last element in path property, if parentId is missing and path exists on the node entry', () => {
-            const firstParentId = 'parent-0-id';
-            const contentEntities = [ {entry: {nodeId: '1234', path: {elements: [ {id: 'parent-1-id'}, { id: firstParentId} ]} }} ];
-
-            expect(service.getFirstParentId(contentEntities)).toBe(firstParentId);
-        });
-
-        it('should give the id of the first node entry, if none of nodes has either parentId, or path properties', () => {
-            const nodeID = '1234';
-            const contentEntities = [ {entry: {id: nodeID}}, {entry: {id: `${nodeID}-2`}} ];
-
-            expect(service.getFirstParentId(contentEntities)).toBe(nodeID);
-        });
-
-        it('should give the nodeId of the first node entry, if none of nodes has either parentId, or path properties', () => {
-            const nodeID = '1234';
-            const contentEntities = [ {entry: {nodeId: nodeID}}, {entry: {id: `${nodeID}-2`}}  ];
-
-            expect(service.getFirstParentId(contentEntities)).toBe(nodeID);
-        });
-    });
-
     describe('getEntryParentId', () => {
         it('should return the parentId, if that exists on the node entry', () => {
             const parentID = 'parent-id';
@@ -278,7 +248,7 @@ describe('NodeActionsService', () => {
             fileToCopy = new TestNode(fileId, isFile, 'file-name');
             folderToCopy = new TestNode();
 
-            spyOn(service, 'getFirstParentId').and.returnValue('parent-id');
+            spyOn(service, 'getEntryParentId').and.returnValue('parent-id');
 
             const dialog = TestBed.get(MatDialog);
             spyOn(dialog, 'open').and.callFake((contentNodeSelectorComponent: any, data: any) => {
@@ -335,7 +305,7 @@ describe('NodeActionsService', () => {
         it('should use the custom data object with custom rowFilter & imageResolver & title with destination picker', () => {
             const spyOnBatchOperation = spyOn(service, 'doBatchOperation').and.callThrough();
             const spyOnDestinationPicker = spyOn(service, 'getContentNodeSelection').and.callThrough();
-            spyOn(service, 'getFirstParentId').and.returnValue('parent-id');
+            spyOn(service, 'getEntryParentId').and.returnValue('parent-id');
 
             let testContentNodeSelectorComponentData;
             const dialog = TestBed.get(MatDialog);
@@ -363,7 +333,7 @@ describe('NodeActionsService', () => {
         it('should use the ContentNodeSelectorComponentData object with file name in title', () => {
             const spyOnBatchOperation = spyOn(service, 'doBatchOperation').and.callThrough();
             spyOn(service, 'getContentNodeSelection').and.callThrough();
-            spyOn(service, 'getFirstParentId').and.returnValue('parent-id');
+            spyOn(service, 'getEntryParentId').and.returnValue('parent-id');
 
             let testContentNodeSelectorComponentData;
             const dialog = TestBed.get(MatDialog);
@@ -383,7 +353,7 @@ describe('NodeActionsService', () => {
         it('should use the ContentNodeSelectorComponentData object without file name in title, if no name exists', () => {
             const spyOnBatchOperation = spyOn(service, 'doBatchOperation').and.callThrough();
             spyOn(service, 'getContentNodeSelection').and.callThrough();
-            spyOn(service, 'getFirstParentId').and.returnValue('parent-id');
+            spyOn(service, 'getEntryParentId').and.returnValue('parent-id');
 
             let testContentNodeSelectorComponentData;
             const dialog = TestBed.get(MatDialog);

--- a/src/app/common/services/node-actions.service.ts
+++ b/src/app/common/services/node-actions.service.ts
@@ -144,22 +144,6 @@ export class NodeActionsService {
         return !notAllowedNode;
     }
 
-    getFirstParentId(nodeEntities: any[]): string {
-        for (let i = 0; i < nodeEntities.length; i++) {
-            const nodeEntry = nodeEntities[i].entry;
-
-            if (nodeEntry.parentId) {
-                return nodeEntry.parentId;
-
-            } else if (nodeEntry.path && nodeEntry.path.elements && nodeEntry.path.elements.length) {
-                return nodeEntry.path.elements[nodeEntry.path.elements.length - 1].id;
-            }
-        }
-
-        // if no parent data is found, return the id of first item / the nodeId in case of Shared Files
-        return nodeEntities[0].entry.nodeId || nodeEntities[0].entry.id;
-    }
-
     getEntryParentId(nodeEntry: any) {
         let entryParentId = '';
 
@@ -174,7 +158,7 @@ export class NodeActionsService {
     }
 
     getContentNodeSelection(action: string, contentEntities: MinimalNodeEntity[]): Subject<MinimalNodeEntryEntity[]> {
-        const currentParentFolderId = this.getFirstParentId(contentEntities);
+        const currentParentFolderId = this.getEntryParentId(contentEntities[0]);
 
         const customDropdown: SitePaging = {
             list: {


### PR DESCRIPTION
fixed bug https://issues.alfresco.com/jira/browse/ACA-1145 