### PR TITLE
[ACA-2994] Snackbar- notifications are displayed with wrong colours

### DIFF
--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -33,6 +33,10 @@ $foreground: map-get($custom-theme, foreground);
 $warn: map-get($custom-theme, warn);
 
 @mixin custom-theme($theme) {
+  @include angular-material-theme($theme);
+  @include adf-content-services-theme($theme);
+  @include adf-core-theme($theme);
+
   @include layout-theme($theme);
   @include aca-search-input-theme($theme);
   @include aca-result-row-theme($theme);
@@ -47,10 +51,6 @@ $warn: map-get($custom-theme, warn);
   @include app-create-from-template-theme($theme);
   @include app-create-menu-theme($theme);
   @include adf-style-fixes($theme);
-
-  @include angular-material-theme($theme);
-  @include adf-content-services-theme($theme);
-  @include adf-core-theme($theme);
 
   .mat-toolbar {
     color: var(--theme-text-color, rgba(0, 0, 0, 0.54));

--- a/src/app/ui/snackbar.scss
+++ b/src/app/ui/snackbar.scss
@@ -4,7 +4,7 @@
   $primary: map-get($theme, primary);
 
   .error-snackbar {
-    background-color: mat-color($warn);
+    background-color: mat-color($warn) !important;
 
     .mat-simple-snackbar-action {
       color: white;
@@ -12,7 +12,7 @@
   }
 
   .warning-snackbar {
-    background-color: mat-color($accent);
+    background-color: mat-color($accent) !important;
 
     .mat-simple-snackbar-action {
       color: white;
@@ -20,7 +20,7 @@
   }
 
   .info-snackbar {
-    background-color: mat-color($primary);
+    background-color: mat-color($primary) !important;
 
     .mat-simple-snackbar-action {
       color: white;

--- a/src/app/ui/snackbar.scss
+++ b/src/app/ui/snackbar.scss
@@ -4,7 +4,7 @@
   $primary: map-get($theme, primary);
 
   .error-snackbar {
-    background-color: mat-color($warn) !important;
+    background-color: mat-color($warn);
 
     .mat-simple-snackbar-action {
       color: white;
@@ -12,7 +12,7 @@
   }
 
   .warning-snackbar {
-    background-color: mat-color($accent) !important;
+    background-color: mat-color($accent);
 
     .mat-simple-snackbar-action {
       color: white;
@@ -20,7 +20,7 @@
   }
 
   .info-snackbar {
-    background-color: mat-color($primary) !important;
+    background-color: mat-color($primary);
 
     .mat-simple-snackbar-action {
       color: white;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ACA-2994](https://issues.alfresco.com/jira/browse/ACA-2994)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

the alternative to `!import`  is to specify component  class `.mat-snack-bar-container` to prevent colour override