### PR TITLE
Disable toolbar buttons instead of hiding

### DIFF
--- a/src/app/components/favorites/favorites.component.html
+++ b/src/app/components/favorites/favorites.component.html
@@ -8,7 +8,7 @@
             <button
                 mat-icon-button
                 color="primary"
-                *ngIf="canPreviewFile(documentList.selection)"
+                [disabled]="!canPreviewFile(documentList.selection)"
                 title="{{ 'APP.ACTIONS.VIEW' | translate }}"
                 (click)="onNodeDoubleClick(documentList.selection[0]?.entry)">
                 <mat-icon>open_in_browser</mat-icon>
@@ -17,7 +17,7 @@
             <button
                 mat-icon-button
                 color="primary"
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.DOWNLOAD' | translate }}"
                 [adfNodeDownload]="documentList.selection">
                 <mat-icon>get_app</mat-icon>
@@ -26,7 +26,7 @@
             <button
                 mat-icon-button
                 color="primary"
-                *ngIf="showEditOption(documentList.selection)"
+                [disabled]="!showEditOption(documentList.selection)"
                 title="{{ 'APP.ACTIONS.EDIT' | translate }}"
                 (error)="openSnackMessage($event)"
                 [adf-edit-folder]="documentList.selection[0]?.entry">
@@ -35,7 +35,7 @@
 
             <button mat-icon-button
                 [color]="infoDrawerOpened ? 'accent' : 'primary'"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.DETAILS' | translate }}"
                 (click)="toggleSidebar()">
                 <mat-icon>info_outline</mat-icon>
@@ -44,7 +44,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.MORE' | translate }}"
                 [matMenuTriggerFor]="actionsMenu">
                 <mat-icon>more_vert</mat-icon>
@@ -89,7 +89,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="isFileSelected(documentList.selection)"
+                    [disabled]="!isFileSelected(documentList.selection)"
                     [app-node-versions]="documentList.selection">
                     <mat-icon color="primary">history</mat-icon>
                     <span>{{ 'APP.ACTIONS.VERSIONS' | translate }}</span>

--- a/src/app/components/files/files.component.html
+++ b/src/app/components/files/files.component.html
@@ -10,7 +10,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="canPreviewFile(documentList.selection)"
+                [disabled]="!canPreviewFile(documentList.selection)"
                 title="{{ 'APP.ACTIONS.VIEW' | translate }}"
                 (click)="showPreview(documentList.selection[0]?.entry)">
                 <mat-icon>open_in_browser</mat-icon>
@@ -19,7 +19,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.DOWNLOAD' | translate }}"
                 [adfNodeDownload]="documentList.selection">
                 <mat-icon>get_app</mat-icon>
@@ -28,7 +28,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="canEditFolder(documentList.selection)"
+                [disabled]="!canEditFolder(documentList.selection)"
                 title="{{ 'APP.ACTIONS.EDIT' | translate }}"
                 (error)="openSnackMessage($event)"
                 [adf-edit-folder]="documentList.selection[0]?.entry">
@@ -37,7 +37,7 @@
 
             <button mat-icon-button
                 [color]="infoDrawerOpened ? 'accent' : 'primary'"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.DETAILS' | translate }}"
                 (click)="toggleSidebar()">
                 <mat-icon>info_outline</mat-icon>
@@ -46,7 +46,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.MORE' | translate }}"
                 [matMenuTriggerFor]="actionsMenu">
                 <mat-icon>more_vert</mat-icon>
@@ -77,7 +77,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canMove(documentList.selection)"
+                    [disabled]="!canMove(documentList.selection)"
                     [app-move-node]="documentList.selection">
                     <mat-icon color="primary">library_books</mat-icon>
                     <span>{{ 'APP.ACTIONS.MOVE' | translate }}</span>
@@ -85,7 +85,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canDelete(documentList.selection)"
+                    [disabled]="!canDelete(documentList.selection)"
                     [app-delete-node]="documentList.selection">
                     <mat-icon color="primary">delete</mat-icon>
                     <span>{{ 'APP.ACTIONS.DELETE' | translate }}</span>
