### PR TITLE
[ACA-2125] Update sidenav colors and font-size

### DIFF
--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
@@ -8,9 +8,13 @@
     align-items: center;
     flex: 0 0 65px;
     flex-basis: 48px;
-    background: #fafafa;
+    background: #fcfcfc;
     border-bottom: 1px solid var(--theme-border-color, rgba(0, 0, 0, 0.07));
     padding: 0 24px;
+
+    .adf-breadcrumb-item-current {
+      font-size: 18.7px;
+    }
   }
 
   .aca-page-layout-content {

--- a/src/app/components/sidenav/sidenav.component.theme.scss
+++ b/src/app/components/sidenav/sidenav.component.theme.scss
@@ -7,16 +7,16 @@
   $border: 1px solid mat-color($foreground, divider, 0.07);
 
   .aca-menu-panel {
-    .action-button--active {
-      color: mat-color($accent) !important;
-    }
-
     .action-button {
       color: mat-color($primary);
-    }
 
-    .action-button:hover {
-      color: mat-color($accent);
+      &--active {
+        color: mat-color($accent, 800) !important;
+      }
+
+      &:hover {
+        color: mat-color($accent, 800);
+      }
     }
   }
 
@@ -24,7 +24,12 @@
     background-color: mat-color($background, background);
 
     .item:hover .action-button__label {
-      color: mat-color($accent);
+      color: mat-color($accent, 800);
+    }
+
+    .action-button__label {
+      font-size: 18.7px;
+      font-weight: bold;
     }
 
     .mat-expansion-panel {
@@ -46,7 +51,7 @@
     }
 
     .action-button--active {
-      color: mat-color($accent) !important;
+      color: mat-color($accent, 800) !important;
     }
 
     .action-button {

--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -58,6 +58,21 @@ $custom-theme: mat-light-theme($custom-theme-primary, $custom-theme-accent);
 $foreground: map-get($custom-theme, foreground);
 $warn: map-get($custom-theme, warn);
 
+$custom-background-color: #fcfcfc;
+$background: map-get($custom-theme, background);
+$background: map_merge(
+  $background,
+  (
+    background: $custom-background-color
+  )
+);
+$custom-theme: map_merge(
+  $custom-theme,
+  (
+    background: $background
+  )
+);
+
 @mixin custom-theme($theme) {
   @include layout-theme($theme);
   @include aca-search-input-theme($theme);

--- a/src/app/ui/theme.scss
+++ b/src/app/ui/theme.scss
@@ -12,6 +12,21 @@ $accent: mat-palette($alfresco-ecm-blue);
 $warn: mat-palette($alfresco-warn);
 $theme: mat-light-theme($primary, $accent, $warn);
 
+$custom-background-color: #fcfcfc;
+$background: map-get($theme, background);
+$background: map_merge(
+  $background,
+  (
+    background: $custom-background-color
+  )
+);
+$theme: map_merge(
+  $theme,
+  (
+    background: $background
+  )
+);
+
 @include angular-material-theme($theme);
 
 @include adf-content-services-theme($theme);


### PR DESCRIPTION
<!--
Definition of Done:

- Technical Documentation
- Code compliant with Clean Coding rules and tslint
- Unit tests
- Automation tests
-->

Issue Number: ACA-2125

## Changes
- Rise `font-size` from **14px to 18.7px** and `font-weight` from **normal to bold** so we need only a 3:1 contrast ratio for colors and not a 4.5:1 ratio for AA accessibility level compliance for sidenav buttons.
- New color chose from `alfresco-accent-orange` palette and update the default background-color from `#fafafa` to `#fcfcfc` to respect the 3:1 contrast ratio.
- Rise `font-size` from **14px to 18.7px** for  the`page-layout-header` to harmonize with sidenav.