### PR TITLE
[ACA-2869] Create File from template - keep the dialog open if creation fails due to the usage of a duplicate file name

### DIFF
--- a/docs/extending/application-actions.md
+++ b/docs/extending/application-actions.md
@@ -124,5 +124,5 @@ Below is the list of public actions types you can use in the plugin definitions 
 | 1.8.0   | VIEW_NODE              | NodeId<`string`> , [ViewNodeExtras](../features/file-viewer.md#details)<`any`> | Lightweight preview of a node by id. Can be invoked from extensions. For details also see [File Viewer](../features/file-viewer.md#details) |
 | 1.8.0   | CLOSE_PREVIEW          | n/a                                                                            | Closes the viewer ( preview of the item )                                                                                                   |
 | 1.9.0   | RESET_SELECTION        | n/a                                                                            | Resets active document list selection                                                                                                       |
-| 2.0.0   | FILE_FROM_TEMPLATE | n/a | Invoke dialogs flow for creating a file from selected template|
-| 2.0.0   | CREATE_FILE_FROM_TEMPLATE | Node | Copy selected tetmplate into current folder    |
+| 1.10.0   | FILE_FROM_TEMPLATE | n/a | Invoke dialogs flow for creating a file from selected template|
+| 1.10.0   | CREATE_FILE_FROM_TEMPLATE | Node | Copy selected tetmplate into current folder    |

--- a/docs/extending/application-actions.md
+++ b/docs/extending/application-actions.md
@@ -124,4 +124,5 @@ Below is the list of public actions types you can use in the plugin definitions 
 | 1.8.0   | VIEW_NODE              | NodeId<`string`> , [ViewNodeExtras](../features/file-viewer.md#details)<`any`> | Lightweight preview of a node by id. Can be invoked from extensions. For details also see [File Viewer](../features/file-viewer.md#details) |
 | 1.8.0   | CLOSE_PREVIEW          | n/a                                                                            | Closes the viewer ( preview of the item )                                                                                                   |
 | 1.9.0   | RESET_SELECTION        | n/a                                                                            | Resets active document list selection                                                                                                       |
-| 2.0.0   | CREATE_FILE_FROM_TEMPLATE        | n/a | Invoke a dialog listing `Node Templates` folder. Selected template can be copied in the current folder from where tha action was invoked                                                                                               |
+| 2.0.0   | FILE_FROM_TEMPLATE | n/a | Invoke dialogs flow for creating a file from selected template|
+| 2.0.0   | CREATE_FILE_FROM_TEMPLATE | Node | Copy selected tetmplate into current folder    |

--- a/projects/aca-shared/store/src/actions/template.actions.ts
+++ b/projects/aca-shared/store/src/actions/template.actions.ts
@@ -24,13 +24,21 @@
  */
 
 import { Action } from '@ngrx/store';
+import { Node } from '@alfresco/js-api';
 
 export enum TemplateActionTypes {
-  FileFromTemplate = 'FILE_FROM_TEMPLATE'
+  FileFromTemplate = 'FILE_FROM_TEMPLATE',
+  CreateFileFromTemplate = 'CREATE_FILE_FROM_TEMPLATE'
 }
 
 export class FileFromTemplate implements Action {
   readonly type = TemplateActionTypes.FileFromTemplate;
 
   constructor() {}
+}
+
+export class CreateFileFromTemplate implements Action {
+  readonly type = TemplateActionTypes.CreateFileFromTemplate;
+
+  constructor(public payload: Node) {}
 }

--- a/projects/aca-shared/store/src/actions/template.actions.ts
+++ b/projects/aca-shared/store/src/actions/template.actions.ts
@@ -26,11 +26,11 @@
 import { Action } from '@ngrx/store';
 
 export enum TemplateActionTypes {
-  CreateFileFromTemplate = 'CREATE_FILE_FROM_TEMPLATE'
+  FileFromTemplate = 'FILE_FROM_TEMPLATE'
 }
 
-export class CreateFileFromTemplate implements Action {
-  readonly type = TemplateActionTypes.CreateFileFromTemplate;
+export class FileFromTemplate implements Action {
+  readonly type = TemplateActionTypes.FileFromTemplate;
 
   constructor() {}
 }

--- a/src/app/dialogs/node-templates/create-from-template-dialog.service.ts
+++ b/src/app/dialogs/node-templates/create-from-template-dialog.service.ts
@@ -25,10 +25,11 @@
 
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+import { Node } from '@alfresco/js-api';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CreateFromTemplateDialogService {
-  success$: Subject<any> = new Subject();
+  success$: Subject<Node> = new Subject();
 }

--- a/src/app/dialogs/node-templates/create-from-template-dialog.service.ts
+++ b/src/app/dialogs/node-templates/create-from-template-dialog.service.ts
@@ -1,0 +1,34 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CreateFromTemplateDialogService {
+  success$: Subject<any> = new Subject();
+}

--- a/src/app/dialogs/node-templates/create-from-template.dialog.ts
+++ b/src/app/dialogs/node-templates/create-from-template.dialog.ts
@@ -33,6 +33,7 @@ import {
   FormControl,
   ValidationErrors
 } from '@angular/forms';
+import { CreateFromTemplateDialogService } from './create-from-template-dialog.service';
 
 @Component({
   templateUrl: './create-from-template.dialog.html',
@@ -43,12 +44,17 @@ export class CreateFileFromTemplateDialogComponent implements OnInit {
   public form: FormGroup;
 
   constructor(
+    private createFromTemplateDialogService: CreateFromTemplateDialogService,
     private formBuilder: FormBuilder,
     private dialogRef: MatDialogRef<CreateFileFromTemplateDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {}
 
   ngOnInit() {
+    this.createFromTemplateDialogService.success$.subscribe((data: Node) => {
+      this.dialogRef.close(data);
+    });
+
     this.form = this.formBuilder.group({
       name: [
         this.data.name,

--- a/src/app/dialogs/node-templates/create-from-template.dialog.ts
+++ b/src/app/dialogs/node-templates/create-from-template.dialog.ts
@@ -34,6 +34,8 @@ import {
   ValidationErrors
 } from '@angular/forms';
 import { CreateFromTemplateDialogService } from './create-from-template-dialog.service';
+import { Store } from '@ngrx/store';
+import { AppStore, CreateFileFromTemplate } from '@alfresco/aca-shared/store';
 
 @Component({
   templateUrl: './create-from-template.dialog.html',
@@ -45,6 +47,7 @@ export class CreateFileFromTemplateDialogComponent implements OnInit {
 
   constructor(
     private createFromTemplateDialogService: CreateFromTemplateDialogService,
+    private store: Store<AppStore>,
     private formBuilder: FormBuilder,
     private dialogRef: MatDialogRef<CreateFileFromTemplateDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
@@ -82,7 +85,7 @@ export class CreateFileFromTemplateDialogComponent implements OnInit {
       }
     };
     const data: Node = Object.assign({}, this.data, update);
-    this.dialogRef.close(data);
+    this.store.dispatch(new CreateFileFromTemplate(data));
   }
 
   close() {

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -115,7 +115,7 @@
         "title": "APP.NEW_MENU.MENU_ITEMS.FILE_TEMPLATE",
         "description": "APP.NEW_MENU.MENU_ITEMS.FILE_TEMPLATE",
         "actions": {
-          "click": "CREATE_FILE_FROM_TEMPLATE"
+          "click": "FILE_FROM_TEMPLATE"
         },
         "rules": {
           "enabled": "app.navigation.folder.canUpload"


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: [ACA-2869](https://issues.alfresco.com/jira/browse/ACA-2869)

## Changes
Created 2 template effects:
    - FileFromTemplate - manages dialogs
    - CreateFileFromTemplate -  create node from template source
Created a dialog service which holds a Subject to be called once node is successful created to close the dialog that subscribes to it. This will keep the dialog open in case of error