### PR TITLE
[ACA-2208] Hide app menu on swipe

### DIFF
--- a/src/app/components/layout/app-layout/app-layout.component.html
+++ b/src/app/components/layout/app-layout/app-layout.component.html
@@ -20,7 +20,10 @@
 
     <adf-sidenav-layout-navigation>
       <ng-template let-isMenuMinimized="isMenuMinimized">
-        <app-sidenav [showLabel]="!isMenuMinimized()"></app-sidenav>
+        <app-sidenav
+          [showLabel]="!isMenuMinimized()"
+          (swipeleft)="hideMenu($event)"
+        ></app-sidenav>
       </ng-template>
     </adf-sidenav-layout-navigation>
 

--- a/src/app/components/layout/app-layout/app-layout.component.spec.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.spec.ts
@@ -163,4 +163,18 @@ describe('AppLayoutComponent', () => {
       done();
     });
   });
+
+  it('should close menu on mobile screen size', () => {
+    component.minimizeSidenav = false;
+    component.layout.container = {
+      isMobileScreenSize: true
+    };
+
+    spyOn(component.layout.container, 'toggleMenu');
+    fixture.detectChanges();
+
+    component.hideMenu(<any>{ preventDefault: () => {} });
+
+    expect(component.layout.container.toggleMenu).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/layout/app-layout/app-layout.component.spec.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.spec.ts
@@ -167,7 +167,8 @@ describe('AppLayoutComponent', () => {
   it('should close menu on mobile screen size', () => {
     component.minimizeSidenav = false;
     component.layout.container = {
-      isMobileScreenSize: true
+      isMobileScreenSize: true,
+      toggleMenu: () => {}
     };
 
     spyOn(component.layout.container, 'toggleMenu');

--- a/src/app/components/layout/app-layout/app-layout.component.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.ts
@@ -152,6 +152,14 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
     this.onDestroy$.complete();
   }
 
+  hideMenu(event: Event) {
+    event.preventDefault();
+
+    if (!this.minimizeSidenav) {
+      this.layout.container.toggleMenu();
+    }
+  }
+
   private updateState() {
     if (this.minimizeSidenav && !this.layout.isMenuMinimized) {
       this.layout.isMenuMinimized = true;

--- a/src/app/components/layout/app-layout/app-layout.component.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.ts
@@ -153,9 +153,8 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
   }
 
   hideMenu(event: Event) {
-    event.preventDefault();
-
-    if (!this.minimizeSidenav) {
+    if (!this.minimizeSidenav && this.layout.container.isMobileScreenSize) {
+      event.preventDefault();
       this.layout.container.toggleMenu();
     }
   }

--- a/src/app/ui/overrides/adf-sidenav-layout.theme.scss
+++ b/src/app/ui/overrides/adf-sidenav-layout.theme.scss
@@ -4,6 +4,14 @@
   adf-sidenav-layout {
     @include flex-column;
 
+    // TODO: move to ADF
+    @media screen and ($mat-xsmall) {
+      .mat-drawer {
+        width: calc(-50px + 100vw) !important;
+        max-width: 320px !important;
+      }
+    }
+
     .mat-drawer-content {
       @include flex-column;
       overflow: auto;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #928 


## What is the new behavior?

- Allow using `swipe left` gesture on small screens to close the application menu.
- Adopt the size of the menu to small devices, always leave a space for click out

**iPhone 5 layout**

<img width="443" alt="screenshot 2019-02-13 at 12 51 47" src="https://user-images.githubusercontent.com/503991/52714124-03addc80-2f91-11e9-8da1-c599f60b5f73.png">

**iPhone 6 layout**

<img width="461" alt="screenshot 2019-02-13 at 12 52 02" src="https://user-images.githubusercontent.com/503991/52714164-17f1d980-2f91-11e9-9766-a55d0ebe6a86.png">


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
