### PR TITLE
[ACA-2193] Lock node - unlock after new version is uploaded

### DIFF
--- a/docs/extending/application-actions.md
+++ b/docs/extending/application-actions.md
@@ -76,42 +76,44 @@ and perform document list reload if needed.
 
 Below is the list of public actions types you can use in the plugin definitions as a reference to the action:
 
-| Name | Payload | Description |
-| -- | -- | -- |
-| SET_CURRENT_FOLDER | Node | Notify components about currently opened folder. |
-| SET_CURRENT_URL | string | Notify components about current browser URL. |
-| SET_USER_PROFILE | Person | Assign current user profile. |
-| TOGGLE_INFO_DRAWER | n/a | Toggle info drawer for the selected node. |
-| ADD_FAVORITE | MinimalNodeEntity[] | Add nodes (or selection) to favorites. |
-| REMOVE_FAVORITE | MinimalNodeEntity[] | Removes nodes (or selection) from favorites. |
-| DELETE_LIBRARY | string | Delete a Library by id. Takes selected node if payload not provided. |
-| CREATE_LIBRARY | n/a | Invoke a "Create Library" dialog. |
-| SET_SELECTED_NODES | MinimalNodeEntity[] | Notify components about selected nodes. |
-| DELETE_NODES | MinimalNodeEntity[] | Delete the nodes (or selection). Supports undo actions. |
-| UNDO_DELETE_NODES | any[] | Reverts deletion of nodes (or selection). |
-| RESTORE_DELETED_NODES  | MinimalNodeEntity[] | Restores deleted nodes (or selection). Typically used with Trashcan. |
-| PURGE_DELETED_NODES | MinimalNodeEntity[] | Permanently delete nodes (or selection). Typically used with Trashcan. |
-| DOWNLOAD_NODES | MinimalNodeEntity[] | Download nodes (or selections). Creates a ZIP archive for folders or multiple items. |
-| CREATE_FOLDER | string | Invoke a "Create Folder" dialog for the opened folder (or the parent folder id in the payload). |
-| EDIT_FOLDER | MinimalNodeEntity | Invoke an "Edit Folder" dialog for the node (or selection). |
-| SHARE_NODE | MinimalNodeEntity | Invoke a "Share" dialog for the node (or selection). |
-| UNSHARE_NODES | MinimalNodeEntity[] | Remove nodes (or selection) from the shared nodes (does not remove content). |
-| COPY_NODES | MinimalNodeEntity[] | Invoke a "Copy" dialog for the nodes (or selection). Supports undo actions. |
-| MOVE_NODES | MinimalNodeEntity[] | Invoke a "Move" dialog for the nodes (or selection). Supports undo actions. |
-| MANAGE_PERMISSIONS | MinimalNodeEntity | Invoke a "Manage Permissions" dialog for the node (or selection). |
-| MANAGE_VERSIONS | MinimalNodeEntity | Invoke a "Manage Versions" dialog for the node (or selection). |
-| NAVIGATE_URL | string | Navigate to a given route URL within the application. |
-| NAVIGATE_ROUTE | any[] | Navigate to a particular Route (supports parameters). |
-| NAVIGATE_FOLDER | MinimalNodeEntity | Navigate to a folder based on the Node properties. |
-| NAVIGATE_PARENT_FOLDER | MinimalNodeEntity | Navigate to a containing folder based on the Node properties. |
-| NAVIGATE_LIBRARY | string | Navigate to library. |
-| SEARCH_BY_TERM | string | Perform a simple search by the term and navigate to Search results. |
-| SNACKBAR_INFO | string | Show information snackbar with the message provided. |
-| SNACKBAR_WARNING | string | Show warning snackbar with the message provided. |
-| SNACKBAR_ERROR | string | Show error snackbar with the message provided. |
-| UPLOAD_FILES | n/a | Invoke "Upload Files" dialog and upload files to the currently opened folder. |
-| UPLOAD_FOLDER | n/a | Invoke "Upload Folder" dialog and upload selected folder to the currently opened one. |
-| VIEW_FILE | MinimalNodeEntity | Preview the file (or selection) in the Viewer. |
-| PRINT_FILE | MinimalNodeEntity | Print the file opened in the Viewer (or selected). |
-| FULLSCREEN_VIEWER | n/a | Enters fullscreen mode to view the file opened in the Viewer. |
-| LOGOUT | n/a | Log out and redirect to Login screen. |
+| Name                   | Payload             | Description                                                                                     |
+| ---------------------- | ------------------- | ----------------------------------------------------------------------------------------------- |
+| SET_CURRENT_FOLDER     | Node                | Notify components about currently opened folder.                                                |
+| SET_CURRENT_URL        | string              | Notify components about current browser URL.                                                    |
+| SET_USER_PROFILE       | Person              | Assign current user profile.                                                                    |
+| TOGGLE_INFO_DRAWER     | n/a                 | Toggle info drawer for the selected node.                                                       |
+| ADD_FAVORITE           | MinimalNodeEntity[] | Add nodes (or selection) to favorites.                                                          |
+| REMOVE_FAVORITE        | MinimalNodeEntity[] | Removes nodes (or selection) from favorites.                                                    |
+| DELETE_LIBRARY         | string              | Delete a Library by id. Takes selected node if payload not provided.                            |
+| CREATE_LIBRARY         | n/a                 | Invoke a "Create Library" dialog.                                                               |
+| SET_SELECTED_NODES     | MinimalNodeEntity[] | Notify components about selected nodes.                                                         |
+| DELETE_NODES           | MinimalNodeEntity[] | Delete the nodes (or selection). Supports undo actions.                                         |
+| UNDO_DELETE_NODES      | any[]               | Reverts deletion of nodes (or selection).                                                       |
+| RESTORE_DELETED_NODES  | MinimalNodeEntity[] | Restores deleted nodes (or selection). Typically used with Trashcan.                            |
+| PURGE_DELETED_NODES    | MinimalNodeEntity[] | Permanently delete nodes (or selection). Typically used with Trashcan.                          |
+| DOWNLOAD_NODES         | MinimalNodeEntity[] | Download nodes (or selections). Creates a ZIP archive for folders or multiple items.            |
+| CREATE_FOLDER          | string              | Invoke a "Create Folder" dialog for the opened folder (or the parent folder id in the payload). |
+| EDIT_FOLDER            | MinimalNodeEntity   | Invoke an "Edit Folder" dialog for the node (or selection).                                     |
+| SHARE_NODE             | MinimalNodeEntity   | Invoke a "Share" dialog for the node (or selection).                                            |
+| UNSHARE_NODES          | MinimalNodeEntity[] | Remove nodes (or selection) from the shared nodes (does not remove content).                    |
+| COPY_NODES             | MinimalNodeEntity[] | Invoke a "Copy" dialog for the nodes (or selection). Supports undo actions.                     |
+| MOVE_NODES             | MinimalNodeEntity[] | Invoke a "Move" dialog for the nodes (or selection). Supports undo actions.                     |
+| MANAGE_PERMISSIONS     | MinimalNodeEntity   | Invoke a "Manage Permissions" dialog for the node (or selection).                               |
+| MANAGE_VERSIONS        | MinimalNodeEntity   | Invoke a "Manage Versions" dialog for the node (or selection).                                  |
+| NAVIGATE_URL           | string              | Navigate to a given route URL within the application.                                           |
+| NAVIGATE_ROUTE         | any[]               | Navigate to a particular Route (supports parameters).                                           |
+| NAVIGATE_FOLDER        | MinimalNodeEntity   | Navigate to a folder based on the Node properties.                                              |
+| NAVIGATE_PARENT_FOLDER | MinimalNodeEntity   | Navigate to a containing folder based on the Node properties.                                   |
+| NAVIGATE_LIBRARY       | string              | Navigate to library.                                                                            |
+| SEARCH_BY_TERM         | string              | Perform a simple search by the term and navigate to Search results.                             |
+| SNACKBAR_INFO          | string              | Show information snackbar with the message provided.                                            |
+| SNACKBAR_WARNING       | string              | Show warning snackbar with the message provided.                                                |
+| SNACKBAR_ERROR         | string              | Show error snackbar with the message provided.                                                  |
+| UPLOAD_FILES           | n/a                 | Invoke "Upload Files" dialog and upload files to the currently opened folder.                   |
+| UPLOAD_FOLDER          | n/a                 | Invoke "Upload Folder" dialog and upload selected folder to the currently opened one.           |
+| UPLOAD_FILE_VERSION    | n/a                 | Invoke "New File Version" dialog.                                                               |
+| VIEW_FILE              | MinimalNodeEntity   | Preview the file (or selection) in the Viewer.                                                  |
+| UNLOCK_WRITE           | NodeEntry           | Unlock file from read only mode                                                                 |
+| PRINT_FILE             | MinimalNodeEntity   | Print the file opened in the Viewer (or selected).                                              |
+| FULLSCREEN_VIEWER      | n/a                 | Enters fullscreen mode to view the file opened in the Viewer.                                   |
+| LOGOUT                 | n/a                 | Log out and redirect to Login screen.                                                           |

