### PR TITLE
hotfix for document list background colour

### DIFF
--- a/src/app/ui/overrides/_alfresco-document-list.scss
+++ b/src/app/ui/overrides/_alfresco-document-list.scss
@@ -4,6 +4,7 @@
 
 adf-document-list {
     @include flex-column;
+    background-color: white; // TODO: remove when ADF 2.4.0 is out.
 }
 
 .adf-document-list--loading {


### PR DESCRIPTION
Hotfix for the background colour regression in ADF 2.3.0. Will be reviewed for ACA 1.3.0 once ADF 2.4.0 alpha with the corresponding fix is out.