### PR TITLE
[ACA-2979] Change create menu item colors

### DIFF
--- a/src/app/components/create-menu/create-menu.component.scss
+++ b/src/app/components/create-menu/create-menu.component.scss
@@ -77,11 +77,7 @@
         font-weight: normal;
 
         &:hover {
-          color: mat-color($primary);
-
-          .mat-icon {
-            color: mat-color($primary);
-          }
+          color: mat-color($primary, A400);
         }
       }
 

--- a/src/app/components/create-menu/create-menu.component.scss
+++ b/src/app/components/create-menu/create-menu.component.scss
@@ -75,10 +75,13 @@
         transform: none;
         transition: unset;
         font-weight: normal;
-        color: mat-color($primary);
 
         &:hover {
-          color: mat-color($accent);
+          color: mat-color($primary);
+
+          .mat-icon {
+            color: mat-color($primary);
+          }
         }
       }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
With the theme update, the create menu component has its colors changed and it wasn't: Every item blue (primary) and hovered item green (accent).


**What is the new behaviour?**
Colors of the create menu are now first grey default and blue (Primary #2 Hue 2) (Cf design system) when hovered.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2979