### PR TITLE
chore: a11y removed overriding role from button in menu

### DIFF
--- a/src/app/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.html
+++ b/src/app/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.html
@@ -27,9 +27,12 @@
   </ng-container>
 
   <ng-container *ngSwitchDefault>
+    <!--
+      ACA-2543: removed attribute mat-menu-item which applied a role, overriding the native button role; added the applied class directly for styling.
+    -->
     <button
       [id]="actionRef.id"
-      mat-menu-item
+      [class]="'mat-menu-item'"
       color="primary"
       [disabled]="actionRef.disabled"
       [attr.title]="


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2543

## Changes

* removed the ng attribute which was applying an overriding role to the button, causing it to not read like a button
* added the applied class manually for styling