### PR TITLE
[ACA-2970] Change hover and select data row background color

### DIFF
--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -65,8 +65,8 @@ $data-table-cell-min-width--no-grow: 120px;
 $data-table-cell-min-width--fileSize: 80px !important;
 $data-table-cell-text-color: mat-color($foreground, text, 0.54);
 $data-table-cell-link-color: mat-color($foreground, text);
-$data-table-hover-color: #e0f7fa;
-$data-table-selection-color: #e0f7fa;
+$data-table-hover-color: #e3fafd;
+$data-table-selection-color: #e3fafd;
 
 $adf-pagination--border: 1px solid mat-color($foreground, text, 0.07);
 $adf-pagination__empty--height: 0;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
The background color of data table row when selected or hovered is slightly too dark: only 4.47:1 contrast ratio with the text inside it and we need 4.5 ratio for AA accessibility.


**What is the new behaviour?**
Lighter colors for hover and selected states for data table row.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2970