### PR TITLE
[ACA-1266] use 'npm ci' for faster installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ services:
   - docker
 
 install:
-  - npm install
+  - npm install -g npm@latest
+  - npm ci
 
 script:
   - npm run build

--- a/README.md
+++ b/README.md
@@ -27,18 +27,21 @@ please include a clear description, steps to reproduce and screenshots where app
 All issues will be reviewed; bugs will be categorized if reproducible and enhancement/feature suggestions
 will be considered against existing priorities if the use case serves a general-purpose need.
 
+## Want to help?
+
+Want to file a bug, contribute some code, or improve documentation? Excellent!
+Read up on our guidelines for [contributing][contributing]
+and then check out one of our issues in the [Jira][jira] or [GitHub][github]
+
 ## Development server
 
 Run `npm start` for a dev server. Navigate to `http://localhost:3000/` (opens by default).
 The app will automatically reload if you change any of the source files.
 
-## Code scaffolding
-
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
-
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Use the `--prod` flag for a production build.
 
 ## Running unit tests
 
@@ -48,25 +51,10 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
-## Running documentation locally
-
-For development purposes, you can run and test documentation locally.
-That is useful when working in different branches instead of a `master` one.
-
-Run the following command to install the lightweight development server [wsrv](https://denysvuika.gitlab.io/wsrv/#/):
-
-```sh
-npm install -g wsrv
-```
-
-Now you can use the next command to serve the documentation folder in the browser:
-
-```sh
-wsrv docs/ -s -l -o
-```
-
-The browser page is going to automatically reload upon changes.
-
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+[contributing]: ttps://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md
+[github]: https://github.com/Alfresco/alfresco-content-app/issues
+[jira]: https://issues.alfresco.com/jira/projects/ACA


### PR DESCRIPTION
- use 'npm ci' for CI mode