### PR TITLE
[ACA-2715] Fix display version of AOS on About page

### DIFF
--- a/projects/adf-office-services-ext/assets/aos.plugin.json
+++ b/projects/adf-office-services-ext/assets/aos.plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../extension.schema.json",
   "$id": "9a635542-d87a-4558-ae64-ffa199d1a364",
-  "$version": "0.0.6",
+  "$version": "0.0.7",
   "$name": "keensoft.aos.plugin",
   "$description": "Extension that provides Office Edit Online Action",
   "$vendor": "Keensoft",


### PR DESCRIPTION
Sync the AOS version displayed on the About page with the version from AOS package.json

<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: https://issues.alfresco.com/jira/browse/ACA-2715

## Changes
