### PR TITLE
[ACA-3048] temporary remove puppeteer from e2e

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -106,7 +106,6 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      // binary: require('puppeteer').executablePath(),
       prefs: {
         credentials_enable_service: false,
         download: {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -106,7 +106,7 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      binary: require('puppeteer').executablePath(),
+      // binary: require('puppeteer').executablePath(),
       prefs: {
         credentials_enable_service: false,
         download: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe: ACA-3048


**What is the current behaviour?** (You can also link to an open issue here)

since Chrome released a new version, and cause the puppeteer has not yet done a new release with this version of chrome, the e2e tests do not start.

**What is the new behaviour?**

a temporary solution is to remove puppeteer, to let the tests use the Chrome browser installed by default on the travis agent, which is the latest, v81.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: ACA-3048
