### PR TITLE
[ACA-2364] support 'canPreview' rule for the Viewer

### DIFF
--- a/.github/plint.yml
+++ b/.github/plint.yml
@@ -2,6 +2,10 @@ modules:
   - pr.prettier
   - pr.spellcheck
 
+prettier:
+  exclude:
+    - *.json
+
 spellcheck:
   dictionaries:
     - html

--- a/.github/plint.yml
+++ b/.github/plint.yml
@@ -3,10 +3,16 @@ modules:
   - pr.spellcheck
 
 spellcheck:
+  dictionaries:
+    - html
+    - en-gb
+    - en_US
   words:
     - plint
     - ngrx
     - qshare
     - snackbar
+    - exif
+    - docx
   exclude:
     - src/assets/app.extensions.json

--- a/.github/plint.yml
+++ b/.github/plint.yml
@@ -4,7 +4,7 @@ modules:
 
 prettier:
   exclude:
-    - *.json
+    - '*.json'
 
 spellcheck:
   dictionaries:

--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -363,6 +363,7 @@ Viewer component in ACA supports the following extension points:
 - Toolbar actions
 - `More` toolbar actions
 - `Open With` actions
+- Rules
 
 ```json
 {
@@ -546,6 +547,35 @@ and invoke it from the custom `Open With` menu entry called `Snackbar`.
 ```
 
 As with other content actions, custom plugins can disable, update or extend `Open With` actions.
+
+### Rules
+
+You can provide global rules for the Viewer by utilizing the `features.viewer.rules` object:
+
+```ts
+export interface ViewerRules {
+  /**
+   * Checks if user can preview the node.
+   */
+  canPreview?: string;
+}
+```
+
+For example:
+
+```json
+{
+  "features": {
+    "viewer": {
+      "rules": {
+        "canPreview": "customRule"
+      }
+    }
+  }
+}
+```
+
+The rule should return `true` if node preview is allowed, otherwise `false`.
 
 ## Content metadata presets
 

--- a/extension.schema.json
+++ b/extension.schema.json
@@ -684,6 +684,16 @@
           "description": "Viewer component extensions",
           "type": "object",
           "properties": {
+            "rules": {
+              "description": "Viewer rules",
+              "type": "object",
+              "properties": {
+                "canPreview": {
+                  "description": "Controls whether preview is enabled for particular node",
+                  "type": "string"
+                }
+              }
+            },
             "openWith": {
               "description": "The [Open With] menu extensions",
               "type": "array",

--- a/src/app/extensions/extension.service.ts
+++ b/src/app/extensions/extension.service.ts
@@ -53,7 +53,8 @@ import {
 } from '@alfresco/adf-extensions';
 import { AppConfigService, AuthenticationService } from '@alfresco/adf-core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { RepositoryInfo } from '@alfresco/js-api';
+import { RepositoryInfo, NodeEntry } from '@alfresco/js-api';
+import { ViewerRules } from './viewer.rules';
 
 @Injectable({
   providedIn: 'root'
@@ -76,6 +77,7 @@ export class AppExtensionService implements RuleContext {
   navbar: Array<NavBarGroupRef> = [];
   sidebar: Array<SidebarTabRef> = [];
   contentMetadata: any;
+  viewerRules: ViewerRules;
 
   documentListPresets: {
     files: Array<DocumentListPresetRef>;
@@ -183,6 +185,8 @@ export class AppExtensionService implements RuleContext {
       trashcan: this.getDocumentListPreset(config, 'trashcan'),
       searchLibraries: this.getDocumentListPreset(config, 'search-libraries')
     };
+
+    this.viewerRules = <ViewerRules>(config.features.viewer['rules'] || {});
 
     this.registerIcons(config);
 
@@ -504,7 +508,37 @@ export class AppExtensionService implements RuleContext {
     }
   }
 
+  // todo: move to ADF/RuleService
+  isRuleDefined(ruleId: string): boolean {
+    return ruleId && this.getEvaluator(ruleId) ? true : false;
+  }
+
+  // todo: move to ADF/RuleService
+  evaluateRule(ruleId: string, ...args: any[]): boolean {
+    const evaluator = this.getEvaluator(ruleId);
+
+    if (evaluator) {
+      return evaluator(this, ...args);
+    }
+
+    return false;
+  }
+
   getEvaluator(key: string): RuleEvaluator {
     return this.extensions.getEvaluator(key);
+  }
+
+  canPreviewNode(node: NodeEntry) {
+    const rules = this.viewerRules;
+
+    if (this.isRuleDefined(rules.canPreview)) {
+      const canPreview = this.evaluateRule(rules.canPreview, node);
+
+      if (!canPreview) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/app/extensions/extension.service.ts
+++ b/src/app/extensions/extension.service.ts
@@ -77,7 +77,7 @@ export class AppExtensionService implements RuleContext {
   navbar: Array<NavBarGroupRef> = [];
   sidebar: Array<SidebarTabRef> = [];
   contentMetadata: any;
-  viewerRules: ViewerRules;
+  viewerRules: ViewerRules = {};
 
   documentListPresets: {
     files: Array<DocumentListPresetRef>;
@@ -186,7 +186,9 @@ export class AppExtensionService implements RuleContext {
       searchLibraries: this.getDocumentListPreset(config, 'search-libraries')
     };
 
-    this.viewerRules = <ViewerRules>(config.features.viewer['rules'] || {});
+    if (config.features && config.features.viewer) {
+      this.viewerRules = <ViewerRules>(config.features.viewer['rules'] || {});
+    }
 
     this.registerIcons(config);
 

--- a/src/app/extensions/viewer.rules.ts
+++ b/src/app/extensions/viewer.rules.ts
@@ -1,0 +1,31 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface ViewerRules {
+  /**
+   * Checks if user can preview the node.
+   */
+  canPreview?: string;
+}

--- a/src/app/store/effects/viewer.effects.ts
+++ b/src/app/store/effects/viewer.effects.ts
@@ -37,6 +37,7 @@ import {
 } from '@alfresco/aca-shared/store';
 import { Router } from '@angular/router';
 import { Store, createSelector } from '@ngrx/store';
+import { AppExtensionService } from '../../extensions/extension.service';
 
 export const fileToPreview = createSelector(
   getAppSelection,
@@ -54,7 +55,8 @@ export class ViewerEffects {
   constructor(
     private store: Store<AppStore>,
     private actions$: Actions,
-    private router: Router
+    private router: Router,
+    private extensions: AppExtensionService
   ) {}
 
   @Effect({ dispatch: false })
@@ -94,7 +96,10 @@ export class ViewerEffects {
       if (action.payload && action.payload.entry) {
         const { id, nodeId, isFile } = <any>action.payload.entry;
 
-        if (isFile || nodeId) {
+        if (
+          this.extensions.canPreviewNode(action.payload) &&
+          (isFile || nodeId)
+        ) {
           this.displayPreview(nodeId || id, action.parentId);
         }
       } else {
@@ -105,7 +110,10 @@ export class ViewerEffects {
             if (result.selection && result.selection.file) {
               const { id, nodeId, isFile } = <any>result.selection.file.entry;
 
-              if (isFile || nodeId) {
+              if (
+                this.extensions.canPreviewNode(action.payload) &&
+                (isFile || nodeId)
+              ) {
                 const parentId = result.folder ? result.folder.id : null;
                 this.displayPreview(nodeId || id, parentId);
               }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: ACA-2364


## What is the new behavior?

allow defining custom rules to determine whether a node can be previewed or not,
can be used to restrict certain content from opening in the Viewer

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
