### PR TITLE
[ACA-2220] simple "search in fields" support

### DIFF
--- a/src/app/components/search/search-results/search-results.component.spec.ts
+++ b/src/app/components/search/search-results/search-results.component.spec.ts
@@ -1,24 +1,109 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SearchResultsComponent } from './search-results.component';
+import { AppTestingModule } from '../../../testing/app-testing.module';
+import { AppSearchResultsModule } from '../search-results.module';
+import { CoreModule, AppConfigService } from '@alfresco/adf-core';
+import { Store } from '@ngrx/store';
+import { NavigateToFolder } from '../../../store/actions';
+import { Pagination } from '@alfresco/js-api';
+import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
 
 describe('SearchComponent', () => {
   let component: SearchResultsComponent;
   let fixture: ComponentFixture<SearchResultsComponent>;
+  let config: AppConfigService;
+  let store: Store<any>;
+  let queryBuilder: SearchQueryBuilderService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchResultsComponent]
-    }).compileComponents();
-  }));
+      imports: [CoreModule.forRoot(), AppTestingModule, AppSearchResultsModule]
+    });
 
-  beforeEach(() => {
+    config = TestBed.get(AppConfigService);
+    store = TestBed.get(Store);
+    queryBuilder = TestBed.get(SearchQueryBuilderService);
+
     fixture = TestBed.createComponent(SearchResultsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }));
+
+  it('should return null if formatting invalid query', () => {
+    expect(component.formatSearchQuery(null)).toBeNull();
+    expect(component.formatSearchQuery('')).toBeNull();
   });
 
-  xit('should create', () => {
-    expect(component).toBeTruthy();
+  it('should use original user input if content contains colons', () => {
+    const query = 'TEXT:test OR TYPE:folder';
+    expect(component.formatSearchQuery(query)).toBe(query);
+  });
+
+  it('should format user input according to the configuration fields', () => {
+    config.config = {
+      search: {
+        'aca:fields': ['cm:name', 'cm:title']
+      }
+    };
+
+    const query = component.formatSearchQuery('hello');
+    expect(query).toBe(`cm:name:"hello*" OR cm:title:"hello*"`);
+  });
+
+  it('should format user input as cm:name if configuration not provided', () => {
+    config.config = {
+      search: {
+        'aca:fields': undefined
+      }
+    };
+
+    const query = component.formatSearchQuery('hello');
+    expect(query).toBe(`cm:name:"hello*"`);
+  });
+
+  it('should navigate to folder on double click', () => {
+    const node: any = {
+      entry: {
+        isFolder: true
+      }
+    };
+
+    spyOn(store, 'dispatch').and.stub();
+
+    component.onNodeDoubleClick(node);
+
+    expect(store.dispatch).toHaveBeenCalledWith(new NavigateToFolder(node));
+  });
+
+  it('should preview file node on double click', () => {
+    const node: any = {
+      entry: {
+        isFolder: false
+      }
+    };
+
+    spyOn(component, 'showPreview').and.stub();
+
+    component.onNodeDoubleClick(node);
+
+    expect(component.showPreview).toHaveBeenCalledWith(node);
+  });
+
+  it('should re-run search on pagination change', () => {
+    const page = new Pagination({
+      maxItems: 10,
+      skipCount: 0
+    });
+
+    spyOn(queryBuilder, 'update').and.stub();
+
+    component.onPaginationChanged(page);
+
+    expect(queryBuilder.paging).toEqual({
+      maxItems: 10,
+      skipCount: 0
+    });
+    expect(queryBuilder.update).toHaveBeenCalled();
   });
 });

--- a/src/app/components/search/search-results/search-results.component.ts
+++ b/src/app/components/search/search-results/search-results.component.ts
@@ -119,6 +119,12 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
       return null;
     }
 
+    userInput = userInput.trim();
+
+    if (userInput.includes(':')) {
+      return userInput;
+    }
+
     const fields = this.config.get<string[]>('search.aca:fields', ['cm:name']);
     const query = fields.map(field => `${field}:"${userInput}*"`).join(' OR ');
 

--- a/src/app/components/search/search-results/search-results.component.ts
+++ b/src/app/components/search/search-results/search-results.component.ts
@@ -114,7 +114,7 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
     }
   }
 
-  private formatSearchQuery(userInput: string) {
+  formatSearchQuery(userInput: string) {
     if (!userInput) {
       return null;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [ACA-2220](https://issues.alfresco.com/jira/browse/ACA-2220)


## What is the new behavior?

Provide a very simple support for search in fields:
If the search input query contains a column (`:`) symbol, passes the query to the search service as it is.

This enables the whole range of scenarios for advanced search, examples:
https://docs.alfresco.com/6.0/concepts/rm-searchsyntax-fields.html

<img width="1142" alt="screenshot 2019-02-25 at 14 40 42" src="https://user-images.githubusercontent.com/503991/53350043-3a331200-3916-11e9-97c2-847e93c4e606.png">

Can also be joined with `AND` or `OR`

<img width="1112" alt="screenshot 2019-02-25 at 15 59 27" src="https://user-images.githubusercontent.com/503991/53350104-5d5dc180-3916-11e9-8aca-7917c5962649.png">


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
