### PR TITLE
DEPLOY-550/DEPLOY-591: Adapt current aca docker-image to allow passing ACS url trough env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM nginx:stable-alpine
 LABEL version="1.3"
 LABEL maintainer="Denys Vuika <denys.vuika@alfresco.com>"
 
+
 COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY --chown=nginx:nginx ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 COPY dist/app/ .
 
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [[ $ACSURL ]]; then
+  sed -i s%{protocol}//{hostname}{:port}%"$ACSURL"%g /usr/share/nginx/html/app.config.json
+fi
+
+nginx -g "daemon off;"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: DEPLOY-591
The current setup of ecmUrl variable in app.config.json does not take into account custom paths for acs. ex: http://example.com/content
Also in a dynamic cloud env like k8s it is considerably easier to change the value of the variable by changing env variables on a container.

## What is the new behavior?

When ACSURL is specified to the docker image as an env variable it will be written in app.config.json

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