@@ -93,7 +93,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canManageVersions(documentList.selection)"
+                    [disabled]="!canManageVersions(documentList.selection)"
                     [app-node-versions]="documentList.selection">
                     <mat-icon color="primary">history</mat-icon>
                     <span>{{ 'APP.ACTIONS.VERSIONS' | translate }}</span>

--- a/src/app/components/recent-files/recent-files.component.html
+++ b/src/app/components/recent-files/recent-files.component.html
@@ -8,7 +8,7 @@
             <button
                 mat-icon-button
                 color="primary"
-                *ngIf="canPreviewFile(documentList.selection)"
+                [disabled]="!canPreviewFile(documentList.selection)"
                 title="{{ 'APP.ACTIONS.VIEW' | translate }}"
                 (click)="onNodeDoubleClick(documentList.selection[0]?.entry)">
                 <mat-icon>open_in_browser</mat-icon>
@@ -17,7 +17,7 @@
             <button
                 mat-icon-button
                 color="primary"
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.DOWNLOAD' | translate }}"
                 [adfNodeDownload]="documentList.selection">
                 <mat-icon>get_app</mat-icon>
@@ -25,7 +25,7 @@
 
             <button mat-icon-button
                 [color]="infoDrawerOpened ? 'accent' : 'primary'"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.DETAILS' | translate }}"
                 (click)="toggleSidebar()">
                 <mat-icon>info_outline</mat-icon>
@@ -34,7 +34,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.MORE' | translate }}"
                 [matMenuTriggerFor]="actionsMenu">
                 <mat-icon>more_vert</mat-icon>
@@ -65,7 +65,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canMove(documentList.selection)"
+                    [disabled]="!canMove(documentList.selection)"
                     [app-move-node]="documentList.selection">
                     <mat-icon color="primary">library_books</mat-icon>
                     <span>{{ 'APP.ACTIONS.MOVE' | translate }}</span>
@@ -73,7 +73,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canDelete(documentList.selection)"
+                    [disabled]="!canDelete(documentList.selection)"
                     [app-delete-node]="documentList.selection">
                     <mat-icon color="primary">delete</mat-icon>
                     <span>{{ 'APP.ACTIONS.DELETE' | translate }}</span>
@@ -81,7 +81,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="canManageVersions(documentList.selection)"
+                    [disabled]="!canManageVersions(documentList.selection)"
                     [app-node-versions]="documentList.selection">
                     <mat-icon color="primary">history</mat-icon>
                     <span>{{ 'APP.ACTIONS.VERSIONS' | translate }}</span>

--- a/src/app/components/shared-files/shared-files.component.html
+++ b/src/app/components/shared-files/shared-files.component.html
@@ -7,7 +7,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="canPreviewFile(documentList.selection)"
+                [disabled]="!canPreviewFile(documentList.selection)"
                 title="{{ 'APP.ACTIONS.VIEW' | translate }}"
                 (click)="onNodeDoubleClick(documentList.selection[0]?.entry)">
                 <mat-icon>open_in_browser</mat-icon>
@@ -16,7 +16,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.DOWNLOAD' | translate }}"
                 [adfNodeDownload]="documentList.selection">
                 <mat-icon>get_app</mat-icon>
@@ -24,7 +24,7 @@
 
             <button mat-icon-button
                 [color]="infoDrawerOpened ? 'accent' : 'primary'"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.DETAILS' | translate }}"
                 (click)="toggleSidebar()">
                 <mat-icon>info_outline</mat-icon>
@@ -33,7 +33,7 @@
             <button
                 color="primary"
                 mat-icon-button
-                *ngIf="hasSelection(documentList.selection)"
+                [disabled]="!hasSelection(documentList.selection)"
                 title="{{ 'APP.ACTIONS.MORE' | translate }}"
                 [matMenuTriggerFor]="actionsMenu">
                 <mat-icon>more_vert</mat-icon>
