### PR TITLE
[ACA-2168] auto-generate licenses for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # 1. Generate licenses
 
 FROM node:11.9-alpine AS builder
-WORKDIR /usr/src/alfresco/aca
+WORKDIR /usr/src/alfresco
 COPY package.json package.json
 
 RUN mkdir -p ./licenses && \
@@ -21,6 +21,6 @@ RUN chmod +x /docker-entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 COPY dist/app/ .
-COPY --from=builder /usr/src/alfresco/aca/licenses ./licenses
+COPY --from=builder /usr/src/alfresco/licenses ./licenses
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p ./licenses && \
 # 2. Generate image
 
 FROM nginx:stable-alpine
-LABEL version="1.4"
+LABEL version="1.7"
 LABEL maintainer="Denys Vuika <denys.vuika@alfresco.com>"
 
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# 1. Generate licenses
+
+FROM node:11.9-alpine AS builder
+WORKDIR /usr/src/alfresco/aca
+COPY package.json package.json
+
+RUN mkdir -p ./licenses && \
+  yarn licenses list > ./licenses/licenses.txt && \
+  yarn licenses generate-disclaimer > ./licenses/disclaimer.txt
+
+# 2. Generate image
+
 FROM nginx:stable-alpine
 LABEL version="1.4"
 LABEL maintainer="Denys Vuika <denys.vuika@alfresco.com>"
@@ -9,5 +21,6 @@ RUN chmod +x /docker-entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 COPY dist/app/ .
+COPY --from=builder /usr/src/alfresco/aca/licenses ./licenses
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

- Automatically generate licenses and disclaimer upon image build
- Regenerate licenses only when package.json content changes

The files should be accessible via the web interface:

* <app-url>/licenses/licenses.txt
* <app-url>/licenses/disclaimer.txt



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
