### PR TITLE
[ACA-2211] auth guard: add support for withCredentials

### DIFF
--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -26,14 +26,15 @@
 import { AppAuthGuard } from './auth.guard';
 import { TestBed } from '@angular/core/testing';
 import { AppTestingModule } from '../testing/app-testing.module';
-import { AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService, AppConfigService } from '@alfresco/adf-core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
-describe('AppAuthGuard', () => {
+fdescribe('AppAuthGuard', () => {
   let auth: AuthenticationService;
   let guard: AppAuthGuard;
   let router: Router;
+  let config: AppConfigService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,8 +45,29 @@ describe('AppAuthGuard', () => {
     auth = TestBed.get(AuthenticationService);
     guard = TestBed.get(AppAuthGuard);
     router = TestBed.get(Router);
+    config = TestBed.get(AppConfigService);
 
     spyOn(router, 'navigateByUrl').and.stub();
+  });
+
+  it('should fall through when withCredentials enabled', () => {
+    spyOn(auth, 'isEcmLoggedIn').and.returnValue(false);
+
+    config.config = {
+      auth: {
+        withCredentials: false
+      }
+    };
+
+    expect(guard.checkLogin(null)).toBe(false);
+
+    config.config = {
+      auth: {
+        withCredentials: true
+      }
+    };
+
+    expect(guard.checkLogin(null)).toBe(true);
   });
 
   it('should evaluate to [true] if logged in already', () => {

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -30,7 +30,7 @@ import { AuthenticationService, AppConfigService } from '@alfresco/adf-core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
-fdescribe('AppAuthGuard', () => {
+describe('AppAuthGuard', () => {
   let auth: AuthenticationService;
   let guard: AppAuthGuard;
   let router: Router;

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -44,7 +44,10 @@ export class AppAuthGuard extends AuthGuardEcm {
   }
 
   checkLogin(redirectUrl: string): boolean {
-    const withCredentials = this._config.get<boolean>('auth.withCredentials', false);
+    const withCredentials = this._config.get<boolean>(
+      'auth.withCredentials',
+      false
+    );
 
     if (withCredentials || this._auth.isEcmLoggedIn()) {
       return true;

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -38,13 +38,15 @@ export class AppAuthGuard extends AuthGuardEcm {
   constructor(
     private _auth: AuthenticationService,
     private _router: Router,
-    config: AppConfigService
+    private _config: AppConfigService
   ) {
-    super(_auth, _router, config);
+    super(_auth, _router, _config);
   }
 
   checkLogin(redirectUrl: string): boolean {
-    if (this._auth.isEcmLoggedIn()) {
+    const withCredentials = this._config.get<boolean>('auth.withCredentials', false);
+
+    if (withCredentials || this._auth.isEcmLoggedIn()) {
       return true;
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #913


## What is the new behavior?

Skipt the Basic/oAuth checks if `withCredentials` (Kerberos) is enabled in `app.config.json`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

To enable the mode, one has to set the following setting in the `app.config.json` file:

```json
{
    "auth": {
        "withCredentials": true
    }
}
```