### PR TITLE
[ACA-2604] Fix color update on datable row

### DIFF
--- a/src/app/components/search/search-results-row/search-results-row.component.scss
+++ b/src/app/components/search/search-results-row/search-results-row.component.scss
@@ -24,13 +24,12 @@
 
   .link:hover,
   .aca-location-link .adf-datatable-cell-value:hover {
-    color: mat-color($primary) !important;
+    color: mat-color($primary, A200) !important;
     text-decoration: underline;
   }
 
   .adf-is-selected .link:not(:hover),
-  .adf-is-selected .aca-location-link .adf-datatable-cell-value:not(:hover) {
-    text-decoration: none;
-    color: mat-color($primary, A400) !important;
+  .adf-is-selected .adf-datatable-cell-value:not(:hover) {
+    color: mat-color($primary) !important;
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
When a data table cell is selected, the color of its background and links changes and the contrast ratio of 4.5:1 isn't respected anymore.


**What is the new behaviour?**
The new colors are darker and respect the 4.5:1 ratio at any time.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2604