### PR TITLE
[ACA-2850][ACA-2849] Viewer - document properties not refreshed after changes or uploading new version

### DIFF
--- a/e2e/components/menu/menu.ts
+++ b/e2e/components/menu/menu.ts
@@ -355,7 +355,7 @@ export class Menu extends Component {
     return this.cancelEditingAction.isPresent();
   }
 
-  async isEditOfflineActionPresent() {
+  async isEditOfflineActionPresent(): Promise<boolean> {
     return this.editOfflineAction.isPresent();
   }
 

--- a/e2e/components/menu/menu.ts
+++ b/e2e/components/menu/menu.ts
@@ -351,6 +351,14 @@ export class Menu extends Component {
     return this.uploadFolderAction.isEnabled();
   }
 
+  async isCancelEditingActionPresent() {
+    return this.cancelEditingAction.isPresent();
+  }
+
+  async isEditOfflineActionPresent() {
+    return this.editOfflineAction.isPresent();
+  }
+
 
   async clickCreateFolder() {
     const action = this.createFolderAction;

--- a/e2e/components/menu/menu.ts
+++ b/e2e/components/menu/menu.ts
@@ -351,7 +351,7 @@ export class Menu extends Component {
     return this.uploadFolderAction.isEnabled();
   }
 
-  async isCancelEditingActionPresent() {
+  async isCancelEditingActionPresent(): Promise<boolean> {
     return this.cancelEditingAction.isPresent();
   }
 

--- a/e2e/suites/viewer/viewer-actions.test.ts
+++ b/e2e/suites/viewer/viewer-actions.test.ts
@@ -74,6 +74,7 @@ describe('Viewer actions', () => {
     const fileForEditOffline = `file1-${Utils.random()}.docx`; let fileForEditOfflineId;
     const fileForCancelEditing = `file2-${Utils.random()}.docx`; let fileForCancelEditingId;
     const fileForUploadNewVersion = `file3-${Utils.random()}.docx`; let fileForUploadNewVersionId;
+    const fileForUploadNewVersion2 = `file4-${Utils.random()}.docx`; let fileForUploadNewVersionId2;
 
     beforeAll(async (done) => {
       parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
@@ -88,9 +89,11 @@ describe('Viewer actions', () => {
       fileForEditOfflineId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForEditOffline)).entry.id;
       fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
       fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
+      fileForUploadNewVersionId2 = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion2)).entry.id;
 
       await apis.user.nodes.lockFile(fileForCancelEditingId);
       await apis.user.nodes.lockFile(fileForUploadNewVersionId);
+      await apis.user.nodes.lockFile(fileForUploadNewVersionId2);
 
 
       await loginPage.loginWith(username);
@@ -219,6 +222,26 @@ describe('Viewer actions', () => {
       expect(await viewer.getFileTitle()).toContain(docxFile2);
       expect(await apis.user.nodes.getFileVersionType(filePersonalFilesId)).toEqual('MAJOR', 'File has incorrect version type');
       expect(await apis.user.nodes.getFileVersionLabel(filePersonalFilesId)).toEqual('2.0', 'File has incorrect version label');
+    });
+
+    it('Upload new version action when node is locked - [MNT-21058]', async () => {
+
+      await dataTable.doubleClickOnRowByName(fileForUploadNewVersion2);
+      await viewer.waitForViewerToOpen();
+
+      await toolbar.openMoreMenu();
+      expect(await toolbar.menu.isCancelEditingActionPresent()).toBe(true, `'Cancel Editing' button should be shown`);
+      expect(await toolbar.menu.isEditOfflineActionPresent()).toBe(false, `'Edit Offline' shouldn't be shown`);
+
+      await toolbar.menu.clickMenuItem('Upload New Version');
+      await Utils.uploadFileNewVersion(docxFile);
+      await page.waitForDialog();
+
+      await uploadNewVersionDialog.clickUpload();
+
+      await toolbar.openMoreMenu();
+      expect(await toolbar.menu.isCancelEditingActionPresent()).toBe(false, `'Cancel Editing' button shouldn't be shown`);
+      expect(await toolbar.menu.isEditOfflineActionPresent()).toBe(true, `'Edit Offline' should be shown`);
     });
 
     it('Full screen action - [C279282]', async () => {

--- a/src/app/components/page.component.ts
+++ b/src/app/components/page.component.ts
@@ -133,6 +133,10 @@ export abstract class PageComponent implements OnInit, OnDestroy {
   }
 
   reload(selectedNode?: MinimalNodeEntity): void {
+    if (this.isOutletPreviewUrl()) {
+      return;
+    }
+
     this.store.dispatch(new ReloadDocumentListAction());
     if (selectedNode) {
       this.store.dispatch(new SetSelectedNodesAction([selectedNode]));
@@ -145,5 +149,9 @@ export abstract class PageComponent implements OnInit, OnDestroy {
 
   trackById(_: number, obj: { id: string }) {
     return obj.id;
+  }
+
+  private isOutletPreviewUrl() {
+    return location.href.includes('viewer:view');
   }
 }

--- a/src/app/components/page.component.ts
+++ b/src/app/components/page.component.ts
@@ -151,7 +151,7 @@ export abstract class PageComponent implements OnInit, OnDestroy {
     return obj.id;
   }
 
-  private isOutletPreviewUrl() {
+  private isOutletPreviewUrl(): boolean {
     return location.href.includes('viewer:view');
   }
 }

--- a/src/app/components/viewer/viewer.component.ts
+++ b/src/app/components/viewer/viewer.component.ts
@@ -188,7 +188,10 @@ export class AppViewerComponent implements OnInit, OnDestroy {
         debounceTime(300),
         takeUntil(this.onDestroy$)
       )
-      .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry));
+      .subscribe(file => {
+        this.apiService.nodeUpdated.next(file.data.entry);
+        this.displayNode(file.data.entry.id);
+      });
 
     this.previewLocation = this.router.url
       .substr(0, this.router.url.indexOf('/', 1))


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: 
[ACA-2850](https://issues.alfresco.com/jira/browse/ACA-2850)
[ACA-2849](https://issues.alfresco.com/jira/browse/ACA-2849)

## Changes
- after upload a  new version get new data for viewer to display
- prevent feature document list upload event triggering  reload when in outlet viewer since it already does the same actions