### PR TITLE
[ACA-2124] New bg-color and font style for "New" button

### DIFF
--- a/src/app/components/create-menu/create-menu.component.scss
+++ b/src/app/components/create-menu/create-menu.component.scss
@@ -15,11 +15,11 @@
       display: block;
       box-shadow: none !important;
       height: 37.5px;
-      background-color: mat-color($accent);
+      background-color: mat-color($accent, 800);
       color: mat-color($primary, default-contrast) !important;
       border-radius: 4px;
-      font-size: 12.7px;
-      font-weight: normal;
+      font-size: 18.7px;
+      font-weight: bold;
       text-transform: uppercase;
 
       .mat-icon {


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2124

## Changes

- Rise `font-size` from **12.7px to 18.7px** and `font-weight` from **normal to bold** to need only a 3:1 contrast ratio for colors and not a 4.5:1 ratio for AA accessibility level compliance.
- New color chose from `alfresco-accent-orange` palette to respect the 3:1 contrast ratio.

PS : Sidenav colors will be updated and harmonized in next PR (cf ACA-2125)