### PR TITLE
[ACA-2782] Header - sidenav menu button expanded/collapsed state not exposed via ARIA

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -5,6 +5,7 @@
   [color]="headerColor$ | async"
   [title]="appName$ | async"
   (clicked)="toggleClicked.emit($event)"
+  [expandedSidenav]="expandedSidenav"
 >
   <div class="adf-toolbar--spacer adf-toolbar-divider"></div>
 

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -52,7 +52,7 @@ export class AppHeaderComponent implements OnInit {
   @Output()
   toggleClicked = new EventEmitter();
 
-  @Input() expandedSidenav: Boolean = true;
+  @Input() expandedSidenav = true;
 
   appName$: Observable<string>;
   headerColor$: Observable<string>;

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -28,7 +28,8 @@ import {
   ViewEncapsulation,
   Output,
   EventEmitter,
-  OnInit
+  OnInit,
+  Input
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
@@ -50,6 +51,8 @@ import {
 export class AppHeaderComponent implements OnInit {
   @Output()
   toggleClicked = new EventEmitter();
+
+  @Input() expandedSidenav: Boolean = true;
 
   appName$: Observable<string>;
   headerColor$: Observable<string>;

--- a/src/app/components/layout/app-layout/app-layout.component.html
+++ b/src/app/components/layout/app-layout/app-layout.component.html
@@ -15,6 +15,7 @@
           aria-level="1"
           *ngIf="!hideSidenav"
           (toggleClicked)="layout.toggleMenu($event)"
+          [expandedSidenav]="expandedSidenav"
         >
         </app-header>
       </ng-template>


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2782

## Changes
Accessiblity improvement with showing on the sidenav toggle button if the sidnav is expanded or not