### PR TITLE
[ACA-1558] cache busting for index.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,27 +1,33 @@
 worker_processes  1;
 
 events {
-    worker_connections  1024;
+  worker_connections  1024;
 }
 
 http {
-    server {
-        listen 80;
-        server_name  localhost;
+  server {
+    listen 80;
+    server_name  localhost;
 
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        include /etc/nginx/mime.types;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
 
-        gzip on;
-        gzip_min_length 1000;
-        gzip_proxied expired no-cache no-store private auth;
-        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-        access_log off;
+    access_log off;
 
-        location / {
-            try_files $uri $uri/ /index.html;
-        }
+    location / {
+      try_files $uri $uri/ /index.html;
     }
+
+    location ~ \.html$ {
+      add_header Cache-Control "private, no-cache, no-store, must-revalidate";
+      add_header Expires "Sat, 01 Jan 2000 00:00:00 GMT";
+      add_header Pragma no-cache;
+    }
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,56 +1,64 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Alfresco Content App</title>
-  <base href="/">
+  <head>
+    <meta charset="utf-8" />
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96">
+    <!-- Important: cache busting for index.html -->
+    <meta http-equiv="cache-control" content="max-age=0" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+    <meta http-equiv="pragma" content="no-cache" />
 
-  <style>
-    @keyframes bouncing-loader {
+    <title>Alfresco Content App</title>
+    <base href="/" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+
+    <style>
+      @keyframes bouncing-loader {
         from {
-            opacity: 1;
-            transform: translateY(0);
+          opacity: 1;
+          transform: translateY(0);
         }
         to {
-            opacity: 0.1;
-            transform: translateY(-1rem);
+          opacity: 0.1;
+          transform: translateY(-1rem);
         }
-    }
-    .bouncing-loader {
+      }
+      .bouncing-loader {
         display: flex;
         justify-content: center;
         position: absolute;
         top: 50%;
         left: 50%;
-    }
-    .bouncing-loader > div {
+      }
+      .bouncing-loader > div {
         width: 1rem;
         height: 1rem;
         margin: 3rem 0.2rem;
         background: #8385aa;
         border-radius: 50%;
         animation: bouncing-loader 0.6s infinite alternate;
-    }
-    .bouncing-loader > div:nth-child(2) {
+      }
+      .bouncing-loader > div:nth-child(2) {
         animation-delay: 0.2s;
-    }
-    .bouncing-loader > div:nth-child(3) {
+      }
+      .bouncing-loader > div:nth-child(3) {
         animation-delay: 0.4s;
-    }
-  </style>
-</head>
-<body>
+      }
+    </style>
+  </head>
+  <body>
     <main>
-        <app-root>
-            <div class="bouncing-loader">
-                <div></div>
-                <div></div>
-                <div></div>
-            </div>
-        </app-root>
+      <app-root>
+        <div class="bouncing-loader">
+          <div></div>
+          <div></div>
+          <div></div>
+        </div>
+      </app-root>
     </main>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

each time we build a new Angular app, the static assets have cache control embedded into file names as hashes, however index.html is always the same. That causes the app trying to load old files that no longer exist on server (referenced from the cached index.html)

Issue Number: ACA-1558

## What is the new behavior?

disable caching for "index.html" file so that once new build is released the app correctly updates itself on client sides. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
