### PR TITLE
[ACA-1930] Search results list does not refresh after renaming a folder

### DIFF
--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -48,7 +48,7 @@ import {
   LibraryDialogComponent,
   ShareDialogComponent
 } from '@alfresco/adf-content-services';
-import { TranslationService } from '@alfresco/adf-core';
+import { TranslationService, AlfrescoApiService } from '@alfresco/adf-core';
 import {
   DeletedNodesPaging,
   MinimalNodeEntity,
@@ -94,6 +94,7 @@ export class ContentManagementService {
   favoriteLibraryToggle = new Subject<any>();
 
   constructor(
+    private alfrescoApiService: AlfrescoApiService,
     private store: Store<AppStore>,
     private contentApi: ContentApiService,
     private permission: NodePermissionService,
@@ -263,7 +264,7 @@ export class ContentManagementService {
 
     dialog.afterClosed().subscribe(node => {
       if (node) {
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.alfrescoApiService.nodeUpdated.next(node);
       }
     });
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/Alfresco/alfresco-content-app/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application / Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [ACA-1930](https://issues.alfresco.com/jira/browse/ACA-1930)


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
