### PR TITLE
[ACA-2497] DocumentList - focus indicator is not clearly visible

### DIFF
--- a/src/app/ui/overrides/adf-document-list.theme.scss
+++ b/src/app/ui/overrides/adf-document-list.theme.scss
@@ -63,10 +63,6 @@
       &:first-child {
         min-width: $data-table-thumbnail-width;
       }
-
-      &:focus {
-        outline: none !important;
-      }
     }
 
     .adf-datatable-cell {


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: [ACA-2497](https://issues.alfresco.com/jira/browse/ACA-2497)

## Changes
render document list cell visual outline for accessibility 