@@ -64,7 +64,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="permission.check(documentList.selection, ['delete'], { target: 'allowableOperationsOnTarget' })"
+                    [disabled]="!permission.check(documentList.selection, ['delete'], { target: 'allowableOperationsOnTarget' })"
                     [app-move-node]="documentList.selection">
                     <mat-icon color="primary">library_books</mat-icon>
                     <span>{{ 'APP.ACTIONS.MOVE' | translate }}</span>
@@ -72,7 +72,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="permission.check(documentList.selection, ['delete'])"
+                    [disabled]="!permission.check(documentList.selection, ['delete'])"
                     [appUnshareNode]="documentList.selection"
                     (links-unshared)="refresh()">
                     <mat-icon color="primary">stop_screen_share</mat-icon>
@@ -81,7 +81,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="permission.check(documentList.selection, ['delete'], { target: 'allowableOperationsOnTarget' })"
+                    [disabled]="!permission.check(documentList.selection, ['delete'], { target: 'allowableOperationsOnTarget' })"
                     [app-delete-node]="documentList.selection">
                     <mat-icon color="primary">delete</mat-icon>
                     <span>{{ 'APP.ACTIONS.DELETE' | translate }}</span>
@@ -89,7 +89,7 @@
 
                 <button
                     mat-menu-item
-                    *ngIf="permission.check(documentList.selection[0], ['update'])"
+                    [disabled]="!permission.check(documentList.selection[0], ['update'])"
                     [app-node-versions]="documentList.selection">
                     <mat-icon color="primary">history</mat-icon>
                     <span>{{ 'APP.ACTIONS.VERSIONS' | translate }}</span>

--- a/src/app/components/trashcan/trashcan.component.html
+++ b/src/app/components/trashcan/trashcan.component.html
@@ -9,7 +9,7 @@
                 mat-icon-button
                 [app-permanent-delete-node]="documentList.selection"
                 (selection-node-deleted)="refresh()"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.DELETE_PERMANENT' | translate }}">
                 <mat-icon>delete_forever</mat-icon>
             </button>
@@ -19,7 +19,7 @@
                 mat-icon-button
                 (selection-node-restored)="refresh()"
                 [app-restore-node]="documentList.selection"
-                *ngIf="documentList.selection.length"
+                [disabled]="!documentList.selection.length"
                 title="{{ 'APP.ACTIONS.RESTORE' | translate }}">
                 <mat-icon>restore</mat-icon>
            </button>

--- a/src/app/ui/overrides/_toolbar.scss
+++ b/src/app/ui/overrides/_toolbar.scss
@@ -1,5 +1,7 @@
 @import 'variables';
 
+
+
 .adf-toolbar {
     .mat-toolbar-single-row {
         padding: 0 14px;
@@ -10,6 +12,12 @@
         .mat-toolbar {
             border: none !important;
             padding: 0;
+        }
+    }
+
+    mat-toolbar {
+        .mat-icon-button[disabled][disabled] .mat-icon {
+            color: #d6d6d6 !important;
         }
     }
 }


### PR DESCRIPTION
I'm proposing to change the toolbar button from hidden to disable when they are not available....this will help the discoverability of functionality. And in general less surprising for users.

**Before**:
No selection:
<img width="600" alt="screen shot 2018-04-13 at 16 18 21" src="https://user-images.githubusercontent.com/688226/38743373-d5656898-3f36-11e8-9e62-b4e2c5b2c11a.png">
Selected:
<img width="600" alt="screen shot 2018-04-13 at 16 18 28" src="https://user-images.githubusercontent.com/688226/38743368-d2ae4796-3f36-11e8-8302-37d7da77dc4a.png">

**Now**:
No selection:
<img width="600" alt="screen shot 2018-04-16 at 09 46 31" src="https://user-images.githubusercontent.com/688226/38798970-1696f158-415b-11e8-8878-5da6d7018526.png">
Selected:
<img width="600" alt="screen shot 2018-04-13 at 16 17 35" src="https://user-images.githubusercontent.com/688226/38743376-d88a234c-3f36-11e8-8cda-7dfdb24fa880.png">
