### PR TITLE
reload active doclist via NgRx actions

### DIFF
--- a/docs/extending/application-actions.md
+++ b/docs/extending/application-actions.md
@@ -117,3 +117,4 @@ Below is the list of public actions types you can use in the plugin definitions 
 | PRINT_FILE             | MinimalNodeEntity   | Print the file opened in the Viewer (or selected).                                              |
 | FULLSCREEN_VIEWER      | n/a                 | Enters fullscreen mode to view the file opened in the Viewer.                                   |
 | LOGOUT                 | n/a                 | Log out and redirect to Login screen.                                                           |
+| RELOAD_DOCUMENT_LIST   | n/a                 | Reload active document list                                                                     |

--- a/src/app/components/favorites/favorites.component.spec.ts
+++ b/src/app/components/favorites/favorites.component.spec.ts
@@ -108,12 +108,6 @@ describe('FavoritesComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should refresh on editing folder event', () => {
-      contentService.folderEdited.next(null);
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should refresh on move node event', () => {
       contentService.nodesMoved.next(null);
 

--- a/src/app/components/favorites/favorites.component.spec.ts
+++ b/src/app/components/favorites/favorites.component.spec.ts
@@ -167,12 +167,12 @@ describe('FavoritesComponent', () => {
 
   describe('refresh', () => {
     it('should call document list reload', () => {
-      spyOn(component.documentList, 'reload');
+      spyOn(component, 'reload');
       fixture.detectChanges();
 
       component.reload();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/favorites/favorites.component.spec.ts
+++ b/src/app/components/favorites/favorites.component.spec.ts
@@ -35,7 +35,6 @@ import {
   AppConfigPipe
 } from '@alfresco/adf-core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
-import { ContentManagementService } from '../../services/content-management.service';
 import { of } from 'rxjs';
 import { FavoritesComponent } from './favorites.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
@@ -45,7 +44,6 @@ describe('FavoritesComponent', () => {
   let fixture: ComponentFixture<FavoritesComponent>;
   let component: FavoritesComponent;
   let alfrescoApi: AlfrescoApiService;
-  let contentService: ContentManagementService;
   let contentApi: ContentApiService;
   let router: Router;
   let page;
@@ -97,22 +95,7 @@ describe('FavoritesComponent', () => {
     );
 
     contentApi = TestBed.get(ContentApiService);
-
-    contentService = TestBed.get(ContentManagementService);
     router = TestBed.get(Router);
-  });
-
-  describe('Events', () => {
-    beforeEach(() => {
-      spyOn(component, 'reload');
-      fixture.detectChanges();
-    });
-
-    it('should refresh on node deleted event', () => {
-      contentService.nodesDeleted.next(null);
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('Node navigation', () => {

--- a/src/app/components/favorites/favorites.component.spec.ts
+++ b/src/app/components/favorites/favorites.component.spec.ts
@@ -108,12 +108,6 @@ describe('FavoritesComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should refresh on move node event', () => {
-      contentService.nodesMoved.next(null);
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should refresh on node deleted event', () => {
       contentService.nodesDeleted.next(null);
 

--- a/src/app/components/favorites/favorites.component.spec.ts
+++ b/src/app/components/favorites/favorites.component.spec.ts
@@ -119,12 +119,6 @@ describe('FavoritesComponent', () => {
 
       expect(component.reload).toHaveBeenCalled();
     });
-
-    it('should refresh on node restore event', () => {
-      contentService.nodesRestored.next(null);
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('Node navigation', () => {

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -66,7 +66,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
 
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
-      this.content.nodesRestored.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -67,7 +67,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
       this.content.nodesRestored.subscribe(() => this.reload()),
-      this.content.folderEdited.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
       this.content.favoriteRemoved.subscribe(() => this.reload()),
       this.content.favoriteToggle.subscribe(() => this.reload()),

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -66,7 +66,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
 
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
-      this.content.nodesMoved.subscribe(() => this.reload()),
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -68,7 +68,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
       this.content.nodesDeleted.subscribe(() => this.reload()),
       this.content.nodesRestored.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
-      this.content.favoriteRemoved.subscribe(() => this.reload()),
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -69,8 +69,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
       this.content.nodesRestored.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
       this.content.favoriteRemoved.subscribe(() => this.reload()),
-      this.content.favoriteToggle.subscribe(() => this.reload()),
-      this.content.favoriteToggle.subscribe(() => this.reload()),
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -65,7 +65,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
     super.ngOnInit();
 
     this.subscriptions = this.subscriptions.concat([
-      this.content.nodesDeleted.subscribe(() => this.reload()),
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/favorites/favorites.component.ts
+++ b/src/app/components/favorites/favorites.component.ts
@@ -121,6 +121,6 @@ export class FavoritesComponent extends PageComponent implements OnInit {
   }
 
   private onFileUploadedEvent(event: FileUploadEvent) {
-    this.documentList.reload();
+    this.reload();
   }
 }

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -182,12 +182,6 @@ describe('FilesComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     });
 
-    it('should call refresh moveNode event', () => {
-      contentManagementService.nodesMoved.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should call refresh on fileUploadComplete event if parent node match', fakeAsync(() => {
       const file = { file: { options: { parentId: 'parentId' } } };
       component.node = <any>{ id: 'parentId' };

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -176,12 +176,6 @@ describe('FilesComponent', () => {
       expect(component.documentList.reload).not.toHaveBeenCalled();
     });
 
-    it('should call refresh onCreateFolder event', () => {
-      contentManagementService.folderCreated.next();
-
-      expect(component.documentList.reload).toHaveBeenCalled();
-    });
-
     it('should call refresh editFolder event', () => {
       contentManagementService.folderEdited.next();
 

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -188,12 +188,6 @@ describe('FilesComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     });
 
-    it('should call refresh restoreNode event', () => {
-      contentManagementService.nodesRestored.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should call refresh on fileUploadComplete event if parent node match', fakeAsync(() => {
       const file = { file: { options: { parentId: 'parentId' } } };
       component.node = <any>{ id: 'parentId' };

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -41,7 +41,6 @@ import {
   AppConfigPipe
 } from '@alfresco/adf-core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
-import { ContentManagementService } from '../../services/content-management.service';
 import { NodeActionsService } from '../../services/node-actions.service';
 import { FilesComponent } from './files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
@@ -52,7 +51,6 @@ describe('FilesComponent', () => {
   let node;
   let fixture: ComponentFixture<FilesComponent>;
   let component: FilesComponent;
-  let contentManagementService: ContentManagementService;
   let uploadService: UploadService;
   let router: Router;
   let nodeActionsService: NodeActionsService;
@@ -86,7 +84,6 @@ describe('FilesComponent', () => {
     fixture = TestBed.createComponent(FilesComponent);
     component = fixture.componentInstance;
 
-    contentManagementService = TestBed.get(ContentManagementService);
     uploadService = TestBed.get(UploadService);
     router = TestBed.get(Router);
     nodeActionsService = TestBed.get(NodeActionsService);
@@ -174,12 +171,6 @@ describe('FilesComponent', () => {
       nodeActionsService.contentCopied.next(nodes);
 
       expect(component.reload).not.toHaveBeenCalled();
-    });
-
-    it('should call refresh deleteNode event', () => {
-      contentManagementService.nodesDeleted.next();
-
-      expect(component.reload).toHaveBeenCalled();
     });
 
     it('should call refresh on fileUploadComplete event if parent node match', fakeAsync(() => {

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -176,12 +176,6 @@ describe('FilesComponent', () => {
       expect(component.documentList.reload).not.toHaveBeenCalled();
     });
 
-    it('should call refresh editFolder event', () => {
-      contentManagementService.folderEdited.next();
-
-      expect(component.documentList.reload).toHaveBeenCalled();
-    });
-
     it('should call refresh deleteNode event', () => {
       contentManagementService.nodesDeleted.next();
 

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -145,7 +145,7 @@ describe('FilesComponent', () => {
   describe('refresh on events', () => {
     beforeEach(() => {
       spyOn(contentApi, 'getNode').and.returnValue(of({ entry: node }));
-      spyOn(component.documentList, 'reload');
+      spyOn(component, 'reload');
 
       fixture.detectChanges();
     });
@@ -160,7 +160,7 @@ describe('FilesComponent', () => {
 
       nodeActionsService.contentCopied.next(nodes);
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
 
     it('should not call refresh onContentCopied event when parent mismatch', () => {
@@ -173,25 +173,25 @@ describe('FilesComponent', () => {
 
       nodeActionsService.contentCopied.next(nodes);
 
-      expect(component.documentList.reload).not.toHaveBeenCalled();
+      expect(component.reload).not.toHaveBeenCalled();
     });
 
     it('should call refresh deleteNode event', () => {
       contentManagementService.nodesDeleted.next();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
 
     it('should call refresh moveNode event', () => {
       contentManagementService.nodesMoved.next();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
 
     it('should call refresh restoreNode event', () => {
       contentManagementService.nodesRestored.next();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
 
     it('should call refresh on fileUploadComplete event if parent node match', fakeAsync(() => {
@@ -202,7 +202,7 @@ describe('FilesComponent', () => {
 
       tick(500);
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     }));
 
     it('should not call refresh on fileUploadComplete event if parent mismatch', fakeAsync(() => {
@@ -213,7 +213,7 @@ describe('FilesComponent', () => {
 
       tick(500);
 
-      expect(component.documentList.reload).not.toHaveBeenCalled();
+      expect(component.reload).not.toHaveBeenCalled();
     }));
 
     it('should call refresh on fileUploadDeleted event if parent node match', fakeAsync(() => {
@@ -224,7 +224,7 @@ describe('FilesComponent', () => {
 
       tick(500);
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     }));
 
     it('should not call refresh on fileUploadDeleted event if parent mismatch', fakeAsync(() => {
@@ -235,7 +235,7 @@ describe('FilesComponent', () => {
 
       tick(500);
 
-      expect(component.documentList.reload).not.toHaveBeenCalled();
+      expect(component.reload).not.toHaveBeenCalled();
     }));
   });
 

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -103,7 +103,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       ),
       content.nodesDeleted.subscribe(() => this.reload()),
       content.nodesMoved.subscribe(() => this.reload()),
-      content.nodesRestored.subscribe(() => this.reload()),
       uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -101,9 +101,9 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       nodeActionsService.contentCopied.subscribe(nodes =>
         this.onContentCopied(nodes)
       ),
-      content.nodesDeleted.subscribe(() => this.documentList.reload()),
-      content.nodesMoved.subscribe(() => this.documentList.reload()),
-      content.nodesRestored.subscribe(() => this.documentList.reload()),
+      content.nodesDeleted.subscribe(() => this.reload()),
+      content.nodesMoved.subscribe(() => this.reload()),
+      content.nodesRestored.subscribe(() => this.reload()),
       uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),
@@ -176,7 +176,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
 
     // check root and child nodes
     if (node && node.entry && node.entry.parentId === this.getParentNodeId()) {
-      this.documentList.reload();
+      this.reload();
       return;
     }
 
@@ -213,7 +213,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     if (alreadyDisplayedParentFolder) {
       return;
     }
-    this.documentList.reload();
+    this.reload();
   }
 
   onContentCopied(nodes: MinimalNodeEntity[]) {
@@ -223,7 +223,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       );
     });
     if (newNode) {
-      this.documentList.reload();
+      this.reload();
     }
   }
 

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -102,7 +102,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
         this.onContentCopied(nodes)
       ),
       content.nodesDeleted.subscribe(() => this.reload()),
-      content.nodesMoved.subscribe(() => this.reload()),
       uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -73,7 +73,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     super.ngOnInit();
 
-    const { route, content, nodeActionsService, uploadService } = this;
+    const { route, nodeActionsService, uploadService } = this;
     const { data } = route.snapshot;
 
     this.title = data.title;
@@ -101,7 +101,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       nodeActionsService.contentCopied.subscribe(nodes =>
         this.onContentCopied(nodes)
       ),
-      content.nodesDeleted.subscribe(() => this.reload()),
       uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(file => this.onFileUploadedEvent(file)),

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -101,7 +101,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       nodeActionsService.contentCopied.subscribe(nodes =>
         this.onContentCopied(nodes)
       ),
-      content.folderEdited.subscribe(() => this.documentList.reload()),
       content.nodesDeleted.subscribe(() => this.documentList.reload()),
       content.nodesMoved.subscribe(() => this.documentList.reload()),
       content.nodesRestored.subscribe(() => this.documentList.reload()),

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -101,7 +101,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       nodeActionsService.contentCopied.subscribe(nodes =>
         this.onContentCopied(nodes)
       ),
-      content.folderCreated.subscribe(() => this.documentList.reload()),
       content.folderEdited.subscribe(() => this.documentList.reload()),
       content.nodesDeleted.subscribe(() => this.documentList.reload()),
       content.nodesMoved.subscribe(() => this.documentList.reload()),

--- a/src/app/components/page.component.ts
+++ b/src/app/components/page.component.ts
@@ -35,7 +35,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AppExtensionService } from '../extensions/extension.service';
 import { ContentManagementService } from '../services/content-management.service';
-import { SetSelectedNodesAction, ViewFileAction } from '../store/actions';
+import { ViewFileAction, ReloadDocumentListAction } from '../store/actions';
 import {
   appSelection,
   currentFolder,
@@ -128,11 +128,7 @@ export abstract class PageComponent implements OnInit, OnDestroy {
   }
 
   reload(): void {
-    if (this.documentList) {
-      this.documentList.resetSelection();
-      this.store.dispatch(new SetSelectedNodesAction([]));
-      this.documentList.reload();
-    }
+    this.store.dispatch(new ReloadDocumentListAction());
   }
 
   trackByActionId(index: number, action: ContentActionRef) {

--- a/src/app/components/recent-files/recent-files.component.spec.ts
+++ b/src/app/components/recent-files/recent-files.component.spec.ts
@@ -101,14 +101,6 @@ describe('RecentFilesComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     });
 
-    it('should reload on onRestoreNode event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesRestored.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should reload on move node event', () => {
       fixture.detectChanges();
 

--- a/src/app/components/recent-files/recent-files.component.spec.ts
+++ b/src/app/components/recent-files/recent-files.component.spec.ts
@@ -34,8 +34,6 @@ import {
   AppConfigPipe
 } from '@alfresco/adf-core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
-import { ContentManagementService } from '../../services/content-management.service';
-
 import { RecentFilesComponent } from './recent-files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
@@ -43,7 +41,6 @@ describe('RecentFilesComponent', () => {
   let fixture: ComponentFixture<RecentFilesComponent>;
   let component: RecentFilesComponent;
   let alfrescoApi: AlfrescoApiService;
-  let contentService: ContentManagementService;
   let page;
 
   beforeEach(() => {
@@ -73,7 +70,6 @@ describe('RecentFilesComponent', () => {
     fixture = TestBed.createComponent(RecentFilesComponent);
     component = fixture.componentInstance;
 
-    contentService = TestBed.get(ContentManagementService);
     alfrescoApi = TestBed.get(AlfrescoApiService);
     alfrescoApi.reset();
 
@@ -86,20 +82,6 @@ describe('RecentFilesComponent', () => {
     spyOn(alfrescoApi.searchApi, 'search').and.returnValue(
       Promise.resolve(page)
     );
-  });
-
-  describe('OnInit()', () => {
-    beforeEach(() => {
-      spyOn(component, 'reload').and.stub();
-    });
-
-    it('should reload nodes on onDeleteNode event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesDeleted.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('refresh', () => {

--- a/src/app/components/recent-files/recent-files.component.spec.ts
+++ b/src/app/components/recent-files/recent-files.component.spec.ts
@@ -100,14 +100,6 @@ describe('RecentFilesComponent', () => {
 
       expect(component.reload).toHaveBeenCalled();
     });
-
-    it('should reload on move node event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesMoved.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('refresh', () => {

--- a/src/app/components/recent-files/recent-files.component.spec.ts
+++ b/src/app/components/recent-files/recent-files.component.spec.ts
@@ -120,12 +120,12 @@ describe('RecentFilesComponent', () => {
 
   describe('refresh', () => {
     it('should call document list reload', () => {
-      spyOn(component.documentList, 'reload');
+      spyOn(component, 'reload');
       fixture.detectChanges();
 
       component.reload();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/recent-files/recent-files.component.ts
+++ b/src/app/components/recent-files/recent-files.component.ts
@@ -31,7 +31,7 @@ import { PageComponent } from '../page.component';
 import { Store } from '@ngrx/store';
 import { AppStore } from '../../store/states/app.state';
 import { AppExtensionService } from '../../extensions/extension.service';
-import { FileUploadEvent, UploadService } from '@alfresco/adf-core';
+import { UploadService } from '@alfresco/adf-core';
 import { debounceTime } from 'rxjs/operators';
 
 @Component({
@@ -62,10 +62,10 @@ export class RecentFilesComponent extends PageComponent implements OnInit {
 
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
-        .subscribe(file => this.onFileUploadedEvent(file)),
+        .subscribe(() => this.onFileUploadedEvent()),
       this.uploadService.fileUploadDeleted
         .pipe(debounceTime(300))
-        .subscribe(file => this.onFileUploadedEvent(file)),
+        .subscribe(() => this.onFileUploadedEvent()),
 
       this.breakpointObserver
         .observe([Breakpoints.HandsetPortrait, Breakpoints.HandsetLandscape])
@@ -83,7 +83,7 @@ export class RecentFilesComponent extends PageComponent implements OnInit {
     }
   }
 
-  private onFileUploadedEvent(event: FileUploadEvent) {
-    this.documentList.reload();
+  private onFileUploadedEvent() {
+    this.reload();
   }
 }

--- a/src/app/components/recent-files/recent-files.component.ts
+++ b/src/app/components/recent-files/recent-files.component.ts
@@ -58,7 +58,6 @@ export class RecentFilesComponent extends PageComponent implements OnInit {
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
-      this.content.nodesRestored.subscribe(() => this.reload()),
 
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))

--- a/src/app/components/recent-files/recent-files.component.ts
+++ b/src/app/components/recent-files/recent-files.component.ts
@@ -57,7 +57,6 @@ export class RecentFilesComponent extends PageComponent implements OnInit {
 
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
-      this.content.nodesMoved.subscribe(() => this.reload()),
 
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))

--- a/src/app/components/recent-files/recent-files.component.ts
+++ b/src/app/components/recent-files/recent-files.component.ts
@@ -56,8 +56,6 @@ export class RecentFilesComponent extends PageComponent implements OnInit {
     super.ngOnInit();
 
     this.subscriptions = this.subscriptions.concat([
-      this.content.nodesDeleted.subscribe(() => this.reload()),
-
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
         .subscribe(() => this.onFileUploadedEvent()),

--- a/src/app/components/shared-files/shared-files.component.spec.ts
+++ b/src/app/components/shared-files/shared-files.component.spec.ts
@@ -93,14 +93,6 @@ describe('SharedFilesComponent', () => {
 
       expect(component.reload).toHaveBeenCalled();
     });
-
-    it('should reload on move node event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesMoved.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('refresh', () => {

--- a/src/app/components/shared-files/shared-files.component.spec.ts
+++ b/src/app/components/shared-files/shared-files.component.spec.ts
@@ -34,14 +34,12 @@ import {
   AppConfigPipe
 } from '@alfresco/adf-core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
-import { ContentManagementService } from '../../services/content-management.service';
 import { SharedFilesComponent } from './shared-files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
 describe('SharedFilesComponent', () => {
   let fixture: ComponentFixture<SharedFilesComponent>;
   let component: SharedFilesComponent;
-  let contentService: ContentManagementService;
   let alfrescoApi: AlfrescoApiService;
   let page;
 
@@ -72,27 +70,12 @@ describe('SharedFilesComponent', () => {
     fixture = TestBed.createComponent(SharedFilesComponent);
     component = fixture.componentInstance;
 
-    contentService = TestBed.get(ContentManagementService);
     alfrescoApi = TestBed.get(AlfrescoApiService);
     alfrescoApi.reset();
 
     spyOn(alfrescoApi.sharedLinksApi, 'findSharedLinks').and.returnValue(
       Promise.resolve(page)
     );
-  });
-
-  describe('OnInit', () => {
-    beforeEach(() => {
-      spyOn(component, 'reload').and.callFake(val => val);
-    });
-
-    it('should refresh on deleteNode event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesDeleted.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
   });
 
   describe('refresh', () => {

--- a/src/app/components/shared-files/shared-files.component.spec.ts
+++ b/src/app/components/shared-files/shared-files.component.spec.ts
@@ -113,12 +113,12 @@ describe('SharedFilesComponent', () => {
 
   describe('refresh', () => {
     it('should call document list reload', () => {
-      spyOn(component.documentList, 'reload');
+      spyOn(component, 'reload');
       fixture.detectChanges();
 
       component.reload();
 
-      expect(component.documentList.reload).toHaveBeenCalled();
+      expect(component.reload).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/shared-files/shared-files.component.spec.ts
+++ b/src/app/components/shared-files/shared-files.component.spec.ts
@@ -94,14 +94,6 @@ describe('SharedFilesComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     });
 
-    it('should refresh on restoreNode event', () => {
-      fixture.detectChanges();
-
-      contentService.nodesRestored.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-
     it('should reload on move node event', () => {
       fixture.detectChanges();
 

--- a/src/app/components/shared-files/shared-files.component.ts
+++ b/src/app/components/shared-files/shared-files.component.ts
@@ -57,7 +57,6 @@ export class SharedFilesComponent extends PageComponent implements OnInit {
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
       this.content.nodesMoved.subscribe(() => this.reload()),
-      this.content.nodesRestored.subscribe(() => this.reload()),
       this.content.linksUnshared
         .pipe(debounceTime(300))
         .subscribe(() => this.reload()),

--- a/src/app/components/shared-files/shared-files.component.ts
+++ b/src/app/components/shared-files/shared-files.component.ts
@@ -56,7 +56,6 @@ export class SharedFilesComponent extends PageComponent implements OnInit {
 
     this.subscriptions = this.subscriptions.concat([
       this.content.nodesDeleted.subscribe(() => this.reload()),
-      this.content.nodesMoved.subscribe(() => this.reload()),
       this.content.linksUnshared
         .pipe(debounceTime(300))
         .subscribe(() => this.reload()),

--- a/src/app/components/shared-files/shared-files.component.ts
+++ b/src/app/components/shared-files/shared-files.component.ts
@@ -55,7 +55,6 @@ export class SharedFilesComponent extends PageComponent implements OnInit {
     super.ngOnInit();
 
     this.subscriptions = this.subscriptions.concat([
-      this.content.nodesDeleted.subscribe(() => this.reload()),
       this.content.linksUnshared
         .pipe(debounceTime(300))
         .subscribe(() => this.reload()),

--- a/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.ts
+++ b/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.ts
@@ -29,7 +29,7 @@ import { AppStore } from '../../../store/states';
 import { appSelection } from '../../../store/selectors/app.selectors';
 import { Observable } from 'rxjs';
 import { SelectionState } from '@alfresco/adf-extensions';
-import { ContentManagementService } from '../../../services/content-management.service';
+import { ReloadDocumentListAction } from '../../../store/actions';
 
 @Component({
   selector: 'app-toggle-favorite',
@@ -51,14 +51,11 @@ import { ContentManagementService } from '../../../services/content-management.s
 export class ToggleFavoriteComponent {
   selection$: Observable<SelectionState>;
 
-  constructor(
-    private store: Store<AppStore>,
-    private content: ContentManagementService
-  ) {
+  constructor(private store: Store<AppStore>) {
     this.selection$ = this.store.select(appSelection);
   }
 
   onToggleEvent() {
-    this.content.favoriteToggle.next();
+    this.store.dispatch(new ReloadDocumentListAction());
   }
 }

--- a/src/app/components/trashcan/trashcan.component.spec.ts
+++ b/src/app/components/trashcan/trashcan.component.spec.ts
@@ -33,7 +33,6 @@ import {
   AppConfigPipe
 } from '@alfresco/adf-core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
-import { ContentManagementService } from '../../services/content-management.service';
 import { TrashcanComponent } from './trashcan.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
@@ -41,7 +40,6 @@ describe('TrashcanComponent', () => {
   let fixture: ComponentFixture<TrashcanComponent>;
   let component: TrashcanComponent;
   let alfrescoApi: AlfrescoApiService;
-  let contentService: ContentManagementService;
   let page;
 
   beforeEach(() => {
@@ -73,7 +71,6 @@ describe('TrashcanComponent', () => {
 
     alfrescoApi = TestBed.get(AlfrescoApiService);
     alfrescoApi.reset();
-    contentService = TestBed.get(ContentManagementService);
 
     component.documentList = <any>{
       reload: jasmine.createSpy('reload'),

--- a/src/app/components/trashcan/trashcan.component.spec.ts
+++ b/src/app/components/trashcan/trashcan.component.spec.ts
@@ -93,15 +93,4 @@ describe('TrashcanComponent', () => {
     contentService.nodesPurged.next({});
     expect(component.reload).toHaveBeenCalled();
   });
-
-  describe('onRestoreNode()', () => {
-    it('should call refresh()', () => {
-      spyOn(component, 'reload');
-      fixture.detectChanges();
-
-      contentService.nodesRestored.next();
-
-      expect(component.reload).toHaveBeenCalled();
-    });
-  });
 });

--- a/src/app/components/trashcan/trashcan.component.spec.ts
+++ b/src/app/components/trashcan/trashcan.component.spec.ts
@@ -104,16 +104,4 @@ describe('TrashcanComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     });
   });
-
-  describe('refresh()', () => {
-    it('calls child component to reload', () => {
-      component.reload();
-      expect(component.documentList.reload).toHaveBeenCalled();
-    });
-
-    it('calls child component to reset selection', () => {
-      component.reload();
-      expect(component.documentList.resetSelection).toHaveBeenCalled();
-    });
-  });
 });

--- a/src/app/components/trashcan/trashcan.component.spec.ts
+++ b/src/app/components/trashcan/trashcan.component.spec.ts
@@ -86,11 +86,4 @@ describe('TrashcanComponent', () => {
       Promise.resolve(page)
     );
   });
-
-  it('should reload on nodes purged', () => {
-    component.ngOnInit();
-    spyOn(component, 'reload').and.stub();
-    contentService.nodesPurged.next({});
-    expect(component.reload).toHaveBeenCalled();
-  });
 });

--- a/src/app/components/trashcan/trashcan.component.ts
+++ b/src/app/components/trashcan/trashcan.component.ts
@@ -57,8 +57,6 @@ export class TrashcanComponent extends PageComponent implements OnInit {
     super.ngOnInit();
 
     this.subscriptions.push(
-      this.content.nodesPurged.subscribe(() => this.reload()),
-
       this.breakpointObserver
         .observe([Breakpoints.HandsetPortrait, Breakpoints.HandsetLandscape])
         .subscribe(result => {

--- a/src/app/components/trashcan/trashcan.component.ts
+++ b/src/app/components/trashcan/trashcan.component.ts
@@ -57,7 +57,6 @@ export class TrashcanComponent extends PageComponent implements OnInit {
     super.ngOnInit();
 
     this.subscriptions.push(
-      this.content.nodesRestored.subscribe(() => this.reload()),
       this.content.nodesPurged.subscribe(() => this.reload()),
 
       this.breakpointObserver

--- a/src/app/directives/document-list.directive.ts
+++ b/src/app/directives/document-list.directive.ts
@@ -84,7 +84,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
       .subscribe(() => this.onReady());
 
     this.content.reload.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
-      this.documentList.reload();
+      this.reload();
     });
   }
 
@@ -130,5 +130,11 @@ export class DocumentListDirective implements OnInit, OnDestroy {
     });
 
     this.store.dispatch(new SetSelectedNodesAction(selection));
+  }
+
+  private reload() {
+    this.documentList.resetSelection();
+    this.store.dispatch(new SetSelectedNodesAction([]));
+    this.documentList.reload();
   }
 }

--- a/src/app/directives/document-list.directive.ts
+++ b/src/app/directives/document-list.directive.ts
@@ -27,16 +27,19 @@ import { Directive, OnDestroy, OnInit, HostListener } from '@angular/core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UserPreferencesService } from '@alfresco/adf-core';
-import { Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { SetSelectedNodesAction } from '../store/actions';
+import { takeUntil } from 'rxjs/operators';
+import { ContentManagementService } from '../services/content-management.service';
 
 @Directive({
   selector: '[acaDocumentList]'
 })
 export class DocumentListDirective implements OnInit, OnDestroy {
-  private subscriptions: Subscription[] = [];
   private isLibrary = false;
+
+  onDestroy$ = new Subject<boolean>();
 
   get sortingPreferenceKey(): string {
     return this.route.snapshot.data.sortingPreferenceKey;
@@ -44,6 +47,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
 
   constructor(
     private store: Store<any>,
+    private content: ContentManagementService,
     private documentList: DocumentListComponent,
     private preferences: UserPreferencesService,
     private route: ActivatedRoute,
@@ -75,14 +79,18 @@ export class DocumentListDirective implements OnInit, OnDestroy {
       this.documentList.data.setSorting({ key, direction });
     }
 
-    this.subscriptions.push(
-      this.documentList.ready.subscribe(() => this.onReady())
-    );
+    this.documentList.ready
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(() => this.onReady());
+
+    this.content.reload.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      this.documentList.reload();
+    });
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach(subscription => subscription.unsubscribe());
-    this.subscriptions = [];
+    this.onDestroy$.next(true);
+    this.onDestroy$.complete();
   }
 
   @HostListener('sorting-changed', ['$event'])

--- a/src/app/services/content-management.service.spec.ts
+++ b/src/app/services/content-management.service.spec.ts
@@ -1265,39 +1265,6 @@ describe('ContentManagementService', () => {
       ).toBe(true);
     }));
 
-    describe('refresh()', () => {
-      it('dispatch event on finish', fakeAsync(done => {
-        spyOn(contentApi, 'restoreNode').and.returnValue(of({}));
-        spyOn(contentApi, 'getDeletedNodes').and.returnValue(
-          of({
-            list: { entries: [] }
-          })
-        );
-
-        const path = {
-          elements: [
-            {
-              id: '1-1',
-              name: 'somewhere-over-the-rainbow'
-            }
-          ]
-        };
-
-        const selection = [
-          <any>{
-            entry: {
-              id: '1',
-              path
-            }
-          }
-        ];
-
-        store.dispatch(new RestoreDeletedNodesAction(selection));
-
-        contentManagementService.nodesRestored.subscribe(() => done());
-      }));
-    });
-
     describe('notification', () => {
       beforeEach(() => {
         spyOn(contentApi, 'getDeletedNodes').and.returnValue(

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -78,7 +78,6 @@ interface RestoredNode {
 })
 export class ContentManagementService {
   reload = new Subject<any>();
-  nodesMoved = new Subject<any>();
   nodesDeleted = new Subject<any>();
   libraryDeleted = new Subject<string>();
   libraryCreated = new Subject<SiteEntry>();
@@ -557,7 +556,7 @@ export class ContentManagementService {
         const [operationResult, moveResponse] = result;
         this.showMoveMessage(nodes, operationResult, moveResponse);
 
-        this.nodesMoved.next(null);
+        this.store.dispatch(new ReloadDocumentListAction());
       },
       error => {
         this.showMoveMessage(nodes, error);
@@ -612,7 +611,7 @@ export class ContentManagementService {
       )
       .subscribe(
         () => {
-          this.nodesMoved.next(null);
+          this.store.dispatch(new ReloadDocumentListAction());
         },
         error => {
           let message = 'APP.MESSAGES.ERRORS.GENERIC';

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -90,8 +90,6 @@ export class ContentManagementService {
   library400Error = new Subject<any>();
   joinLibraryToggle = new Subject<string>();
   linksUnshared = new Subject<any>();
-  favoriteAdded = new Subject<Array<MinimalNodeEntity>>();
-  favoriteRemoved = new Subject<Array<MinimalNodeEntity>>();
   favoriteLibraryToggle = new Subject<any>();
 
   constructor(
@@ -112,7 +110,6 @@ export class ContentManagementService {
           node.entry.isFavorite = true;
         });
         this.store.dispatch(new SetSelectedNodesAction(nodes));
-        this.favoriteAdded.next(nodes);
         this.store.dispatch(new ReloadDocumentListAction());
       });
     }
@@ -125,7 +122,6 @@ export class ContentManagementService {
           node.entry.isFavorite = false;
         });
         this.store.dispatch(new SetSelectedNodesAction(nodes));
-        this.favoriteRemoved.next(nodes);
         this.store.dispatch(new ReloadDocumentListAction());
       });
     }

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -80,7 +80,6 @@ export class ContentManagementService {
   reload = new Subject<any>();
   nodesMoved = new Subject<any>();
   nodesDeleted = new Subject<any>();
-  nodesPurged = new Subject<any>();
   libraryDeleted = new Subject<string>();
   libraryCreated = new Subject<SiteEntry>();
   libraryUpdated = new Subject<SiteEntry>();
@@ -753,7 +752,7 @@ export class ContentManagementService {
       const status = this.processStatus(purgedNodes);
 
       if (status.success.length) {
-        this.nodesPurged.next();
+        this.store.dispatch(new ReloadDocumentListAction());
       }
       const message = this.getPurgeMessage(status);
       if (message) {

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -523,6 +523,7 @@ export class ContentManagementService {
     forkJoin(...batch).subscribe(
       () => {
         this.nodesDeleted.next(null);
+        this.store.dispatch(new ReloadDocumentListAction());
       },
       error => {
         let i18nMessageString = 'APP.MESSAGES.ERRORS.GENERIC';
@@ -657,6 +658,7 @@ export class ContentManagementService {
 
       if (status.someSucceeded) {
         this.nodesDeleted.next();
+        this.store.dispatch(new ReloadDocumentListAction());
       }
     });
   }

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -82,7 +82,6 @@ export class ContentManagementService {
   nodesDeleted = new Subject<any>();
   nodesPurged = new Subject<any>();
   nodesRestored = new Subject<any>();
-  folderEdited = new Subject<any>();
   libraryDeleted = new Subject<string>();
   libraryCreated = new Subject<SiteEntry>();
   libraryUpdated = new Subject<SiteEntry>();
@@ -268,9 +267,9 @@ export class ContentManagementService {
       this.store.dispatch(new SnackbarErrorAction(message));
     });
 
-    dialog.afterClosed().subscribe((node: MinimalNodeEntryEntity) => {
+    dialog.afterClosed().subscribe(node => {
       if (node) {
-        this.folderEdited.next(node);
+        this.store.dispatch(new ReloadDocumentListAction());
       }
     });
   }

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -40,7 +40,8 @@ import {
   NavigateToParentFolder,
   SnackbarUserAction,
   UndoDeleteNodesAction,
-  SetSelectedNodesAction
+  SetSelectedNodesAction,
+  ReloadDocumentListAction
 } from '../store/actions';
 import { Store } from '@ngrx/store';
 import { AppStore } from '../store/states';
@@ -76,12 +77,12 @@ interface RestoredNode {
   providedIn: 'root'
 })
 export class ContentManagementService {
+  reload = new Subject<any>();
   nodesMoved = new Subject<any>();
   nodesDeleted = new Subject<any>();
   nodesPurged = new Subject<any>();
   nodesRestored = new Subject<any>();
   folderEdited = new Subject<any>();
-  folderCreated = new Subject<any>();
   libraryDeleted = new Subject<string>();
   libraryCreated = new Subject<SiteEntry>();
   libraryUpdated = new Subject<SiteEntry>();
@@ -246,7 +247,7 @@ export class ContentManagementService {
 
     dialogInstance.afterClosed().subscribe(node => {
       if (node) {
-        this.folderCreated.next(node);
+        this.store.dispatch(new ReloadDocumentListAction());
       }
     });
   }

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -81,7 +81,6 @@ export class ContentManagementService {
   nodesMoved = new Subject<any>();
   nodesDeleted = new Subject<any>();
   nodesPurged = new Subject<any>();
-  nodesRestored = new Subject<any>();
   libraryDeleted = new Subject<string>();
   libraryCreated = new Subject<SiteEntry>();
   libraryUpdated = new Subject<SiteEntry>();
@@ -415,7 +414,7 @@ export class ContentManagementService {
       const failedStatus = this.processStatus([]);
       failedStatus.fail.push(...selection);
       this.showRestoreNotification(failedStatus);
-      this.nodesRestored.next();
+      this.store.dispatch(new ReloadDocumentListAction());
       return;
     }
 
@@ -434,7 +433,7 @@ export class ContentManagementService {
 
         if (!remainingNodes.length) {
           this.showRestoreNotification(status);
-          this.nodesRestored.next();
+          this.store.dispatch(new ReloadDocumentListAction());
         } else {
           this.restoreDeletedNodes(remainingNodes);
         }
@@ -680,7 +679,7 @@ export class ContentManagementService {
       }
 
       if (processedData.someSucceeded) {
-        this.nodesRestored.next();
+        this.store.dispatch(new ReloadDocumentListAction());
       }
     });
   }

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -92,7 +92,6 @@ export class ContentManagementService {
   linksUnshared = new Subject<any>();
   favoriteAdded = new Subject<Array<MinimalNodeEntity>>();
   favoriteRemoved = new Subject<Array<MinimalNodeEntity>>();
-  favoriteToggle = new Subject<Array<MinimalNodeEntity>>();
   favoriteLibraryToggle = new Subject<any>();
 
   constructor(
@@ -114,7 +113,7 @@ export class ContentManagementService {
         });
         this.store.dispatch(new SetSelectedNodesAction(nodes));
         this.favoriteAdded.next(nodes);
-        this.favoriteToggle.next(nodes);
+        this.store.dispatch(new ReloadDocumentListAction());
       });
     }
   }
@@ -127,7 +126,7 @@ export class ContentManagementService {
         });
         this.store.dispatch(new SetSelectedNodesAction(nodes));
         this.favoriteRemoved.next(nodes);
-        this.favoriteToggle.next(nodes);
+        this.store.dispatch(new ReloadDocumentListAction());
       });
     }
   }

--- a/src/app/store/actions/app.actions.ts
+++ b/src/app/store/actions/app.actions.ts
@@ -35,6 +35,7 @@ export const SET_USER_PROFILE = 'SET_USER_PROFILE';
 export const TOGGLE_INFO_DRAWER = 'TOGGLE_INFO_DRAWER';
 export const TOGGLE_DOCUMENT_DISPLAY_MODE = 'TOGGLE_DOCUMENT_DISPLAY_MODE';
 export const LOGOUT = 'LOGOUT';
+export const RELOAD_DOCUMENT_LIST = 'RELOAD_DOCUMENT_LIST';
 
 export class SetInitialStateAction implements Action {
   readonly type = SET_INITIAL_STATE;
@@ -73,5 +74,10 @@ export class ToggleDocumentDisplayMode implements Action {
 
 export class LogoutAction implements Action {
   readonly type = LOGOUT;
+  constructor(public payload?: any) {}
+}
+
+export class ReloadDocumentListAction implements Action {
+  readonly type = RELOAD_DOCUMENT_LIST;
   constructor(public payload?: any) {}
 }

--- a/src/app/store/effects/app.effects.ts
+++ b/src/app/store/effects/app.effects.ts
@@ -26,17 +26,32 @@
 import { Effect, Actions, ofType } from '@ngrx/effects';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
-import { LogoutAction, LOGOUT } from '../actions/app.actions';
+import {
+  LogoutAction,
+  LOGOUT,
+  ReloadDocumentListAction,
+  RELOAD_DOCUMENT_LIST
+} from '../actions/app.actions';
 import { AuthenticationService } from '@alfresco/adf-core';
 import { Router } from '@angular/router';
+import { ContentManagementService } from '../../services/content-management.service';
 
 @Injectable()
 export class AppEffects {
   constructor(
     private actions$: Actions,
     private auth: AuthenticationService,
-    private router: Router
+    private router: Router,
+    private content: ContentManagementService
   ) {}
+
+  @Effect({ dispatch: false })
+  reload = this.actions$.pipe(
+    ofType<ReloadDocumentListAction>(RELOAD_DOCUMENT_LIST),
+    map(action => {
+      this.content.reload.next(action);
+    })
+  );
 
   @Effect({ dispatch: false })
   logout$ = this.actions$.pipe(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #975


## What is the new behavior?

Introduce support for reloading document list via NgRx Action (`RELOAD_DOCUMENT_LIST`).
Deprecate some of the application events that existed only to reload the data.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
