### PR TITLE
[ACA-2782] Header - sidenav menu button expanded/collapsed state not exposed via ARIA

### DIFF
--- a/src/app/components/layout/app-layout/app-layout.component.html
+++ b/src/app/components/layout/app-layout/app-layout.component.html
@@ -9,13 +9,13 @@
     (expanded)="onExpanded($event)"
   >
     <adf-sidenav-layout-header>
-      <ng-template>
+      <ng-template let-isMenuMinimized="isMenuMinimized">
         <app-header
           role="heading"
           aria-level="1"
           *ngIf="!hideSidenav"
           (toggleClicked)="layout.toggleMenu($event)"
-          [expandedSidenav]="expandedSidenav"
+          [expandedSidenav]="isMenuMinimized() ? 'false' : 'true'"
         >
         </app-header>
       </ng-template>

--- a/src/app/components/layout/app-layout/app-layout.component.html
+++ b/src/app/components/layout/app-layout/app-layout.component.html
@@ -15,7 +15,7 @@
           aria-level="1"
           *ngIf="!hideSidenav"
           (toggleClicked)="layout.toggleMenu($event)"
-          [expandedSidenav]="isMenuMinimized() ? 'false' : 'true'"
+          [expandedSidenav]="!isMenuMinimized()"
         >
         </app-header>
       </ng-template>


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-278

## Changes
Sidenav can be collapsed with other events like Search enter. I didn't know that. So the expanded aria label needs to be calculated bases on the correct state.