--- a/docs/extending/rules.md
+++ b/docs/extending/rules.md
@@ -148,6 +148,9 @@ The button will be visible only when the linked rule evaluates to `true`.
 | app.selection.hasNoLibraryRole  | The selected Library node has no role property.              |
 | app.selection.folder            | A single Folder node is selected.                            |
 | app.selection.folder.canUpdate  | User has permissions to update the selected folder.          |
+| app.selection.folder.canUpdate  | User has permissions to update the selected folder.          |
+| app.selection.file.canLock      | User has permissions to lock file.                           |
+| app.selection.file.canUnlock    | User has permissions to unlock file.                         |
 | repository.isQuickShareEnabled  | Whether the quick share repository option is enabled or not. |
 
 ## Navigation Evaluators
@@ -176,6 +179,8 @@ for example mixing `core.every` and `core.not`.
 | app.navigation.isNotRecentFiles   | Current page is not **Recent Files**.                   |
 | app.navigation.isSearchResults    | User is using the **Search Results** page.              |
 | app.navigation.isNotSearchResults | Current page is not the **Search Results**.             |
+| app.navigation.isSharedPreview    | Current page is preview **Shared Files**                |
+| app.navigation.isFavoritesPreview | Current page is preview **Favorites**                   |
 
 **Tip:** See the [Registration](/extending/registration) section for more details
 on how to register your own entries to be re-used at runtime.

