### PR TITLE
upgrade webdriver-manager and puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10076,7 +10076,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10231,9 +10231,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.19.0.tgz",
-      "integrity": "sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -13123,9 +13123,9 @@
       }
     },
     "webdriver-manager": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.6.tgz",
-      "integrity": "sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
+      "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "prettier": "^1.17.1",
     "protractor": "5.4.2",
     "protractor-screenshoter-plugin": "0.10.3",
-    "puppeteer": "^1.19.0",
+    "puppeteer": "^1.20.0",
     "rxjs-tslint-rules": "^4.19.0",
     "selenium-webdriver": "4.0.0-alpha.1",
     "ts-node": "^8.0.3",
@@ -110,7 +110,7 @@
     "tslint": "~5.11.0",
     "typescript": "3.2.4",
     "wait-on": "^3.0.1",
-    "webdriver-manager": "12.1.6"
+    "webdriver-manager": "12.1.7"
   },
   "lint-staged": {
     "*.{ts,js,css,scss,html}": [


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: N/A

## Changes

upgrade puppeteer version in order to use chrome v78
upgrade webdriver-manager to 12.1.7, compatible with chrome v78