### PR TITLE
[ACA-3043] Create From Template - relativePath not working when ACS installation language is different

### DIFF
--- a/src/app/services/node-template.service.ts
+++ b/src/app/services/node-template.service.ts
@@ -139,20 +139,13 @@ export class NodeTemplateService {
 
   private transformNode(node: MinimalNode): MinimalNode {
     if (node && node.path && node.path && node.path.elements instanceof Array) {
-      let {
-        path: { elements: elementsPath = [] }
-      } = node;
-      elementsPath = elementsPath.filter(
-        path => path.name !== 'Company Home' && path.name !== 'Data Dictionary'
-      );
-      node.path.elements = elementsPath;
+      node.path.elements = this.getPathElements(node);
     }
-
     return node;
   }
 
   private isSelectionValid(node: Node): boolean {
-    if (node.name === this.currentTemplateConfig.relativePath.split('/')[1]) {
+    if (!node.path.elements.length) {
       return false;
     }
 
@@ -183,6 +176,15 @@ export class NodeTemplateService {
     const node: MinimalNodeEntryEntity = row.node.entry;
     return (
       node.nodeType !== 'app:filelink' && node.nodeType !== 'app:folderlink'
+    );
+  }
+
+  private getPathElements(node: Node): PathElement[] {
+    return node.path.elements.filter(
+      pathElement =>
+        !this.rootNode.path.elements.some(
+          rootPathElement => pathElement.id === rootPathElement.id
+        )
     );
   }
 }

--- a/src/app/store/effects/template.effects.spec.ts
+++ b/src/app/store/effects/template.effects.spec.ts
@@ -66,12 +66,12 @@ describe('TemplateEffects', () => {
     }
   };
   const fileTemplateConfig = {
-    relativePath: 'Data Dictionary/Node Templates',
+    primaryPathName: 'app:node_templates',
     selectionType: 'file'
   };
 
   const folderTemplateConfig = {
-    relativePath: 'Data Dictionary/Space Templates',
+    primaryPathName: 'app:space_templates',
     selectionType: 'folder'
   };
 

--- a/src/app/store/effects/template.effects.ts
+++ b/src/app/store/effects/template.effects.ts
@@ -63,7 +63,7 @@ export class TemplateEffects {
     ofType<FileFromTemplate>(TemplateActionTypes.FileFromTemplate),
     map(() => {
       this.openDialog({
-        relativePath: 'Data Dictionary/Node Templates',
+        primaryPathName: 'app:node_templates',
         selectionType: 'file'
       });
     })
@@ -74,7 +74,7 @@ export class TemplateEffects {
     ofType<FolderFromTemplate>(TemplateActionTypes.FolderFromTemplate),
     map(() =>
       this.openDialog({
-        relativePath: 'Data Dictionary/Space Templates',
+        primaryPathName: 'app:space_templates',
         selectionType: 'folder'
       })
     )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ACA-3043](https://issues.alfresco.com/jira/browse/ACA-3043)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://github.com/Alfresco/alfresco-content-app/issues/1402