### PR TITLE
support repository info with app state

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -40,7 +40,7 @@ import {
   SetCurrentUrlAction,
   SetInitialStateAction,
   CloseModalDialogsAction,
-  SetRepositoryStatusAction,
+  SetRepositoryInfoAction,
   SetUserProfileAction
 } from './store/actions';
 import {
@@ -136,7 +136,7 @@ export class AppComponent implements OnInit, OnDestroy {
       .getRepositoryInformation()
       .subscribe((response: DiscoveryEntry) => {
         this.store.dispatch(
-          new SetRepositoryStatusAction(response.entry.repository.status)
+          new SetRepositoryInfoAction(response.entry.repository)
         );
       });
   }

--- a/src/app/extensions/app.interface.ts
+++ b/src/app/extensions/app.interface.ts
@@ -23,10 +23,11 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RuleContext, RepositoryState } from '@alfresco/adf-extensions';
+import { RuleContext } from '@alfresco/adf-extensions';
 import { AuthenticationService } from '@alfresco/adf-core';
+import { RepositoryInfo } from '@alfresco/js-api';
 
 export interface AppRuleContext extends RuleContext {
-  repository: RepositoryState;
+  repository: RepositoryInfo;
   auth: AuthenticationService;
 }

--- a/src/app/extensions/evaluators/repository.evaluators.ts
+++ b/src/app/extensions/evaluators/repository.evaluators.ts
@@ -30,5 +30,5 @@ export function hasQuickShareEnabled(
   context: AppRuleContext,
   ...args: RuleParameter[]
 ): boolean {
-  return context.repository.isQuickShareEnabled;
+  return context.repository.status.isQuickShareEnabled;
 }

--- a/src/app/extensions/extension.service.ts
+++ b/src/app/extensions/extension.service.ts
@@ -48,7 +48,6 @@ import {
   ExtensionService,
   ProfileState,
   mergeObjects,
-  RepositoryState,
   ExtensionRef
 } from '@alfresco/adf-extensions';
 import { AppConfigService, AuthenticationService } from '@alfresco/adf-core';
@@ -56,6 +55,7 @@ import { DocumentListPresetRef } from './document-list.extensions';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IconRef } from './icon.extensions';
 import { AppRuleContext } from './app.interface';
+import { RepositoryInfo } from '@alfresco/js-api';
 
 @Injectable({
   providedIn: 'root'
@@ -103,7 +103,7 @@ export class AppExtensionService implements AppRuleContext {
   selection: SelectionState;
   navigation: NavigationState;
   profile: ProfileState;
-  repository: RepositoryState;
+  repository: RepositoryInfo;
 
   references$: Observable<ExtensionRef[]>;
 

--- a/src/app/store/actions/repository.actions.ts
+++ b/src/app/store/actions/repository.actions.ts
@@ -24,12 +24,11 @@
  */
 
 import { Action } from '@ngrx/store';
-import { RepositoryState } from '@alfresco/adf-extensions';
+import { RepositoryInfo } from '@alfresco/js-api';
 
-export const SET_REPOSITORY_STATUS = 'SET_REPOSITORY_STATUS';
-export const GET_REPOSITORY_STATUS = 'GET_REPOSITORY_STATUS';
+export const SET_REPOSITORY_INFO = 'SET_REPOSITORY_INFO';
 
-export class SetRepositoryStatusAction implements Action {
-  readonly type = SET_REPOSITORY_STATUS;
-  constructor(public payload: RepositoryState) {}
+export class SetRepositoryInfoAction implements Action {
+  readonly type = SET_REPOSITORY_INFO;
+  constructor(public payload: RepositoryInfo) {}
 }

--- a/src/app/store/reducers/app.reducer.ts
+++ b/src/app/store/reducers/app.reducer.ts
@@ -30,8 +30,8 @@ import {
   SetSelectedNodesAction,
   SET_USER_PROFILE,
   SetUserProfileAction,
-  SET_REPOSITORY_STATUS,
-  SetRepositoryStatusAction,
+  SET_REPOSITORY_INFO,
+  SetRepositoryInfoAction,
   SET_LANGUAGE_PICKER,
   SetLanguagePickerAction,
   SET_CURRENT_FOLDER,
@@ -86,10 +86,8 @@ export function appReducer(
         action
       ));
       break;
-    case SET_REPOSITORY_STATUS:
-      newState = updateRepositoryStatus(state, <SetRepositoryStatusAction>(
-        action
-      ));
+    case SET_REPOSITORY_INFO:
+      newState = updateRepositoryStatus(state, <SetRepositoryInfoAction>action);
       break;
     default:
       newState = Object.assign({}, state);
@@ -241,7 +239,7 @@ function setInfoDrawer(state: AppState, action: SetInfoDrawerStateAction) {
 
 function updateRepositoryStatus(
   state: AppState,
-  action: SetRepositoryStatusAction
+  action: SetRepositoryInfoAction
 ) {
   const newState = Object.assign({}, state);
   newState.repository = action.payload;

--- a/src/app/store/selectors/app.selectors.ts
+++ b/src/app/store/selectors/app.selectors.ts
@@ -90,7 +90,7 @@ export const repositoryStatus = createSelector(
 
 export const isQuickShareEnabled = createSelector(
   repositoryStatus,
-  status => status.isQuickShareEnabled
+  info => info.status.isQuickShareEnabled
 );
 
 export const isAdmin = createSelector(

--- a/src/app/store/states/app.state.ts
+++ b/src/app/store/states/app.state.ts
@@ -26,9 +26,9 @@
 import {
   SelectionState,
   ProfileState,
-  NavigationState,
-  RepositoryState
+  NavigationState
 } from '@alfresco/adf-extensions';
+import { RepositoryInfo } from '@alfresco/js-api';
 
 export interface AppState {
   appName: string;
@@ -41,7 +41,7 @@ export interface AppState {
   navigation: NavigationState;
   infoDrawerOpened: boolean;
   documentDisplayMode: string;
-  repository: RepositoryState;
+  repository: RepositoryInfo;
 }
 
 export const INITIAL_APP_STATE: AppState = {
@@ -67,8 +67,10 @@ export const INITIAL_APP_STATE: AppState = {
   },
   infoDrawerOpened: false,
   documentDisplayMode: 'list',
-  repository: {
-    isQuickShareEnabled: true
+  repository: <any>{
+    status: <any>{
+      isQuickShareEnabled: true
+    }
   }
 };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #983 


## What is the new behavior?

- fixes #983 
- stores all repository info (discovery api) in the application state, not only Status

That solves the problem with extensions and rules that cannot access the module information to toggle certain behaviors. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