--- a/src/app/components/preview/preview.component.ts
+++ b/src/app/components/preview/preview.component.ts
@@ -38,7 +38,13 @@ import {
   UrlSegment,
   PRIMARY_OUTLET
 } from '@angular/router';
-import { UserPreferencesService, ObjectUtils } from '@alfresco/adf-core';
+import { debounceTime } from 'rxjs/operators';
+import {
+  UserPreferencesService,
+  ObjectUtils,
+  UploadService,
+  AlfrescoApiService
+} from '@alfresco/adf-core';
 import { Store } from '@ngrx/store';
 import { AppStore } from '../../store/states/app.state';
 import { SetSelectedNodesAction } from '../../store/actions';
@@ -84,6 +90,8 @@ export class PreviewComponent extends PageComponent
     private appDataService: AppDataService,
     private route: ActivatedRoute,
     private router: Router,
+    private apiService: AlfrescoApiService,
+    private uploadService: UploadService,
     store: Store<AppStore>,
     extensions: AppExtensionService,
     content: ContentManagementService
@@ -122,7 +130,11 @@ export class PreviewComponent extends PageComponent
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() =>
         this.navigateToFileLocation(true)
-      )
+      ),
+
+      this.uploadService.fileUploadComplete
+        .pipe(debounceTime(300))
+        .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry))
     ]);
 
     this.openWith = this.extensions.openWithActions;

--- a/src/app/components/preview/preview.component.ts
+++ b/src/app/components/preview/preview.component.ts
@@ -132,6 +132,10 @@ export class PreviewComponent extends PageComponent
         this.navigateToFileLocation(true)
       ),
 
+      this.uploadService.fileUploadDeleted.subscribe(() =>
+        this.navigateToFileLocation(true)
+      ),
+
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry))

--- a/src/app/extensions/core.extensions.module.ts
+++ b/src/app/extensions/core.extensions.module.ts
@@ -111,8 +111,8 @@ export class CoreExtensionsModule {
 
     extensions.setEvaluators({
       'app.selection.canDelete': app.canDeleteSelection,
-      'app.selection.canUnlockFile': app.canUnlockFile,
-      'app.selection.canLockFile': app.canLockFile,
+      'app.selection.file.canUnlock': app.canUnlockFile,
+      'app.selection.file.canLock': app.canLockFile,
       'app.selection.canDownload': app.canDownloadSelection,
       'app.selection.notEmpty': app.hasSelection,
       'app.selection.canUnshare': app.canUnshareNodes,

--- a/src/app/services/content-api.service.ts
+++ b/src/app/services/content-api.service.ts
@@ -281,4 +281,8 @@ export class ContentApiService {
       )
     );
   }
+
+  unlockNode(nodeId: string, opts?) {
+    return this.api.nodesApi.unlockNode(nodeId, opts);
+  }
 }

