### PR TITLE
Move all previews out of the LayoutComponent

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -50,6 +50,60 @@ export const APP_ROUTES: Routes = [
         }
     },
     {
+        path: 'personal-files/:folderId/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'personal-files'
+        }
+    },
+    {
+        path: 'personal-files/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'personal-files'
+        }
+    },
+    {
+        path: 'favorites/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'favorites'
+        }
+    },
+    {
+        path: 'libraries/:folderId/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'libraries'
+        }
+    },
+    {
+        path: 'recent-files/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'recent-files'
+        }
+    },
+    {
+        path: 'shared/preview/:nodeId',
+        component: PreviewComponent,
+        data: {
+            i18nTitle: 'APP.PREVIEW.TITLE',
+            navigateMultiple: true,
+            navigateSource: 'shared'
+        }
+    },
+    {
         path: '',
         component: LayoutComponent,
         children: [
@@ -69,15 +123,6 @@ export const APP_ROUTES: Routes = [
                         component: FavoritesComponent,
                         data: {
                             i18nTitle: 'APP.BROWSE.FAVORITES.TITLE'
-                        }
-                    },
-                    {
-                        path: 'preview/:nodeId',
-                        component: PreviewComponent,
-                        data: {
-                            i18nTitle: 'APP.PREVIEW.TITLE',
-                            navigateMultiple: true,
-                            navigateSource: 'favorites'
                         }
                     }
                 ]
@@ -99,15 +144,6 @@ export const APP_ROUTES: Routes = [
                     data: {
                         i18nTitle: 'APP.BROWSE.LIBRARIES.TITLE',
                         preferencePrefix: 'libraries-files'
-                    }
-                },
-                {
-                    path: ':folderId/preview/:nodeId',
-                    component: PreviewComponent,
-                    data: {
-                        i18nTitle: 'APP.PREVIEW.TITLE',
-                        navigateMultiple: true,
-                        navigateSource: 'libraries'
                     }
                 }
                 ]
@@ -132,24 +168,6 @@ export const APP_ROUTES: Routes = [
                         data: {
                             i18nTitle: 'APP.BROWSE.PERSONAL.TITLE'
                         }
-                    },
-                    {
-                        path: 'preview/:nodeId',
-                        component: PreviewComponent,
-                        data: {
-                            i18nTitle: 'APP.PREVIEW.TITLE',
-                            navigateMultiple: true,
-                            navigateSource: 'personal-files'
-                        }
-                    },
-                    {
-                        path: ':folderId/preview/:nodeId',
-                        component: PreviewComponent,
-                        data: {
-                            i18nTitle: 'APP.PREVIEW.TITLE',
-                            navigateMultiple: true,
-                            navigateSource: 'personal-files'
-                        }
                     }
                 ]
             },
@@ -165,15 +183,6 @@ export const APP_ROUTES: Routes = [
                         data: {
                             i18nTitle: 'APP.BROWSE.RECENT.TITLE'
                         }
-                    },
-                    {
-                        path: 'preview/:nodeId',
-                        component: PreviewComponent,
-                        data: {
-                            i18nTitle: 'APP.PREVIEW.TITLE',
-                            navigateMultiple: true,
-                            navigateSource: 'recent-files'
-                        }
                     }
                 ]
             },
@@ -188,15 +197,6 @@ export const APP_ROUTES: Routes = [
                         component: SharedFilesComponent,
                         data: {
                             i18nTitle: 'APP.BROWSE.SHARED.TITLE'
-                        }
-                    },
-                    {
-                        path: 'preview/:nodeId',
-                        component: PreviewComponent,
-                        data: {
-                            i18nTitle: 'APP.PREVIEW.TITLE',
-                            navigateMultiple: true,
-                            navigateSource: 'shared'
                         }
                     }
                 ]
@@ -225,8 +225,8 @@ export const APP_ROUTES: Routes = [
                 component: GenericErrorComponent
             }
         ],
-        canActivateChild: [ AuthGuardEcm ],
-        canActivate: [ AuthGuardEcm ]
+        canActivateChild: [AuthGuardEcm],
+        canActivate: [AuthGuardEcm]
     }
 ];
 


### PR DESCRIPTION
This PR is to fix an issue I had for a demo on IOS tablets. The LayoutComponent, in this case, was causing display the file preview under the LayoutComponent.

![screen shot 2018-04-11 at 22 47 40](https://user-images.githubusercontent.com/688226/38979611-90090c7a-43b2-11e8-834a-ad42510484e3.png)
