### PR TITLE
[ACA-1578] Facet Intervals - show modified date buckets

### DIFF
--- a/src/app.config.json
+++ b/src/app.config.json
@@ -191,25 +191,17 @@
             { "field": "modifier", "mincount": 1, "label": "SEARCH.FACET_FIELDS.MODIFIER" },
             { "field": "SITE", "mincount": 1, "label": "SEARCH.FACET_FIELDS.FILE_LIBRARY" }
         ],
-        "facetQueries": {},
+        "facetQueries": {
+            "label": "SEARCH.CATEGORIES.MODIFIED_DATE",
+            "queries": [
+                { "label": "Today", "query": "cm:modified:[TODAY to TODAY]" },
+                { "label": "This week", "query": "cm:modified:[NOW/DAY-7DAYS TO NOW/DAY+1DAY]" },
+                { "label": "This month", "query": "cm:modified:[NOW/DAY-1MONTH TO NOW/DAY+1DAY]"},
+                { "label": "In last 6 months", "query": "cm:modified:[NOW/DAY-6MONTHS TO NOW/DAY+1DAY]"},
+                { "label": "This year", "query": "cm:modified:[NOW/DAY-1YEAR TO NOW/DAY+1DAY]"}
+            ]
+        },
         "categories": [
-            {
-                "id": "modifiedDate",
-                "name": "SEARCH.CATEGORIES.MODIFIED_DATE",
-                "enabled": true,
-                "component": {
-                    "selector": "check-list",
-                    "settings": {
-                        "options": [
-                            { "name": "Today", "value": "cm:modified:[TODAY to TODAY]" },
-                            { "name": "This week", "value": "cm:modified:[NOW/DAY-7DAYS TO NOW/DAY+1DAY]" },
-                            { "name": "This month", "value": "cm:modified:[NOW/DAY-1MONTH TO NOW/DAY+1DAY]"},
-                            { "name": "In last 6 months", "value": "cm:modified:[NOW/DAY-6MONTHS TO NOW/DAY+1DAY]"},
-                            { "name": "This year", "value": "cm:modified:[NOW/DAY-1YEAR TO NOW/DAY+1DAY]"}
-                        ]
-                    }
-                }
-            },
             {
                 "id": "size",
                 "name": "SEARCH.CATEGORIES.SIZE",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No buckets were shown for the 'Modified Date' category.

Issue Number: N/A
Please check https://issues.alfresco.com/jira/browse/ACA-1562 & ACA-1578

## What is the new behavior?
The facet buckets are now displayed for the 'Modified Date' facet.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
