### PR TITLE
[ACA-2713] use standard base_path variable

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,9 +66,9 @@ if [[ $ACSURL ]]; then
   cat /tmp/app.config.json > ./app.config.json
 fi
 
-if [[ $BASEPATH ]]; then
+if [[ $BASE_PATH ]]; then
   replace="\/"
-  encoded=${BASEPATH//\//$replace}
+  encoded=${BASE_PATH//\//$replace}
   sed -i s%href=\"/\"%href=\""$encoded"\"%g /tmp/index.html && \
   cat /tmp/index.html > ./index.html
 fi


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2713

## Changes
Use `BASE_PATH` variable name for Docker image