### PR TITLE
[ACA-2242] add old style back

### DIFF
--- a/src/app/ui/overrides/adf-search-filter.theme.scss
+++ b/src/app/ui/overrides/adf-search-filter.theme.scss
@@ -11,5 +11,17 @@
     .mat-radio-label {
       color: mat-color($foreground, text, 0.54);
     }
+
+    .facet-buttons {
+      text-align: right;
+
+      .mat-button {
+        text-transform: uppercase;
+      }
+
+      &--topSpace {
+        padding-top: 15px;
+      }
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The facet-buttons from "Created Date" do not have the correct styling applied.
Issue Number:https://issues.alfresco.com/jira/browse/ACA-2242


## What is the new behavior?
fixes missing buttons styles issue until ADF 3.1.0 will fix it

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
