### PR TITLE
(WIP) dynamic content demo

### DIFF
--- a/src/app.config.json
+++ b/src/app.config.json
@@ -106,6 +106,22 @@
             }
         ]
     },
+    "actions": [
+        {
+            "id": "action1",
+            "type": "DYNAMIC_ACTION",
+            "payload": "test action 1",
+            "icon": "build",
+            "title": "dynamic action 1"
+        },
+        {
+            "id": "action2",
+            "type": "SNACKBAR_INFO",
+            "payload": "Hello, there!",
+            "icon": "alarm",
+            "title": "dynamic action 2"
+        }
+    ],
     "languages": [
         {
             "key": "de",

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -84,6 +84,26 @@
                     "url": "/trashcan"
                 }
             }
+        ],
+        "dynamic": [
+            {
+                "icon": "build",
+                "label": "Dynamic Page 1",
+                "route": {
+                    "url": "/dynamic1",
+                    "path": "dynamic1",
+                    "component": "dynamic1"
+                }
+            },
+            {
+                "icon": "build",
+                "label": "Dynamic Page 2",
+                "route": {
+                    "url": "/dynamic2",
+                    "path": "dynamic2",
+                    "component": "dynamic2"
+                }
+            }
         ]
     },
     "languages": [

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -120,6 +120,12 @@
             "payload": "Hello, there!",
             "icon": "alarm",
             "title": "dynamic action 2"
+        },
+        {
+            "id": "action3",
+            "type": "SNACKBAR_INFO",
+            "payload": "$node.name",
+            "icon": "extension"
         }
     ],
     "languages": [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,6 +77,8 @@ import { EditFolderDirective } from './directives/edit-folder.directive';
 import { CreateFolderDirective } from './directives/create-folder.directive';
 import { DownloadNodesDirective } from './directives/download-nodes.directive';
 import { AppStoreModule } from './store/app-store.module';
+import { DynamicComponentModule } from './dynamic-pages/dynamic.module';
+import { PluginService } from './services/plugin.service';
 
 
 @NgModule({
@@ -97,7 +99,8 @@ import { AppStoreModule } from './store/app-store.module';
         CoreModule,
         ContentModule,
         ElectronModule,
-        AppStoreModule
+        AppStoreModule,
+        DynamicComponentModule
     ],
     declarations: [
         AppComponent,
@@ -136,6 +139,7 @@ import { AppStoreModule } from './store/app-store.module';
         DownloadNodesDirective
     ],
     providers: [
+        PluginService,
         { provide: PageTitleService, useClass: AcaPageTitleService },
         { provide: AppConfigService, useClass: HybridAppConfigService },
         {

--- a/src/app/components/files/files.component.html
+++ b/src/app/components/files/files.component.html
@@ -7,6 +7,13 @@
         </adf-breadcrumb>
 
         <adf-toolbar class="inline" *ngIf="hasSelection">
+            <button *ngFor="let action of actions"
+                mat-icon-button
+                color="primary"
+                title="{{ action.title }}"
+                (click)="runAction(action)">
+                <mat-icon>{{ action.icon }}</mat-icon>
+            </button>
             <button
                 color="primary"
                 mat-icon-button

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -117,9 +117,22 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
         this.browsingFilesService.onChangeParent.next(null);
     }
 
-    runAction(action: any) {
-        const { type, payload } = action;
-        this.store.dispatch({ type, payload });
+    runAction(action: { type: string, payload: string }) {
+        const { type } = action;
+
+        if (type && action.payload) {
+            let payload = action.payload;
+            const $node = this.selectedNodes[0].entry;
+
+            if (payload.startsWith('$node')) {
+                // todo: cache compiled funcs
+                const fn = new Function('$node', `return ${payload}`);
+                payload = fn($node);
+                console.log(payload);
+            }
+
+            this.store.dispatch({ type: type, payload });
+        }
     }
 
     fetchNode(nodeId: string): Observable<MinimalNodeEntryEntity> {

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -29,7 +29,7 @@ import { Router, ActivatedRoute, Params } from '@angular/router';
 import { MinimalNodeEntity, MinimalNodeEntryEntity, PathElementEntity, NodePaging, PathElement } from 'alfresco-js-api';
 import {
     UploadService, FileUploadEvent, NodesApiService,
-    AlfrescoApiService, UserPreferencesService
+    AlfrescoApiService, UserPreferencesService, AppConfigService
 } from '@alfresco/adf-core';
 
 import { BrowsingFilesService } from '../../common/services/browsing-files.service';
@@ -49,10 +49,12 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     isValidPath = true;
 
     private nodePath: PathElement[];
+    actions: any[] = [];
 
     constructor(private router: Router,
                 route: ActivatedRoute,
                 store: Store<AppStore>,
+                private config: AppConfigService,
                 private nodesApi: NodesApiService,
                 private nodeActionsService: NodeActionsService,
                 private uploadService: UploadService,
@@ -66,6 +68,8 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         super.ngOnInit();
+
+        this.actions = this.config.get('actions', []);
 
         const { route, contentManagementService, nodeActionsService, uploadService } = this;
         const { data } = route.snapshot;
@@ -111,6 +115,11 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         super.ngOnDestroy();
         this.browsingFilesService.onChangeParent.next(null);
+    }
+
+    runAction(action: any) {
+        const { type, payload } = action;
+        this.store.dispatch({ type, payload });
     }
 
     fetchNode(nodeId: string): Observable<MinimalNodeEntryEntity> {

--- a/src/app/dynamic-pages/dynamic.actions.ts
+++ b/src/app/dynamic-pages/dynamic.actions.ts
@@ -23,26 +23,11 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { NgModule } from '@angular/core';
-import { Dynamic1Component } from './dynamic1.component';
-import { Dynamic2Component } from './dynamic2.component';
-import { PluginService } from '../services/plugin.service';
-import { EffectsModule } from '@ngrx/effects';
-import { DynamicEffects } from './dynamic.effect';
-import { Store } from '@ngrx/store';
-import { DynamicAction } from './dynamic.actions';
+import { Action } from '@ngrx/store';
 
-@NgModule({
-    imports: [
-        EffectsModule.forFeature([DynamicEffects])
-    ],
-    declarations: [Dynamic1Component, Dynamic2Component],
-    entryComponents: [Dynamic1Component, Dynamic2Component]
-})
-export class DynamicComponentModule {
-    constructor(plugins: PluginService, store: Store<any>) {
-        plugins.components['dynamic1'] = Dynamic1Component;
-        plugins.components['dynamic2'] = Dynamic2Component;
-        store.dispatch(new DynamicAction('hello world'));
-    }
+export const DYNAMIC_ACTION = 'DYNAMIC_ACTION';
+
+export class DynamicAction implements Action {
+    readonly type = DYNAMIC_ACTION;
+    constructor(public payload: string) {}
 }

--- a/src/app/dynamic-pages/dynamic.effect.ts
+++ b/src/app/dynamic-pages/dynamic.effect.ts
@@ -23,26 +23,20 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { NgModule } from '@angular/core';
-import { Dynamic1Component } from './dynamic1.component';
-import { Dynamic2Component } from './dynamic2.component';
-import { PluginService } from '../services/plugin.service';
-import { EffectsModule } from '@ngrx/effects';
-import { DynamicEffects } from './dynamic.effect';
-import { Store } from '@ngrx/store';
-import { DynamicAction } from './dynamic.actions';
+import { Effect, Actions, ofType } from '@ngrx/effects';
+import { Injectable } from '@angular/core';
+import { map } from 'rxjs/operators';
+import { DYNAMIC_ACTION, DynamicAction } from './dynamic.actions';
 
-@NgModule({
-    imports: [
-        EffectsModule.forFeature([DynamicEffects])
-    ],
-    declarations: [Dynamic1Component, Dynamic2Component],
-    entryComponents: [Dynamic1Component, Dynamic2Component]
-})
-export class DynamicComponentModule {
-    constructor(plugins: PluginService, store: Store<any>) {
-        plugins.components['dynamic1'] = Dynamic1Component;
-        plugins.components['dynamic2'] = Dynamic2Component;
-        store.dispatch(new DynamicAction('hello world'));
-    }
+@Injectable()
+export class DynamicEffects {
+    constructor(private actions$: Actions) {}
+
+    @Effect({ dispatch: false })
+    dynamicAction$ = this.actions$.pipe(
+        ofType<DynamicAction>(DYNAMIC_ACTION),
+        map(action => {
+            console.log('Dynamic action', action);
+        })
+    );
 }

--- a/src/app/dynamic-pages/dynamic.module.ts
+++ b/src/app/dynamic-pages/dynamic.module.ts
@@ -1,0 +1,40 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { NgModule } from '@angular/core';
+import { Dynamic1Component } from './dynamic1.component';
+import { Dynamic2Component } from './dynamic2.component';
+import { PluginService } from '../services/plugin.service';
+
+@NgModule({
+    declarations: [Dynamic1Component, Dynamic2Component],
+    entryComponents: [Dynamic1Component, Dynamic2Component]
+})
+export class DynamicComponentModule {
+    constructor(plugins: PluginService) {
+        plugins.components['dynamic1'] = Dynamic1Component;
+        plugins.components['dynamic2'] = Dynamic2Component;
+    }
+}

--- a/src/app/dynamic-pages/dynamic.module.ts
+++ b/src/app/dynamic-pages/dynamic.module.ts
@@ -29,8 +29,6 @@ import { Dynamic2Component } from './dynamic2.component';
 import { PluginService } from '../services/plugin.service';
 import { EffectsModule } from '@ngrx/effects';
 import { DynamicEffects } from './dynamic.effect';
-import { Store } from '@ngrx/store';
-import { DynamicAction } from './dynamic.actions';
 
 @NgModule({
     imports: [
@@ -40,9 +38,8 @@ import { DynamicAction } from './dynamic.actions';
     entryComponents: [Dynamic1Component, Dynamic2Component]
 })
 export class DynamicComponentModule {
-    constructor(plugins: PluginService, store: Store<any>) {
+    constructor(plugins: PluginService) {
         plugins.components['dynamic1'] = Dynamic1Component;
         plugins.components['dynamic2'] = Dynamic2Component;
-        store.dispatch(new DynamicAction('hello world'));
     }
 }

--- a/src/app/dynamic-pages/dynamic1.component.ts
+++ b/src/app/dynamic-pages/dynamic1.component.ts
@@ -1,0 +1,33 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-dynamic-1',
+    template: `<h1>Dynamic Component 1</h1>`
+})
+export class Dynamic1Component {
+}

--- a/src/app/dynamic-pages/dynamic2.component.ts
+++ b/src/app/dynamic-pages/dynamic2.component.ts
@@ -1,0 +1,33 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-dynamic-2',
+    template: `<h1>Dynamic Component 2</h1>`
+})
+export class Dynamic2Component {
+}

--- a/src/app/services/plugin.service.ts
+++ b/src/app/services/plugin.service.ts
@@ -1,0 +1,31 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Injectable, Type } from '@angular/core';
+
+@Injectable()
+export class PluginService {
+    components: { [key: string]: Type<{}> } = {};
+}

--- a/src/app/store/effects/snackbar.effects.ts
+++ b/src/app/store/effects/snackbar.effects.ts
@@ -82,7 +82,7 @@ export class SnackbarEffects {
         }
 
         const snackBarRef = this.snackBar.open(message, actionName, {
-            duration: action.duration,
+            duration: action.duration || 4000,
             panelClass: panelClass
         });
 


### PR DESCRIPTION
# Dynamic Content Demo
**This is a POC for discussion/review purposes and is not meant to be merged**

- self-registering plugin modules (just import the module and it does all the job itself)
  * register dynamic components
  * register dynamic NgRx Actions and Effects
- register dynamic routes and pages in `app.config`
  * support for wrapping dynamic routes with Layout component and Auth Guards
- dynamic toolbar buttons (declared in `app.config`)
  * invoking NgRx actions with static payloads on clicks
    * running dynamic actions coming with the plugin module
    * running existing application-level actions/effects
  * evaluating NgRx payloads at runtime, compiling expressions based on context

<img width="1440" alt="screen shot 2018-06-18 at 09 04 38" src="https://user-images.githubusercontent.com/503991/41524834-af50ea00-72d6-11e8-96ba-79e9b860054d.png">

<img width="1437" alt="screen shot 2018-06-18 at 11 37 05" src="https://user-images.githubusercontent.com/503991/41531665-fd85271c-72eb-11e8-8262-18a7b00e1673.png">
