### PR TITLE
Change the base href in index.html to make app work natively when deployed to a sub dir on a web server

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <meta http-equiv="pragma" content="no-cache" />
 
     <title>Alfresco Content App</title>
-    <base href="/" />
+    <base href="./" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />


### PR DESCRIPTION
The Digital Workspace app already have this fixed and have base href point to ./ in the source code of index.html.

Expected behaviour:
* Build the app and deploy it to a subdirectory on your apache server such as http://localhost/content-app/
* Access http://localhost/content-app/ in the web browser.
* The app should work

Observed behaviour:
* Build the app and deploy it to a subdirectory on your apache server such as http://localhost/content-app/
* Access http://localhost/content-app/ in the web browser.
* The app does not work since all resources will be loaded from relative the root of the url, not relative the current directory as expected.

<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: N/A

## Changes
src/index.html
