### PR TITLE
[ACA-1623] remove mincount set to 0

### DIFF
--- a/src/app.config.json
+++ b/src/app.config.json
@@ -234,22 +234,18 @@
       "fields": [
         {
           "field": "content.mimetype",
-          "mincount": 0,
           "label": "SEARCH.FACET_FIELDS.FILE_TYPE"
         },
         {
           "field": "creator",
-          "mincount": 0,
           "label": "SEARCH.FACET_FIELDS.CREATOR"
         },
         {
           "field": "modifier",
-          "mincount": 0,
           "label": "SEARCH.FACET_FIELDS.MODIFIER"
         },
         {
           "field": "SITE",
-          "mincount": 0,
           "label": "SEARCH.FACET_FIELDS.LOCATION"
         }
       ]
@@ -257,7 +253,6 @@
     "facetQueries": {
       "label": "SEARCH.CATEGORIES.MODIFIED_DATE",
       "expanded": true,
-      "mincount": 0,
       "queries": [
         { "label": "SEARCH.FACET_QUERIES.TODAY", "query": "cm:modified:[TODAY to TODAY]" },
         {


### PR DESCRIPTION
- use the default value of 1

## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[x] Other... Please describe: 
```
The temporary workaround for the [ACA-1623] issue was setting the `mincount` to 0. This way all facets were visible even if they were empty. The issue is now fixed on ADF component so this PR removes the workaround and uses the default value of 1 for `mincount`.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://issues.alfresco.com/jira/browse/ACA-1623


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
