### PR TITLE
[ACA-2849] [MNT] - ADW- Edit option 'Cancel editing'/'edit offline' is not refreshing automatically after uploading new version

### DIFF
--- a/e2e/components/menu/menu.ts
+++ b/e2e/components/menu/menu.ts
@@ -351,6 +351,14 @@ export class Menu extends Component {
     return this.uploadFolderAction.isEnabled();
   }
 
+  async isCancelEditingActionPresent() {
+    return this.cancelEditingAction.isPresent();
+  }
+
+  async isEditOfflineActionPresent() {
+    return this.editOfflineAction.isPresent();
+  }
+
 
   async clickCreateFolder() {
     const action = this.createFolderAction;

--- a/e2e/suites/viewer/viewer-actions.test.ts
+++ b/e2e/suites/viewer/viewer-actions.test.ts
@@ -74,6 +74,7 @@ describe('Viewer actions', () => {
     const fileForEditOffline = `file1-${Utils.random()}.docx`; let fileForEditOfflineId;
     const fileForCancelEditing = `file2-${Utils.random()}.docx`; let fileForCancelEditingId;
     const fileForUploadNewVersion = `file3-${Utils.random()}.docx`; let fileForUploadNewVersionId;
+    const fileForUploadNewVersion2 = `file4-${Utils.random()}.docx`; let fileForUploadNewVersionId2;
 
     beforeAll(async (done) => {
       parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
@@ -88,9 +89,11 @@ describe('Viewer actions', () => {
       fileForEditOfflineId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForEditOffline)).entry.id;
       fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
       fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
+      fileForUploadNewVersionId2 = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion2)).entry.id;
 
       await apis.user.nodes.lockFile(fileForCancelEditingId);
       await apis.user.nodes.lockFile(fileForUploadNewVersionId);
+      await apis.user.nodes.lockFile(fileForUploadNewVersionId2);
 
 
       await loginPage.loginWith(username);
@@ -221,9 +224,9 @@ describe('Viewer actions', () => {
       expect(await apis.user.nodes.getFileVersionLabel(filePersonalFilesId)).toEqual('2.0', 'File has incorrect version label');
     });
 
-    it('Upload new version action when node is locked - [MNT-21058]', async () => {
+    fit('Upload new version action when node is locked - [MNT-21058]', async () => {
 
-      await dataTable.doubleClickOnRowByName(fileForCancelEditing);
+      await dataTable.doubleClickOnRowByName(fileForUploadNewVersion2);
       await viewer.waitForViewerToOpen();
 
       await toolbar.openMoreMenu();

--- a/e2e/suites/viewer/viewer-actions.test.ts
+++ b/e2e/suites/viewer/viewer-actions.test.ts
@@ -221,6 +221,26 @@ describe('Viewer actions', () => {
       expect(await apis.user.nodes.getFileVersionLabel(filePersonalFilesId)).toEqual('2.0', 'File has incorrect version label');
     });
 
+    it('Upload new version action when node is locked - [MNT-21058]', async () => {
+
+      await dataTable.doubleClickOnRowByName(fileForCancelEditing);
+      await viewer.waitForViewerToOpen();
+
+      await toolbar.openMoreMenu();
+      expect(await toolbar.menu.isCancelEditingActionPresent()).toBe(true, `'Cancel Editing' button should be shown`);
+      expect(await toolbar.menu.isEditOfflineActionPresent()).toBe(false, `'Edit Offline' shouldn't be shown`);
+
+      await toolbar.menu.clickMenuItem('Upload New Version');
+      await Utils.uploadFileNewVersion(docxFile);
+      await page.waitForDialog();
+
+      await uploadNewVersionDialog.clickUpload();
+
+      await toolbar.openMoreMenu();
+      expect(await toolbar.menu.isCancelEditingActionPresent()).toBe(false, `'Cancel Editing' button shouldn't be shown`);
+      expect(await toolbar.menu.isEditOfflineActionPresent()).toBe(true, `'Edit Offline' should be shown`);
+    });
+
     it('Full screen action - [C279282]', async () => {
       await dataTable.doubleClickOnRowByName(docxPersonalFiles);
       await viewer.waitForViewerToOpen();

--- a/e2e/suites/viewer/viewer-actions.test.ts
+++ b/e2e/suites/viewer/viewer-actions.test.ts
@@ -224,7 +224,7 @@ describe('Viewer actions', () => {
       expect(await apis.user.nodes.getFileVersionLabel(filePersonalFilesId)).toEqual('2.0', 'File has incorrect version label');
     });
 
-    fit('Upload new version action when node is locked - [MNT-21058]', async () => {
+    it('Upload new version action when node is locked - [MNT-21058]', async () => {
 
       await dataTable.doubleClickOnRowByName(fileForUploadNewVersion2);
       await viewer.waitForViewerToOpen();

--- a/src/app/components/viewer/viewer.component.ts
+++ b/src/app/components/viewer/viewer.component.ts
@@ -188,7 +188,10 @@ export class AppViewerComponent implements OnInit, OnDestroy {
         debounceTime(300),
         takeUntil(this.onDestroy$)
       )
-      .subscribe(file => this.apiService.nodeUpdated.next(file.data.entry));
+      .subscribe(file => {
+        this.apiService.nodeUpdated.next(file.data.entry);
+        this.displayNode(file.data.entry.id);
+      });
 
     this.previewLocation = this.router.url
       .substr(0, this.router.url.indexOf('/', 1))


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2849

## Changes
Render node again after upload was complete.