### PR TITLE
[ACA-2800] Entry.sh overrides wrong BASE_PATH

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -59,9 +59,9 @@ if [ -n "${APP_CONFIG_OAUTH2_REDIRECT_LOGOUT}" ];then
   cat /tmp/app.config.json > ./app.config.json
 fi
 
-if [[ $ACSURL ]]; then
+if [[ $ACS_URL ]]; then
   replace="\/"
-  encoded=${ACSURL//\//$replace}
+  encoded=${ACS_URL//\//$replace}
   sed -i s%{protocol}//{hostname}{:port}%"$encoded"%g /tmp/app.config.json && \
   cat /tmp/app.config.json > ./app.config.json
 fi
@@ -69,7 +69,7 @@ fi
 if [[ $BASE_PATH ]]; then
   replace="\/"
   encoded=${BASE_PATH//\//$replace}
-  sed -i s%href=\"/\"%href=\""$encoded"\"%g /tmp/index.html && \
+  sed -ri s%href=\"(\\.?/)+\"%href=\""$encoded"\"%g /tmp/index.html && \
   cat /tmp/index.html > ./index.html
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,7 +69,7 @@ fi
 if [[ $BASE_PATH ]]; then
   replace="\/"
   encoded=${BASE_PATH//\//$replace}
-  sed -ri s%href=\"(\\.?/)+\"%href=\""$encoded"\"%g /tmp/index.html && \
+  sed -ri 's%href=".?/"%href="'$encoded'"%g' /tmp/index.html && \
   cat /tmp/index.html > ./index.html
 fi
 


### PR DESCRIPTION
* href should be override href="/" and href="./" as that is our prod build. As well ADW uses ACS_URL

<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2800

## Changes
