### PR TITLE
[ACA-2212] allow "edit in office" only for basic auth

### DIFF
--- a/projects/adf-office-services-ext/package.json
+++ b/projects/adf-office-services-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alfresco/adf-office-services-ext",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "Apache-2.0",
   "author": {
     "name": "Keensoft",

--- a/projects/adf-office-services-ext/src/lib/evaluators.ts
+++ b/projects/adf-office-services-ext/src/lib/evaluators.ts
@@ -1,10 +1,17 @@
 import { RuleContext, RuleParameter } from '@alfresco/adf-extensions';
+import { AuthenticationService } from '@alfresco/adf-core';
 import { getFileExtension, supportedExtensions } from './utils';
 
 export function canOpenWithOffice(
   context: RuleContext,
   ...args: RuleParameter[]
 ): boolean {
+  // todo: needs to have typed access via SDK (1.8)
+  const auth: AuthenticationService = (<any>context).auth;
+  if (auth && auth.isOauth()) {
+    return false;
+  }
+
   const file = context.selection.file;
 
   if (!file || !file.entry || !file.entry.properties) {

--- a/src/app/extensions/app.interface.ts
+++ b/src/app/extensions/app.interface.ts
@@ -24,7 +24,9 @@
  */
 
 import { RuleContext, RepositoryState } from '@alfresco/adf-extensions';
+import { AuthenticationService } from '@alfresco/adf-core';
 
 export interface AppRuleContext extends RuleContext {
   repository: RepositoryState;
+  auth: AuthenticationService;
 }

--- a/src/app/extensions/extension.service.ts
+++ b/src/app/extensions/extension.service.ts
@@ -35,7 +35,6 @@ import {
   SelectionState,
   NavigationState,
   ExtensionConfig,
-  RuleContext,
   RuleEvaluator,
   ViewerExtensionRef,
   ContentActionRef,
@@ -52,15 +51,16 @@ import {
   RepositoryState,
   ExtensionRef
 } from '@alfresco/adf-extensions';
-import { AppConfigService } from '@alfresco/adf-core';
+import { AppConfigService, AuthenticationService } from '@alfresco/adf-core';
 import { DocumentListPresetRef } from './document-list.extensions';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IconRef } from './icon.extensions';
+import { AppRuleContext } from './app.interface';
 
 @Injectable({
   providedIn: 'root'
 })
-export class AppExtensionService implements RuleContext {
+export class AppExtensionService implements AppRuleContext {
   private _references = new BehaviorSubject<ExtensionRef[]>([]);
 
   defaults = {
@@ -108,6 +108,7 @@ export class AppExtensionService implements RuleContext {
   references$: Observable<ExtensionRef[]>;
 
   constructor(
+    public auth: AuthenticationService,
     protected store: Store<AppStore>,
     protected loader: ExtensionLoaderService,
     protected extensions: ExtensionService,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [ACA-2212](https://issues.alfresco.com/jira/browse/ACA-2212)


## What is the new behavior?

Where SSO is configured (Alfresco Identity Service) then the **Edit in Office** action will not be shown

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
