### PR TITLE
[ACA-1215] Remove workaround because of broken navigation on -mysites-

### DIFF
--- a/src/app/common/services/node-actions.service.ts
+++ b/src/app/common/services/node-actions.service.ts
@@ -299,7 +299,7 @@ export class NodeActionsService {
 
         // replace first item with 'File Libraries'
         elements[0].name = this.translation.instant('APP.BROWSE.LIBRARIES.TITLE');
-        // elements[0].id = '-mysites-'; // commented this until navigation on custom sources is enabled on document-list
+        elements[0].id = '-mysites-';
 
         if (this.isSiteContainer(node)) {
             // rename 'documentLibrary' entry to the target site display name


### PR DESCRIPTION
latest ADF changes allow us to set the right breadcrumb rootId for FileLibraries on Document Picker