### PR TITLE
[ACA-2604] Search result/input color update

### DIFF
--- a/src/app/components/search/search-input/search-input.component.theme.scss
+++ b/src/app/components/search/search-input/search-input.component.theme.scss
@@ -10,7 +10,7 @@ $top-margin: 12px;
   $border: 1px solid mat-color($foreground, divider, 0.07);
 
   .app-search-container {
-    color: mat-color($foreground, text, 0.54);
+    color: mat-color($foreground, text, 0.72);
 
     .app-input-form-field {
       .mat-input-element {

--- a/src/app/components/search/search-results-row/search-results-row.component.scss
+++ b/src/app/components/search/search-results-row/search-results-row.component.scss
@@ -1,24 +1,36 @@
 @import 'mixins';
 
-.aca-search-results-row {
-  @include flex-column;
-}
+@mixin aca-result-row-theme($theme) {
+  $primary: map-get($theme, primary);
+  $foreground: map-get($theme, foreground);
 
-.line {
-  margin: 5px;
-}
+  .aca-search-results-row {
+    @include flex-column;
+  }
 
-.bold {
-  font-weight: 400;
-  color: rgba(0, 0, 0, 0.87);
-}
+  .line {
+    margin: 5px;
+  }
 
-.link {
-  text-decoration: none;
-  color: rgba(0, 0, 0, 0.87);
-}
+  .bold {
+    font-weight: 400;
+    color: mat-color($foreground, text, 0.87);
+  }
 
-.link:hover {
-  color: #2196f3;
-  text-decoration: underline;
+  .link {
+    text-decoration: none;
+    color: mat-color($foreground, text, 0.87);
+  }
+
+  .link:hover,
+  .aca-location-link .adf-datatable-cell-value:hover {
+    color: mat-color($primary) !important;
+    text-decoration: underline;
+  }
+
+  .adf-is-selected .link:not(:hover),
+  .adf-is-selected .aca-location-link .adf-datatable-cell-value:not(:hover) {
+    text-decoration: none;
+    color: mat-color($primary, A400) !important;
+  }
 }

--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -3,6 +3,7 @@
 
 @import '../components/sidenav/sidenav.component.theme';
 @import '../components/search/search-input/search-input.component.theme';
+@import '../components/search/search-results-row/search-results-row.component.scss';
 @import '../components/settings/settings.component.theme';
 @import '../components/current-user/current-user.component.theme';
 @import '../components/permissions/permission-manager/permission-manager.component.theme';
@@ -61,6 +62,7 @@ $warn: map-get($custom-theme, warn);
 @mixin custom-theme($theme) {
   @include layout-theme($theme);
   @include aca-search-input-theme($theme);
+  @include aca-result-row-theme($theme);
   @include app-permission-manager-theme($theme);
   @include aca-node-versions-dialog-theme($theme);
   @include aca-settings-theme($theme);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Styling

**What is the current behaviour?** (You can also link to an open issue here)
No change in color when a row is selected and missing some contrast for AA accessibility in the search input.


**What is the new behaviour?**
When a row is selected its links are colored from a color in the new palette (Cf ACA-2695) same when a link is hovered with a different color form the new palette.
Also little change of color in the search-input to meet AA Accessibility.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2604