### PR TITLE
[ACA-2472] Temporarily disable "Emailed" and "Likes" properties

### DIFF
--- a/src/app.config.json
+++ b/src/app.config.json
@@ -132,7 +132,10 @@
             "qshare:shared",
 
             "exif:exif",
-            "cm:effectivity"
+            "cm:effectivity",
+
+            "cm:emailed",
+            "cm:likesRatingSchemeRollups"
           ]
         },
         {

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -1047,7 +1047,10 @@
               "qshare:shared",
 
               "exif:exif",
-              "cm:effectivity"
+              "cm:effectivity",
+
+              "cm:emailed",
+              "cm:likesRatingSchemeRollups"
             ]
           },
           {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[x] Other... Please describe: These aspects and their properties will not be displayed.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://issues.alfresco.com/jira/browse/ACA-2472


## What is the new behavior?
 Don't show these aspects until the ADF content-metadata has support to set individual aspects to 'editable' false. At that moment, these 2 aspects should be displayed, but set as not-editable as mentioned on [ACA-2421](https://issues.alfresco.com/jira/browse/ACA-2421) and [ACA-2422](https://issues.alfresco.com/jira/browse/ACA-2421).
 
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
