### PR TITLE
[ACA-2177] remove separator between Favorite and Edit folder

### DIFF
--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -610,11 +610,6 @@
             }
           },
           {
-            "id": "app.create.separator.2",
-            "type": "separator",
-            "order": 450
-          },
-          {
             "id": "app.toolbar.editFolder",
             "order": 450,
             "title": "APP.ACTIONS.EDIT",
@@ -627,7 +622,7 @@
             }
           },
           {
-            "id": "app.create.separator.3",
+            "id": "app.create.separator.2",
             "type": "separator",
             "order": 500
           },
@@ -668,7 +663,7 @@
             }
           },
           {
-            "id": "app.create.separator.4",
+            "id": "app.create.separator.3",
             "type": "separator",
             "order": 900
           },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

for a folder in More actions there is a separator between Favorite and Edit actions.

Issue Number: ACA-2177


## What is the new behavior?
removed the separator between Favorite and Edit folder actions

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
