### PR TITLE
[ACA-2621] Shared link - when dialog is closed focus is not returned to trigger

### DIFF
--- a/e2e/resources/extensibility-configs/context-submenus-ext.json
+++ b/e2e/resources/extensibility-configs/context-submenus-ext.json
@@ -422,6 +422,9 @@
             "id": "app.toolbar.share",
             "type": "custom",
             "order": 600,
+            "data": {
+              "iconButton": true
+            },
             "component": "app.shared-link.toggleSharedLink",
             "rules": {
               "visible": "app.selection.file.canShare"
@@ -517,6 +520,9 @@
             "id": "item3",
             "type": "custom",
             "order": 400,
+            "data": {
+              "iconButton": false
+            },
             "component": "app.shared-link.toggleSharedLink",
             "rules": {
               "visible": "app.selection.file.canShare"
@@ -538,6 +544,9 @@
             "id": "item3",
             "type": "custom",
             "order": 400,
+            "data": {
+              "iconButton": false
+            },
             "component": "app.shared-link.toggleSharedLink",
             "rules": {
               "visible": "app.selection.file.canShare"
@@ -586,6 +595,9 @@
         "id": "app.context.menu.share",
         "type": "custom",
         "order": 400,
+        "data": {
+          "iconButton": false
+        },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
           "visible": "app.selection.file.canShare"
@@ -805,6 +817,9 @@
               "id": "app.viewer.share",
               "type": "custom",
               "order": 300,
+              "data": {
+                "iconButton": true
+              },
               "component": "app.shared-link.toggleSharedLink",
               "rules": {
                 "visible": "app.selection.file.canShare"

--- a/src/app/components/common/toggle-shared/toggle-shared.component.html
+++ b/src/app/components/common/toggle-shared/toggle-shared.component.html
@@ -1,14 +1,30 @@
 <ng-container *ngIf="selection$ | async as selection">
-  <button
-    mat-menu-item
-    data-automation-id="share-action-button"
-    (click)="editSharedNode(selection)"
-  >
-    <mat-icon>link</mat-icon>
-    <ng-container *ngIf="isShared(selection); else not_shared">
-      <span>{{ 'APP.ACTIONS.SHARE_EDIT' | translate }}</span>
-    </ng-container>
-  </button>
+  <ng-container *ngIf="!data.iconButton">
+    <button
+      mat-menu-item
+      data-automation-id="share-action-button"
+      (click)="editSharedNode(selection)"
+    >
+      <mat-icon>link</mat-icon>
+      <ng-container *ngIf="isShared(selection); else not_shared">
+        <span>{{ 'APP.ACTIONS.SHARE_EDIT' | translate }}</span>
+      </ng-container>
+    </button>
+  </ng-container>
+
+  <ng-container *ngIf="data.iconButton">
+    <button
+      mat-icon-button
+      data-automation-id="share-action-button"
+      (click)="editSharedNode(selection)"
+      [attr.title]="
+        (isShared(selection) ? 'APP.ACTIONS.SHARE_EDIT' : 'APP.ACTIONS.SHARE')
+          | translate
+      "
+    >
+      <mat-icon>link</mat-icon>
+    </button>
+  </ng-container>
 </ng-container>
 
 <ng-template #not_shared>

--- a/src/app/components/common/toggle-shared/toggle-shared.component.ts
+++ b/src/app/components/common/toggle-shared/toggle-shared.component.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { SelectionState } from '@alfresco/adf-extensions';
@@ -38,6 +38,8 @@ import {
   templateUrl: './toggle-shared.component.html'
 })
 export class ToggleSharedComponent implements OnInit {
+  @Input() data: any;
+
   selection$: Observable<SelectionState>;
 
   constructor(private store: Store<AppStore>) {}

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -214,9 +214,7 @@ export class ContentManagementService {
           })
           .afterClosed()
           .subscribe(deletedSharedLink => {
-            this.store.dispatch(
-              new SetSelectedNodesAction([deletedSharedLink || node])
-            );
+            this.store.dispatch(new SetSelectedNodesAction([node]));
             if (deletedSharedLink) {
               this.linksUnshared.next(deletedSharedLink);
             }

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -197,26 +197,14 @@
       },
       {
         "id": "app.toolbar.share",
+        "type": "custom",
         "order": 100,
-        "title": "APP.ACTIONS.SHARE",
-        "icon": "link",
-        "actions": {
-          "click": "SHARE_NODE"
+        "data": {
+          "iconButton": true
         },
+        "component": "app.shared-link.toggleSharedLink",
         "rules": {
-          "visible": "app.selection.file.canShare"
-        }
-      },
-      {
-        "id": "app.toolbar.share.edit",
-        "order": 101,
-        "title": "APP.ACTIONS.SHARE_EDIT",
-        "icon": "link",
-        "actions": {
-          "click": "SHARE_NODE"
-        },
-        "rules": {
-          "visible": "app.selection.file.isShared"
+          "visible": "canToggleSharedLink"
         }
       },
       {
@@ -486,6 +474,9 @@
         "id": "app.context.menu.share",
         "type": "custom",
         "order": 100,
+        "data": {
+          "iconButton": false
+        },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
           "visible": "canToggleSharedLink"
@@ -747,26 +738,14 @@
         },
         {
           "id": "app.viewer.share",
+          "type": "custom",
           "order": 200,
-          "title": "APP.ACTIONS.SHARE",
-          "icon": "link",
-          "actions": {
-            "click": "SHARE_NODE"
+          "data": {
+            "iconButton": true
           },
+          "component": "app.shared-link.toggleSharedLink",
           "rules": {
-            "visible": "app.selection.file.canShare"
-          }
-        },
-        {
-          "id": "app.viewer.share.edit",
-          "order": 250,
-          "title": "APP.ACTIONS.SHARE_EDIT",
-          "icon": "link",
-          "actions": {
-            "click": "SHARE_NODE"
-          },
-          "rules": {
-            "visible": "app.selection.file.isShared"
+            "visible": "canToggleSharedLink"
           }
         },
         {


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: [ACA-2621](https://issues.alfresco.com/jira/browse/ACA-2621)

## Changes
use custom component action to ensure elements are not removed from DOM when different states must render. this way, focused element reference will not get lost