### PR TITLE
[ACA-2208] Hide app menu on swipe

### DIFF
--- a/src/app/components/layout/app-layout/app-layout.component.spec.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.spec.ts
@@ -178,4 +178,20 @@ describe('AppLayoutComponent', () => {
 
     expect(component.layout.container.toggleMenu).toHaveBeenCalled();
   });
+
+  it('should close menu on mobile screen size also when minimizeSidenav true', () => {
+    fixture.detectChanges();
+    component.minimizeSidenav = true;
+    component.layout.container = {
+      isMobileScreenSize: true,
+      toggleMenu: () => {}
+    };
+
+    spyOn(component.layout.container, 'toggleMenu');
+    fixture.detectChanges();
+
+    component.hideMenu(<any>{ preventDefault: () => {} });
+
+    expect(component.layout.container.toggleMenu).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/layout/app-layout/app-layout.component.ts
+++ b/src/app/components/layout/app-layout/app-layout.component.ts
@@ -153,7 +153,7 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
   }
 
   hideMenu(event: Event) {
-    if (!this.minimizeSidenav && this.layout.container.isMobileScreenSize) {
+    if (this.layout.container.isMobileScreenSize) {
       event.preventDefault();
       this.layout.container.toggleMenu();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The swipe menu is not working when the user is on search results pages.
Issue Number: N/A


## What is the new behavior?
`swipe left` gesture will hide the application menu also from search results pages.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
