### PR TITLE
[ACA-2912] [MNT] [Security] CVE-2018-5158 - XSS vulnerability in pdfjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9909,9 +9909,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.0.943",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz",
-      "integrity": "sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==",
+      "version": "2.3.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.3.200.tgz",
+      "integrity": "sha512-+8wBjU5h8LPZOIvR9X2uCrp/8xWQG1DRDKMLg5lzGN1qyIAZlYUxA0KQyy12Nw5jN7ozulC6v97PMaDcLgAcFg==",
       "requires": {
         "node-ensure": "^0.0.0",
         "worker-loader": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "minimatch-browser": "^1.0.0",
     "moment": "^2.24.0",
     "moment-es6": "1.0.0",
-    "pdfjs-dist": "2.0.943",
+    "pdfjs-dist": "2.3.200",
     "rxjs": "^6.5.2",
     "zone.js": "0.8.29"
   },


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: [ACA-2912](https://issues.alfresco.com/jira/browse/ACA-2912)

## Changes
Align pdfjs version with ADF