### PR TITLE
Add comments component to file preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "private": true,
   "dependencies": {
-    "@alfresco/adf-content-services": "2.3.0-eff3ea83b03603d77986d6080553f799025e3f90",
-    "@alfresco/adf-core": "2.3.0-eff3ea83b03603d77986d6080553f799025e3f90",
+    "@alfresco/adf-content-services": "2.3.0-0a8438954b0b3f7b0d1ba805e9fd030ba6b36e45",
+    "@alfresco/adf-core": "2.3.0-0a8438954b0b3f7b0d1ba805e9fd030ba6b36e45",
     "@angular/animations": "5.1.1",
     "@angular/cdk": "5.0.1",
     "@angular/common": "5.1.1",

--- a/src/app/components/preview/preview.component.html
+++ b/src/app/components/preview/preview.component.html
@@ -14,12 +14,6 @@
                     [node]="node">
                 </adf-content-metadata-card>
             </adf-info-drawer-tab>
-
-            <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.TABS.VERSIONS' | translate">
-                <ng-container>
-                    <adf-version-manager [node]="node"></adf-version-manager>
-                </ng-container>
-            </adf-info-drawer-tab>
         </adf-info-drawer>
     </ng-template>
 

--- a/src/app/components/preview/preview.component.html
+++ b/src/app/components/preview/preview.component.html
@@ -2,6 +2,10 @@
 
     <ng-template #sidebarTemplate>
         <adf-info-drawer [title]="'APP.INFO_DRAWER.TITLE' | translate">
+            <adf-info-drawer-tab label="Comments">
+                <adf-comments [nodeId]="nodeId"></adf-comments>
+            </adf-info-drawer-tab>
+
             <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.TABS.PROPERTIES' | translate">
                 <adf-content-metadata-card
                     [readOnly]="!permission.check(node, ['update'])"


### PR DESCRIPTION
This PR integrates the comment component for content in the preview page.

- In the right side bar, the version tab has been removed, although version managment is still accesible from the 3 dots icon.
- Properties now is the second tab and comments is the first

<img width="600" alt="screen shot 2018-04-17 at 09 56 38" src="https://user-images.githubusercontent.com/688226/38859710-887496ba-4226-11e8-808b-f81dd0c69502.png">
