### PR TITLE
[ACA-2471] - close preview action

### DIFF
--- a/docs/extending/application-actions.md
+++ b/docs/extending/application-actions.md
@@ -122,3 +122,4 @@ Below is the list of public actions types you can use in the plugin definitions 
 | 1.7.0   | SHOW_SEARCH_FILTER     | n/a                 | Show Filter component in Search Results.                                                        |
 | 1.7.0   | HIDE_SEARCH_FILTER     | n/a                 | Hide Filter component in Search Results                                                         |
 | 1.8.0   | VIEW_NODE              | string              | Lightweight preview of a node by id. Can be invoked from extensions.                            |
+| 1.8.0   | CLOSE_PREVIEW          | n/a              | Closes the viewer ( preview of the item ) |

--- a/projects/aca-shared/store/src/actions/viewer.actions.ts
+++ b/projects/aca-shared/store/src/actions/viewer.actions.ts
@@ -29,7 +29,8 @@ import { MinimalNodeEntity } from '@alfresco/js-api';
 export enum ViewerActionTypes {
   ViewFile = 'VIEW_FILE',
   ViewNode = 'VIEW_NODE',
-  FullScreen = 'FULLSCREEN_VIEWER'
+  FullScreen = 'FULLSCREEN_VIEWER',
+  ClosePreview = 'CLOSE_PREVIEW'
 }
 
 export class ViewFileAction implements Action {
@@ -48,4 +49,9 @@ export class FullscreenViewerAction implements Action {
   readonly type = ViewerActionTypes.FullScreen;
 
   constructor(public payload: MinimalNodeEntity) {}
+}
+
+export class ClosePreviewAction implements Action {
+  readonly type = ViewerActionTypes.ClosePreview;
+  constructor(public payload?: MinimalNodeEntity) {}
 }

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -1,14 +1,14 @@
 module.exports = {
-    "/alfresco": {
-        "target": "http://0.0.0.0:8080",
-        "secure": false,
-        "changeOrigin": true,
-        // workaround for REPO-2260
-        onProxyRes: function (proxyRes, req, res) {
-            const header = proxyRes.headers['www-authenticate'];
-            if (header && header.startsWith('Basic')) {
-                proxyRes.headers['www-authenticate'] = 'x' + header;
-            }
-        }
+  '/alfresco': {
+    target: 'http://0.0.0.0:8080',
+    secure: false,
+    changeOrigin: true,
+    // workaround for REPO-2260
+    onProxyRes: function(proxyRes, req, res) {
+      const header = proxyRes.headers['www-authenticate'];
+      if (header && header.startsWith('Basic')) {
+        proxyRes.headers['www-authenticate'] = 'x' + header;
+      }
     }
+  }
 };

--- a/src/app/components/preview/preview.component.spec.ts
+++ b/src/app/components/preview/preview.component.spec.ts
@@ -39,6 +39,7 @@ import {
   UploadService,
   AlfrescoApiService
 } from '@alfresco/adf-core';
+import { ClosePreviewAction } from '@alfresco/aca-shared/store';
 import { PreviewComponent } from './preview.component';
 import { of, throwError } from 'rxjs';
 import { EffectsModule } from '@ngrx/effects';
@@ -46,6 +47,7 @@ import { NodeEffects } from '../../store/effects/node.effects';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { ContentManagementService } from '../../services/content-management.service';
+import { Store } from '@ngrx/store';
 
 describe('PreviewComponent', () => {
   let fixture: ComponentFixture<PreviewComponent>;
@@ -57,6 +59,7 @@ describe('PreviewComponent', () => {
   let uploadService: UploadService;
   let alfrescoApiService: AlfrescoApiService;
   let contentManagementService: ContentManagementService;
+  let store: Store<any>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -76,6 +79,7 @@ describe('PreviewComponent', () => {
     uploadService = TestBed.get(UploadService);
     alfrescoApiService = TestBed.get(AlfrescoApiService);
     contentManagementService = TestBed.get(ContentManagementService);
+    store = TestBed.get(Store);
   });
 
   it('should extract the property path root', () => {
@@ -731,5 +735,12 @@ describe('PreviewComponent', () => {
     tick(300);
 
     expect(alfrescoApiService.nodeUpdated.next).toHaveBeenCalled();
+  }));
+
+  it('should return to parent folder when event emitted from extension', async(() => {
+    spyOn(component, 'navigateToFileLocation');
+    fixture.detectChanges();
+    store.dispatch(new ClosePreviewAction());
+    expect(component.navigateToFileLocation).toHaveBeenCalled();
   }));
 });

--- a/src/app/components/preview/preview.component.ts
+++ b/src/app/components/preview/preview.component.ts
@@ -38,7 +38,7 @@ import {
   UrlSegment,
   PRIMARY_OUTLET
 } from '@angular/router';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { debounceTime, map, takeUntil } from 'rxjs/operators';
 import {
   UserPreferencesService,
   ObjectUtils,
@@ -46,7 +46,11 @@ import {
   AlfrescoApiService
 } from '@alfresco/adf-core';
 import { Store } from '@ngrx/store';
-import { AppStore } from '@alfresco/aca-shared/store';
+import {
+  AppStore,
+  ClosePreviewAction,
+  ViewerActionTypes
+} from '@alfresco/aca-shared/store';
 import { SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { PageComponent } from '../page.component';
 import { ContentApiService } from '@alfresco/aca-shared';
@@ -55,6 +59,7 @@ import { ContentManagementService } from '../../services/content-management.serv
 import { ContentActionRef, ViewerExtensionRef } from '@alfresco/adf-extensions';
 import { SearchRequest } from '@alfresco/js-api';
 import { from } from 'rxjs';
+import { Actions, ofType } from '@ngrx/effects';
 
 @Component({
   selector: 'app-preview',
@@ -115,6 +120,7 @@ export class PreviewComponent extends PageComponent
     private router: Router,
     private apiService: AlfrescoApiService,
     private uploadService: UploadService,
+    private actions$: Actions,
     store: Store<AppStore>,
     extensions: AppExtensionService,
     content: ContentManagementService
@@ -167,7 +173,14 @@ export class PreviewComponent extends PageComponent
 
       this.uploadService.fileUploadComplete
         .pipe(debounceTime(300))
-        .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry))
+        .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry)),
+
+      this.actions$
+        .pipe(
+          ofType<ClosePreviewAction>(ViewerActionTypes.ClosePreview),
+          map(() => this.navigateToFileLocation(true))
+        )
+        .subscribe(() => {})
     ]);
 
     this.openWith = this.extensions.openWithActions;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
We are overriding the deletion of the node. If the user performs **delete** operation
in the viewer menu, the viewer is not getting closed.

Issue Number: N/A


## What is the new behavior?
I have created one action to close the preview. so, we can able to dispatch the action from the extension.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://issues.alfresco.com/jira/browse/ACA-2471