--- a/src/app/services/content-management.service.spec.ts
+++ b/src/app/services/content-management.service.spec.ts
@@ -43,7 +43,8 @@ import {
   MoveNodesAction,
   CopyNodesAction,
   ShareNodeAction,
-  SetSelectedNodesAction
+  SetSelectedNodesAction,
+  UnlockWriteAction
 } from '../store/actions';
 import { map } from 'rxjs/operators';
 import { NodeEffects } from '../store/effects/node.effects';
@@ -1564,6 +1565,36 @@ describe('ContentManagementService', () => {
 
       expect(contentManagementService.linksUnshared.next).toHaveBeenCalledWith(
         jasmine.any(Object)
+      );
+    }));
+  });
+
+  describe('Unlock Node', () => {
+    it('should unlock node', fakeAsync(() => {
+      spyOn(contentApi, 'unlockNode').and.returnValue(Promise.resolve({}));
+
+      store.dispatch(new UnlockWriteAction({ entry: { id: 'node-id' } }));
+      tick();
+      flush();
+
+      expect(contentApi.unlockNode).toHaveBeenCalled();
+    }));
+
+    it('should raise error when unlock node fails', fakeAsync(done => {
+      spyOn(contentApi, 'unlockNode').and.callFake(
+        () => new Promise((resolve, reject) => reject('error'))
+      );
+      spyOn(store, 'dispatch').and.callThrough();
+      store.dispatch(
+        new UnlockWriteAction({ entry: { id: 'node-id', name: 'some-file' } })
+      );
+      tick();
+      flush();
+
+      expect(store.dispatch['calls'].argsFor(1)[0]).toEqual(
+        new SnackbarErrorAction('APP.MESSAGES.ERRORS.UNLOCK_NODE', {
+          fileName: 'some-file'
+        })
       );
     }));
   });

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -51,7 +51,8 @@ import {
   SiteEntry,
   DeletedNodesPaging,
   PathInfoEntity,
-  SiteBody
+  SiteBody,
+  NodeEntry
 } from '@alfresco/js-api';
 import { NodePermissionService } from './node-permission.service';
 import { NodeInfo, DeletedNodeInfo, DeleteStatus } from '../store/models';
@@ -1216,5 +1217,15 @@ export class ContentManagementService {
         }
       })
     );
+  }
+
+  unlockNode(node: NodeEntry) {
+    this.contentApi.unlockNode(node.entry.id).catch(() => {
+      this.store.dispatch(
+        new SnackbarErrorAction('APP.MESSAGES.ERRORS.UNLOCK_NODE', {
+          fileName: node.entry.name
+        })
+      );
+    });
   }
 }

--- a/src/app/store/actions/node.actions.ts
+++ b/src/app/store/actions/node.actions.ts
@@ -43,6 +43,7 @@ export const PRINT_FILE = 'PRINT_FILE';
 export const FULLSCREEN_VIEWER = 'FULLSCREEN_VIEWER';
 export const MANAGE_VERSIONS = 'MANAGE_VERSIONS';
 export const EDIT_OFFLINE = 'EDIT_OFFLINE';
