### PR TITLE
[ACA-2542] Change create menu colors

### DIFF
--- a/src/app/components/create-menu/create-menu.component.scss
+++ b/src/app/components/create-menu/create-menu.component.scss
@@ -49,7 +49,7 @@
 
     &--collapsed {
       outline: none;
-      color: mat-color($foreground, text, 0.54);
+      color: mat-color($foreground, secondary-text);
       cursor: pointer;
       &:hover {
         color: mat-color($accent);
@@ -69,7 +69,7 @@
         flex-direction: row;
         align-items: center;
         font-size: 14px;
-        color: mat-color($foreground, text, 0.54);
+        color: mat-color($foreground, secondary-text);
         line-height: 48px;
         box-shadow: none;
         transform: none;
@@ -77,7 +77,7 @@
         font-weight: normal;
 
         &:hover {
-          color: mat-color($primary, A400);
+          color: mat-color($primary);
         }
       }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Texts in create menu lack contrast ratio for AA accessibility requirements.


**What is the new behaviour?**
When hovered buttons of the create menu take a primary color giving it enough contrast. 
Refactor some colors in secondary-text color.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2542