### PR TITLE
use default port 4200 for development

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -89,7 +89,7 @@
     "component": {},
     "serve": {
       "proxyConfig": "proxy.conf.js",
-      "port": 3000,
+      "port": 4200,
       "host": "0.0.0.0"
     }
   }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and then check out one of our issues in the [Jira][jira] or [GitHub][github]
 
 ## Development server
 
-Run `npm start` for a dev server. Navigate to `http://localhost:3000/` (opens by default).
+Run `npm start` for a dev server. Navigate to `http://localhost:4200/` (opens by default).
 The app will automatically reload if you change any of the source files.
 
 ## Build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,11 +21,11 @@ The example below demonstrates the most common dynamic format for development en
 The configuration above assumes you are running ACS and Content App on the same server and port
 and allows deploying to different servers having the same unified configuration file.
 
-For example, a proxy server at `localhost:3000` hosting the Content App as the root application,
-and `localhost:3000/alfresco` for the ACS repository.
+For example, a proxy server at `localhost:4200` hosting the Content App as the root application,
+and `localhost:4200/alfresco` for the ACS repository.
 
 At runtime, the application is going to automatically substitute the "{hostname}" value with the original hostname.
-Optionally it can also use the value of the original port if present, for example, "3000" at local machines, or skip the value for port 80.
+Optionally it can also use the value of the original port if present, for example, "4200" at local machines, or skip the value for port 80.
 
 ### Static address
 
@@ -33,7 +33,7 @@ Alternatively, you can provide a static address for the ACS server if necessary:
 
 ```json
 {
-    "ecmHost": "http://localhost:3000",
+    "ecmHost": "http://localhost:4200",
     ...
 }
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,7 +77,7 @@ To perform a cleanup operation, use the next command:
 docker-compose down --rmi all
 ```
 
-Navigate to "http://localhost:3000" to access the running application.
+Navigate to "http://localhost:4200" to access the running application.
 
 <p class="warning">
 Please keep in mind that you should manually build the project every time you want to publish the image or run it locally with the container.
@@ -101,7 +101,7 @@ npm run build:dev
 docker-compose up
 ```
 
-Navigate to "http://localhost:3000" to access the running application.
+Navigate to "http://localhost:4200" to access the running application.
 
 To perform a cleanup operation, use the next command:
 

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -28,7 +28,7 @@ exports.config = {
 
     directConnect: true,
 
-    baseUrl: 'http://localhost:3000',
+    baseUrl: 'http://localhost:4200',
 
     framework: 'jasmine2',
     jasmineNodeOpts: {


### PR DESCRIPTION
- using standard Angular CLI port 4200 not to have issues with shared local storage when running after ADF demo shell
- allows running both apps in parallel at the same time