### PR TITLE
[ACA-2221] Lock node - check selection is not null

### DIFF
--- a/src/app/directives/lock-node.directive.spec.ts
+++ b/src/app/directives/lock-node.directive.spec.ts
@@ -69,6 +69,12 @@ describe('LockNodeDirective', () => {
     api = TestBed.get(AlfrescoApiService);
   });
 
+  it('should return false if selection is null', () => {
+    component.selection = null;
+    fixture.detectChanges();
+    expect(component.directive.isNodeLocked()).toBe(false);
+  });
+
   it('should return false if selection is not locked', () => {
     component.selection = { entry: { name: 'test-name', properties: {} } };
     fixture.detectChanges();

--- a/src/app/directives/lock-node.directive.ts
+++ b/src/app/directives/lock-node.directive.ts
@@ -54,7 +54,7 @@ export class LockNodeDirective {
   constructor(private alfrescoApiService: AlfrescoApiService) {}
 
   isNodeLocked(): boolean {
-    return isLocked(this.node);
+    return !!(this.node && isLocked(this.node));
   }
 
   private async toggleLock(node: NodeEntry | SharedLinkEntry) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [ACA-2221](https://issues.alfresco.com/jira/browse/ACA-2221)


## What is the new behavior?

check if selection is not null 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
