### PR TITLE
[ACA-2496] Change hover color on custom name color

### DIFF
--- a/src/app/components/dl-custom-components/name-column/name-column.component.scss
+++ b/src/app/components/dl-custom-components/name-column/name-column.component.scss
@@ -13,11 +13,19 @@
   }
 }
 
-.aca-custom-name-column {
-  display: block;
-  align-items: center;
+@mixin aca-custom-name-column-theme($theme) {
+  $primary: map-get($theme, primary);
 
-  .adf-datatable-cell-value {
-    margin: 0 4px;
+  .aca-custom-name-column {
+    display: block;
+    align-items: center;
+
+    &:hover {
+      color: mat-color($primary, A200);
+    }
+
+    .adf-datatable-cell-value {
+      margin: 0 4px;
+    }
   }
 }

--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -8,6 +8,7 @@
 @import '../components/current-user/current-user.component.theme';
 @import '../components/permissions/permission-manager/permission-manager.component.theme';
 @import '../components/context-menu/context-menu.component.theme';
+@import '../components/dl-custom-components/name-column/name-column.component.scss';
 @import '../dialogs/node-versions/node-versions.dialog.theme';
 @import '../components/create-menu/create-menu.component.scss';
 @import '../components/layout/layout.theme.scss';
@@ -42,6 +43,7 @@ $warn: map-get($custom-theme, warn);
   @include sidenav-component-theme($theme);
   @include aca-current-user-theme($theme);
   @include aca-context-menu-theme($theme);
+  @include aca-custom-name-column-theme($theme);
   @include app-create-from-template-theme($theme);
   @include app-create-menu-theme($theme);
   @include adf-style-fixes($theme);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
The hover color of the aca-custom-name-column is too light for AA accessibility.


**What is the new behaviour?**
It now take the second primary blue when hovered


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2496