### PR TITLE
[ACA-2849] [MNT] - ADW- Edit option 'Cancel editing'/'edit offline' is not refreshing automatically after uploading new version

### DIFF
--- a/projects/aca-shared/src/lib/services/content-api.service.ts
+++ b/projects/aca-shared/src/lib/services/content-api.service.ts
@@ -287,7 +287,7 @@ export class ContentApiService {
     );
   }
 
-  unlockNode(nodeId: string, opts?: any) {
-    return this.api.nodesApi.unlockNode(nodeId, opts);
+  unlockNode(nodeId: string, opts?: any): Observable<any> {
+    return from(this.api.nodesApi.unlockNode(nodeId, opts));
   }
 }


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2849

## Changes
Reload preview if unlock to show "Edit Offline" instead of "Cancel Editing" after uploading new version