+export const UNLOCK_WRITE = 'UNLOCK_WRITE_LOCK';
 
 export class SetSelectedNodesAction implements Action {
   readonly type = SET_SELECTED_NODES;
@@ -126,5 +127,10 @@ export class ManageVersionsAction implements Action {
 
 export class EditOfflineAction implements Action {
   readonly type = EDIT_OFFLINE;
+  constructor(public payload: any) {}
+}
+
+export class UnlockWriteAction implements Action {
+  readonly type = UNLOCK_WRITE;
   constructor(public payload: any) {}
 }

--- a/src/app/store/effects/node.effects.spec.ts
+++ b/src/app/store/effects/node.effects.spec.ts
@@ -43,7 +43,9 @@ import {
   CopyNodesAction,
   MoveNodesAction,
   ManagePermissionsAction,
-  UnlockWriteAction
+  UnlockWriteAction,
+  FullscreenViewerAction,
+  PrintFileAction
 } from '../actions/node.actions';
 import { SetCurrentFolderAction } from '../actions/app.actions';
 
@@ -397,6 +399,40 @@ describe('NodeEffects', () => {
       store.dispatch(new ManagePermissionsAction(null));
 
       expect(contentService.managePermissions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('printFile$', () => {
+    it('it should print node content from payload', () => {
+      spyOn(contentService, 'printFile').and.stub();
+      const node: any = { entry: { id: 'node-id' } };
+
+      store.dispatch(new PrintFileAction(node));
+
+      expect(contentService.printFile).toHaveBeenCalledWith(node);
+    });
+
+    it('it should print node content from store', fakeAsync(() => {
+      spyOn(contentService, 'printFile').and.stub();
+      const node: any = { entry: { isFile: true, id: 'node-id' } };
+
+      store.dispatch(new SetSelectedNodesAction([node]));
+
+      tick(100);
+
+      store.dispatch(new PrintFileAction(null));
+
+      expect(contentService.printFile).toHaveBeenCalledWith(node);
+    }));
+  });
+
+  describe('fullscreenViewer$', () => {
+    it('should call fullscreen viewer', () => {
+      spyOn(contentService, 'fullscreenViewer').and.stub();
+
+      store.dispatch(new FullscreenViewerAction(null));
+
+      expect(contentService.fullscreenViewer).toHaveBeenCalled();
     });
   });
 

--- a/src/app/store/effects/node.effects.spec.ts
+++ b/src/app/store/effects/node.effects.spec.ts
@@ -42,7 +42,8 @@ import {
   EditFolderAction,
   CopyNodesAction,
   MoveNodesAction,
-  ManagePermissionsAction
+  ManagePermissionsAction,
+  UnlockWriteAction
 } from '../actions/node.actions';
 import { SetCurrentFolderAction } from '../actions/app.actions';
 
@@ -397,5 +398,29 @@ describe('NodeEffects', () => {
 
       expect(contentService.managePermissions).not.toHaveBeenCalled();
     });
+  });
+
+  describe('unlockWrite$', () => {
+    it('should unlock node from payload', () => {
+      spyOn(contentService, 'unlockNode').and.stub();
+      const node: any = { entry: { id: 'node-id' } };
+
+      store.dispatch(new UnlockWriteAction(node));
+
+      expect(contentService.unlockNode).toHaveBeenCalledWith(node);
+    });
+
+    it('should unlock node from store selection', fakeAsync(() => {
+      spyOn(contentService, 'unlockNode').and.stub();
+      const node: any = { entry: { id: 'node-id' } };
+
+      store.dispatch(new SetSelectedNodesAction([node]));
+
+      tick(100);
+
+      store.dispatch(new UnlockWriteAction(node));
+
+      expect(contentService.unlockNode).toHaveBeenCalledWith(node);
+    }));
   });
 });

--- a/src/app/store/effects/node.effects.spec.ts
+++ b/src/app/store/effects/node.effects.spec.ts
@@ -412,13 +412,13 @@ describe('NodeEffects', () => {
 
     it('should unlock node from store selection', fakeAsync(() => {
       spyOn(contentService, 'unlockNode').and.stub();
-      const node: any = { entry: { id: 'node-id' } };
+      const node: any = { entry: { isFile: true, id: 'node-id' } };
 
       store.dispatch(new SetSelectedNodesAction([node]));
 
       tick(100);
 
-      store.dispatch(new UnlockWriteAction(node));
+      store.dispatch(new UnlockWriteAction(null));
 
       expect(contentService.unlockNode).toHaveBeenCalledWith(node);
     }));

--- a/src/app/store/effects/node.effects.ts
+++ b/src/app/store/effects/node.effects.ts
@@ -44,7 +44,9 @@ import {
   ShareNodeAction,
   SHARE_NODE,
   ManageVersionsAction,
-  MANAGE_VERSIONS
+  MANAGE_VERSIONS,
+  UnlockWriteAction,
+  UNLOCK_WRITE
 } from '../actions';
 import { ContentManagementService } from '../../services/content-management.service';
 import { currentFolder, appSelection } from '../selectors/app.selectors';
@@ -314,6 +316,25 @@ export class NodeEffects {
     ofType<FullscreenViewerAction>(FULLSCREEN_VIEWER),
     map(() => {
       this.contentService.fullscreenViewer();
+    })
+  );
+
+  @Effect({ dispatch: false })
+  unlockWrite$ = this.actions$.pipe(
+    ofType<UnlockWriteAction>(UNLOCK_WRITE),
+    map(action => {
+      if (action && action.payload) {
+        this.contentService.unlockNode(action.payload);
+      } else {
+        this.store
+          .select(appSelection)
+          .pipe(take(1))
+          .subscribe(selection => {
+            if (selection && selection.file) {
+              this.contentService.unlockNode(selection.file);
+            }
+          });
+      }
     })
   );
 }

--- a/src/app/store/effects/upload.effects.ts
+++ b/src/app/store/effects/upload.effects.ts
@@ -184,7 +184,11 @@ export class UploadEffects {
       this.uploadService.uploadFilesInTheQueue();
 
       this.uploadService.fileUploadComplete.subscribe(completed => {
-        if (completed.data.entry.id === file.data.entry.id) {
+        if (
+          file.data.entry.properties &&
+          file.data.entry.properties['cm:lockType'] === 'WRITE_LOCK' &&
+          completed.data.entry.id === file.data.entry.id
+        ) {
           this.store.dispatch(new UnlockWriteAction(completed.data));
         }
       });

--- a/src/app/store/effects/upload.effects.ts
+++ b/src/app/store/effects/upload.effects.ts
@@ -34,7 +34,8 @@ import {
   UPLOAD_FOLDER,
   UPLOAD_FILE_VERSION,
   UploadFileVersionAction,
-  SnackbarErrorAction
+  SnackbarErrorAction,
+  UnlockWriteAction
 } from '../actions';
 import {
   map,
@@ -134,7 +135,7 @@ export class UploadEffects {
           );
 
           this.fileVersionInput.value = '';
-          this.uploadQueue([fileModel]);
+          this.uploadVersion(fileModel);
         }),
         catchError(error => {
           this.fileVersionInput.value = '';
@@ -175,5 +176,18 @@ export class UploadEffects {
         this.uploadService.uploadFilesInTheQueue();
       });
     }
+  }
+
+  private uploadVersion(file: FileModel) {
+    this.ngZone.run(() => {
+      this.uploadService.addToQueue(file);
+      this.uploadService.uploadFilesInTheQueue();
+
+      this.uploadService.fileUploadComplete.subscribe(completed => {
+        if (completed.data.entry.id === file.data.entry.id) {
+          this.store.dispatch(new UnlockWriteAction(completed.data));
+        }
+      });
+    });
   }
 }

--- a/src/app/store/effects/upload.effects.ts
+++ b/src/app/store/effects/upload.effects.ts
@@ -43,7 +43,9 @@ import {
   flatMap,
   distinctUntilChanged,
   catchError,
-  switchMap
+  switchMap,
+  tap,
+  filter
 } from 'rxjs/operators';
 import { FileUtils, FileModel, UploadService } from '@alfresco/adf-core';
 import { currentFolder } from '../selectors/app.selectors';
@@ -115,6 +117,12 @@ export class UploadEffects {
       return fromEvent(this.fileVersionInput, 'change').pipe(
         distinctUntilChanged(),
         flatMap(() => this.contentService.versionUploadDialog().afterClosed()),
+        tap(form => {
+          if (!form) {
+            this.fileVersionInput.value = '';
+          }
+        }),
+        filter(form => !!form),
         flatMap(form => forkJoin(of(form), this.contentService.getNodeInfo())),
         map(([form, node]) => {
           const file = this.fileVersionInput.files[0];

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -251,8 +251,8 @@
           "type": "rule",
           "value": "core.some",
           "parameters": [
-            { "type": "rule", "value": "app.selection.canUnlockFile" },
-            { "type": "rule", "value": "app.selection.canLockFile" }
+            { "type": "rule", "value": "app.selection.file.canUnlock" },
+            { "type": "rule", "value": "app.selection.file.canLock" }
           ]
         }
       ]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?



Preconditions

* any file is created
* file is locked for Edit Offline

Steps to reproduce

* Select the locked file and click on More actions -> Upload new version
* Select a file and press Upload
* After the upload is complete, observe the file

Expected result: New version is uploaded and file is unlocked
Actual result: File is not unlocked

Issue Number: ACA-2193


## What is the new behavior?

The file should be unlocked after Uploading a new version

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
