### PR TITLE
[ACA-2351] allow rules access user group membership

### DIFF
--- a/src/app/store/actions/app.actions.ts
+++ b/src/app/store/actions/app.actions.ts
@@ -24,7 +24,7 @@
  */
 
 import { Action } from '@ngrx/store';
-import { Node, Person } from '@alfresco/js-api';
+import { Node, Person, Group } from '@alfresco/js-api';
 import { AppState } from '../states';
 
 export const SET_INITIAL_STATE = 'SET_INITIAL_STATE';
@@ -59,7 +59,7 @@ export class SetCurrentUrlAction implements Action {
 
 export class SetUserProfileAction implements Action {
   readonly type = SET_USER_PROFILE;
-  constructor(public payload: Person) {}
+  constructor(public payload: { person: Person; groups: Group[] }) {}
 }
 
 export class ToggleInfoDrawerAction implements Action {

--- a/src/app/store/reducers/app.reducer.ts
+++ b/src/app/store/reducers/app.reducer.ts
@@ -131,7 +131,8 @@ function updateLanguagePicker(
 
 function updateUser(state: AppState, action: SetUserProfileAction): AppState {
   const newState = Object.assign({}, state);
-  const user = action.payload;
+  const user = action.payload.person;
+  const groups = [...(action.payload.groups || [])];
 
   const id = user.id;
   const firstName = user.firstName || '';
@@ -142,13 +143,15 @@ function updateUser(state: AppState, action: SetUserProfileAction): AppState {
   const capabilities = (<any>user).capabilities;
   const isAdmin = capabilities ? capabilities.isAdmin : true;
 
-  newState.user = {
+  // todo: remove <any>
+  newState.user = <any>{
     firstName,
     lastName,
     userName,
     initials,
     isAdmin,
-    id
+    id,
+    groups
   };
 
   return newState;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
[ACA-2351](https://issues.alfresco.com/jira/browse/ACA-2351)
#1067 


## What is the new behavior?

load user group membership and store in the application state;
that allows rules accessing group information via "context.profile.groups" property.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
