### PR TITLE
[ACA-2496] Refactor of color change for colum name

### DIFF
--- a/src/app/components/dl-custom-components/name-column/name-column.component.scss
+++ b/src/app/components/dl-custom-components/name-column/name-column.component.scss
@@ -16,12 +16,12 @@
 @mixin aca-custom-name-column-theme($theme) {
   $primary: map-get($theme, primary);
 
-  .aca-custom-name-column {
+  aca-custom-name-column {
     display: block;
     align-items: center;
 
     &:hover {
-      color: mat-color($primary, A200);
+      color: mat-color($primary, A200) !important;
     }
 
     .adf-datatable-cell-value {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
The new color isn't attributed to the right element in the column. This doesn't create any unexpected behaviour (the current element have the same size & position as the one that should be focused) but this way is cleaner.


**What is the new behaviour?**
The hover color is applied to the same element as in the adf component.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2496