### PR TITLE
[ACA-2133] fix application ready event for kerberos

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.1",
   "language": "en",
   "words": [
+    "Kerberos",
     "succes",
     "sharedlinks",
     "Redistributable",

--- a/src/app/services/app.service.spec.ts
+++ b/src/app/services/app.service.spec.ts
@@ -26,7 +26,7 @@
 import { AppService } from './app.service';
 import { TestBed } from '@angular/core/testing';
 import { AppTestingModule } from '../testing/app-testing.module';
-import { AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService, AppConfigService } from '@alfresco/adf-core';
 import { AppRouteReuseStrategy } from '../app.routes.strategy';
 import { Subject } from 'rxjs';
 
@@ -34,6 +34,7 @@ describe('AppService', () => {
   let service: AppService;
   let auth: AuthenticationService;
   let routeReuse: AppRouteReuseStrategy;
+  let appConfig: AppConfigService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -53,9 +54,25 @@ describe('AppService', () => {
 
     routeReuse = TestBed.get(AppRouteReuseStrategy);
     auth = TestBed.get(AuthenticationService);
+    appConfig = TestBed.get(AppConfigService);
     spyOn(routeReuse, 'resetCache').and.stub();
 
-    service = new AppService(auth, routeReuse);
+    service = new AppService(auth, appConfig, routeReuse);
+  });
+
+  it('should be ready if [withCredentials] mode is used', done => {
+    appConfig.config = {
+      auth: {
+        withCredentials: true
+      }
+    };
+
+    const instance = new AppService(auth, appConfig, routeReuse);
+    expect(instance.withCredentials).toBeTruthy();
+
+    instance.ready$.subscribe(() => {
+      done();
+    });
   });
 
   it('should reset route cache on login', async () => {

--- a/src/app/services/app.service.ts
+++ b/src/app/services/app.service.ts
@@ -41,10 +41,7 @@ export class AppService {
    * Usually means that `Kerberos` mode is used.
    */
   get withCredentials(): boolean {
-    return this.config.get<boolean>(
-      'auth.withCredentials',
-      false
-    );
+    return this.config.get<boolean>('auth.withCredentials', false);
   }
 
   constructor(

--- a/src/app/services/app.service.ts
+++ b/src/app/services/app.service.ts
@@ -24,7 +24,7 @@
  */
 
 import { Injectable, Inject } from '@angular/core';
-import { AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService, AppConfigService } from '@alfresco/adf-core';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { AppRouteReuseStrategy } from '../app.routes.strategy';
 import { RouteReuseStrategy } from '@angular/router';
@@ -36,11 +36,23 @@ export class AppService {
   private ready: BehaviorSubject<boolean>;
   ready$: Observable<boolean>;
 
+  /**
+   * Whether `withCredentials` mode is enabled.
+   * Usually means that `Kerberos` mode is used.
+   */
+  get withCredentials(): boolean {
+    return this.config.get<boolean>(
+      'auth.withCredentials',
+      false
+    );
+  }
+
   constructor(
     auth: AuthenticationService,
+    private config: AppConfigService,
     @Inject(RouteReuseStrategy) routeStrategy: AppRouteReuseStrategy
   ) {
-    this.ready = new BehaviorSubject(auth.isLoggedIn());
+    this.ready = new BehaviorSubject(auth.isLoggedIn() || this.withCredentials);
     this.ready$ = this.ready.asObservable();
 
     auth.onLogin.subscribe(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
AppService prevents loading Repository and Profile information on application startup when Kerberos is used.

Issue Number: [ACA-2133](https://issues.alfresco.com/jira/browse/ACA-2133)
fixes #894

## What is the new behavior?

Correctly set `ready$` state on application start. 
Load Repository and Profile information.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
