### PR TITLE
E2e cm:content nodes need the aspect versionable

### DIFF
--- a/e2e/utilities/repo-client/apis/nodes/node-body-create.ts
+++ b/e2e/utilities/repo-client/apis/nodes/node-body-create.ts
@@ -33,6 +33,7 @@ export class NodeBodyCreate {
         public name: string,
         public nodeType: string,
         public relativePath: string = '/',
-        public properties?: any[]
+        public properties?: any[],
+        public aspectNames = ['cm:versionable']
     ) {}
 }

--- a/e2e/utilities/repo-client/apis/nodes/node-content-tree.ts
+++ b/e2e/utilities/repo-client/apis/nodes/node-content-tree.ts
@@ -48,7 +48,8 @@ export function flattenNodeContentTree(content: NodeContentTree, relativePath: s
             nodeType: NODE_TYPE_FOLDER,
             name,
             relativePath,
-            properties
+            properties,
+            aspectNames: ['cm:versionable']
         }]);
 
         relativePath = (relativePath === '/')
@@ -75,7 +76,8 @@ export function flattenNodeContentTree(content: NodeContentTree, relativePath: s
             .map((filename: string): NodeBodyCreate => ({
                 nodeType: NODE_TYPE_FILE,
                 name: filename,
-                relativePath
+                relativePath,
+                aspectNames: ['cm:versionable']
             }));
 
         data = data.concat(filesData);

--- a/e2e/utilities/repo-client/apis/nodes/nodes-api.ts
+++ b/e2e/utilities/repo-client/apis/nodes/nodes-api.ts
@@ -219,10 +219,11 @@ export class NodesApi extends RepoApi {
         name,
         nodeType,
         properties: {
-            'cm:title': title,
-            'cm:description': description,
-            'cm:author': author
-        }
+            'cm:title': title === '' ? undefined : title,
+            'cm:description': description  === '' ? undefined : description,
+            'cm:author': author  === '' ? undefined : author
+        },
+        aspectNames: ['cm:versionable']
     };
     if (imageProps) {
       nodeBody.properties = Object.assign(nodeBody.properties, imageProps);

--- a/e2e/utilities/repo-client/apis/upload/upload-api.ts
+++ b/e2e/utilities/repo-client/apis/upload/upload-api.ts
@@ -40,7 +40,8 @@ export class UploadApi extends RepoApi {
     const file = fs.createReadStream(`${E2E_ROOT_PATH}/resources/test-files/${fileName}`);
     const opts = {
       name: file.name,
-      nodeType: 'cm:content'
+      nodeType: 'cm:content',
+      aspectNames: ['cm:versionable']
     };
 
     try {
@@ -55,7 +56,8 @@ export class UploadApi extends RepoApi {
     const file = fs.createReadStream(`${E2E_ROOT_PATH}/resources/test-files/${fileName}`);
     const opts = {
         name: newName,
-        nodeType: 'cm:content'
+        nodeType: 'cm:content',
+        aspectNames: ['cm:versionable']
     };
 
     try {


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: N/A

## Changes
Newer ACS like 6.3.0-EA1 or 6.2.0-RC3 expecting to have the aspect cm:versionable on nodes with type cm:content othwerise the favorite api will fail.