### PR TITLE
fix #653 : add basepath modification at runtime trough env vars

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,5 +3,8 @@
 if [[ $ACSURL ]]; then
   sed -i s%{protocol}//{hostname}{:port}%"$ACSURL"%g /usr/share/nginx/html/app.config.json
 fi
+if [[ $BASEPATH ]]; then
+  sed -i s%href=\"./"%href=\""$BASEPATH"\"%g /usr/share/nginx/html/index.html
+fi
 
 nginx -g "daemon off;"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [ ] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no way of doing path rewriting on the application using nginx for example without setting ./ as base href. 

## What is the new behavior?

We dont want to break local development so adding the possibility of changing the base href when running the docker container gives us the flexibility of choosing under which path we want the app to run in.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
