### PR TITLE
[ACA-2214] Sharing URL being constructed from ECM Host incorrectly

### DIFF
--- a/build-tomcat-e2e.sh
+++ b/build-tomcat-e2e.sh
@@ -3,7 +3,7 @@ npm run build.e2e -- --base-href ./
 node -e "
 const fs = require('fs');
 const config = require('./dist/app/app.config.json');
-config.baseShareUrl = 'http://localhost:4000/content-app';
+config.baseShareUrl = 'http://localhost:4000/content-app/#/preview/s/';
 fs.writeFileSync(
   './dist/app/app.config.json',
   JSON.stringify(config, null, 2)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -49,31 +49,11 @@ Alternatively, you can provide a static address for the ACS server if necessary:
 
 The "baseShareUrl" property tells the application how to construct the address where users will access shared files.
 
-#### Default
-
-When the default value is set the application will construct the File Share URL from the "ecmHost" property: 
-
 ```json
 {
-    ...
-    "baseShareUrl": null,
-    ...
+  "baseShareUrl": "{protocol}//{hostname}{:port}/#/preview/s"
 }
 ```
-
-#### Configuration
-
-If you run the application from a different server than the Content Services server the "baseShareUrl" property should must be configured correctly, for example:
-
-```json
-{
-    ...
-    "baseShareUrl": "http://{serveraddress}{:port}",
-    ...
-}
-```
-
-**Note:** If you run the application as part of Tomcat and not in the root (subfolder), then "baseShareUrl" value should contain full address to the app, for example: "baseShareUrl": "http://{serveraddress}{:port}/{folder}".
 
 ## Application settings
 
@@ -103,7 +83,6 @@ The default logo displayed in the top left corner of the Alfresco Content Applic
 1. Place your custom logo image file in the [app-name]/src/assets/images folder. The displayed image will resize automatically, an image with extreme width/height might not retain its dimensions.
 
 2. In the app.config.json file, set the value of the application.logo to contain the name of the custom logo image: "logo": "/assets/images/[image-name].[extension]"
-
 
 ```json
 {

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -1,7 +1,7 @@
 {
   "ecmHost": "{protocol}//{hostname}{:port}",
   "aosHost": "{protocol}//{hostname}{:port}/alfresco/aos",
-  "baseShareUrl": null,
+  "baseShareUrl": "{protocol}//{hostname}{:port}",
   "providers": "ECM",
   "authType": "BASIC",
   "oauth2": {

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -1,7 +1,7 @@
 {
   "ecmHost": "{protocol}//{hostname}{:port}",
   "aosHost": "{protocol}//{hostname}{:port}/alfresco/aos",
-  "baseShareUrl": "{protocol}//{hostname}{:port}",
+  "baseShareUrl": "{protocol}//{hostname}{:port}/#/preview/s",
   "providers": "ECM",
   "authType": "BASIC",
   "oauth2": {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -24,11 +24,22 @@
  */
 
 import { AppComponent } from './app.component';
+import { SetInitialStateAction } from './store/actions';
 
 describe('AppComponent', () => {
-  let component;
-  const storeMock = <any>{
+  let component: AppComponent;
+
+  const storeMock: any = {
     dispatch: jasmine.createSpy('dispatch')
+  };
+
+  const configMock: any = {
+    get: (key: string) => {
+      if (key === 'baseShareUrl') {
+        return 'http://localhost:4200//#/preview/s';
+      }
+      return null;
+    }
   };
 
   beforeAll(() => {
@@ -37,7 +48,7 @@ describe('AppComponent', () => {
       null,
       null,
       storeMock,
-      null,
+      configMock,
       null,
       null,
       null,
@@ -47,48 +58,59 @@ describe('AppComponent', () => {
     );
   });
 
-  describe('onFileUploadedError', () => {
-    afterEach(() => {
-      storeMock.dispatch['calls'].reset();
+  beforeEach(() => {
+    storeMock.dispatch = jasmine.createSpy('dispatch');
+  });
+
+  it('should setup baseShareUrl as per config', done => {
+    storeMock.dispatch.and.callFake((action: SetInitialStateAction) => {
+      expect(action.payload.sharedUrl).toBe(
+        'http://localhost:4200//#/preview/s/'
+      );
+      done();
     });
 
+    component.loadAppSettings();
+  });
+
+  describe('onFileUploadedError', () => {
     it('should dispatch 403 error message', () => {
-      component.onFileUploadedError({ error: { status: 403 } });
+      component.onFileUploadedError(<any>{ error: { status: 403 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.403'
       );
     });
 
     it('should dispatch 404 error message', () => {
-      component.onFileUploadedError({ error: { status: 404 } });
+      component.onFileUploadedError(<any>{ error: { status: 404 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.404'
       );
     });
 
     it('should dispatch 409 error message', () => {
-      component.onFileUploadedError({ error: { status: 409 } });
+      component.onFileUploadedError(<any>{ error: { status: 409 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.CONFLICT'
       );
     });
 
     it('should dispatch 500 error message', () => {
-      component.onFileUploadedError({ error: { status: 500 } });
+      component.onFileUploadedError(<any>{ error: { status: 500 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.500'
       );
     });
 
     it('should dispatch 504 error message', () => {
-      component.onFileUploadedError({ error: { status: 504 } });
+      component.onFileUploadedError(<any>{ error: { status: 504 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.504'
       );
     });
 
     it('should dispatch generic error message', () => {
-      component.onFileUploadedError({ error: { status: 999 } });
+      component.onFileUploadedError(<any>{ error: { status: 999 } });
       expect(storeMock.dispatch['calls'].argsFor(0)[0].payload).toBe(
         'APP.MESSAGES.UPLOAD.ERROR.GENERIC'
       );

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -36,7 +36,7 @@ describe('AppComponent', () => {
   const configMock: any = {
     get: (key: string) => {
       if (key === 'baseShareUrl') {
-        return 'http://localhost:4200//#/preview/s';
+        return 'http://localhost:4200/#/preview/s';
       }
       return null;
     }
@@ -65,7 +65,7 @@ describe('AppComponent', () => {
   it('should setup baseShareUrl as per config', done => {
     storeMock.dispatch.and.callFake((action: SetInitialStateAction) => {
       expect(action.payload.sharedUrl).toBe(
-        'http://localhost:4200//#/preview/s/'
+        'http://localhost:4200/#/preview/s/'
       );
       done();
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -148,9 +148,10 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   private loadAppSettings() {
-    const baseShareUrl =
-      this.config.get<string>('baseShareUrl') ||
-      this.config.get<string>('ecmHost');
+    let baseShareUrl = this.config.get<string>('baseShareUrl');
+    if (!baseShareUrl.endsWith('/')) {
+      baseShareUrl += '/';
+    }
 
     const state: AppState = {
       ...INITIAL_APP_STATE,
@@ -158,7 +159,7 @@ export class AppComponent implements OnInit, OnDestroy {
       appName: this.config.get<string>('application.name'),
       headerColor: this.config.get<string>('headerColor'),
       logoPath: this.config.get<string>('application.logo'),
-      sharedUrl: `${baseShareUrl}/#/preview/s/`
+      sharedUrl: baseShareUrl
     };
 
     this.store.dispatch(new SetInitialStateAction(state));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -147,7 +147,7 @@ export class AppComponent implements OnInit, OnDestroy {
     });
   }
 
-  private loadAppSettings() {
+  loadAppSettings() {
     let baseShareUrl = this.config.get<string>('baseShareUrl');
     if (!baseShareUrl.endsWith('/')) {
       baseShareUrl += '/';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [ACA-2214](https://issues.alfresco.com/jira/browse/ACA-2214)


## What is the new behavior?

- fixes #946
- adds correct default for the baseShareUrl
- provides full control of the url prefix (including application route)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
