### PR TITLE
[ACA-3257] Add actions extension capability to info drawer

### DIFF
--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -200,6 +200,7 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 - Add extra tabs with custom components
 - Disable tabs from the main application or extensions
 - Replace content or properties of existing tabs
+- Also add custom action button
 
 ```json
 {
@@ -209,6 +210,14 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 
   "features": {
     "sidebar": {
+      "actions": [
+            {
+              "id": "app.sidebar.close",
+              "order": 100,
+              "title": "close",
+              "icon": "highlight_off"
+            }
+      ],
       "tabs": [
             {
               "id": "app.sidebar.properties",
@@ -228,7 +237,7 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 }
 ```
 
-The example above renders two tabs:
+The example above renders two tabs with `close` icon:
 
 - `Properties` tab that references the `app.components.tabs.metadata` component
 - `Comments` tab that references the `app.components.tabs.comments` component

--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -210,7 +210,7 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 
   "features": {
     "sidebar": {
-      "actions": [
+      "toolbar": [
             {
               "id": "app.sidebar.close",
               "order": 100,

--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -200,7 +200,7 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 - Add extra tabs with custom components
 - Disable tabs from the main application or extensions
 - Replace content or properties of existing tabs
-- Also add toolbar
+- Add toolbar buttons
 
 ```json
 {

--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -208,20 +208,22 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
   "$name": "plugin1",
 
   "features": {
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "Properties",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "Comments",
-        "component": "app.components.tabs.comments"
-      }
-    ]
+    "sidebar": {
+      "tabs": [
+            {
+              "id": "app.sidebar.properties",
+              "order": 100,
+              "title": "Properties",
+              "component": "app.components.tabs.metadata"
+            },
+            {
+              "id": "app.sidebar.comments",
+              "order": 200,
+              "title": "Comments",
+              "component": "app.components.tabs.comments"
+            }
+      ]
+    }
   }
 }
 ```

--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -200,7 +200,7 @@ You can provide the following customizations for the Sidebar (aka Info Drawer) c
 - Add extra tabs with custom components
 - Disable tabs from the main application or extensions
 - Replace content or properties of existing tabs
-- Also add custom action button
+- Also add toolbar
 
 ```json
 {

--- a/docs/ja/extending/application-features.md
+++ b/docs/ja/extending/application-features.md
@@ -209,20 +209,22 @@ export interface NavBarLinkRef {
   "$name": "plugin1",
 
   "features": {
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "Properties",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "Comments",
-        "component": "app.components.tabs.comments"
-      }
-    ]
+    "sidebar": {
+      "tabs": [
+            {
+              "id": "app.sidebar.properties",
+              "order": 100,
+              "title": "Properties",
+              "component": "app.components.tabs.metadata"
+            },
+            {
+              "id": "app.sidebar.comments",
+              "order": 200,
+              "title": "Comments",
+              "component": "app.components.tabs.comments"
+            }
+      ]
+    }
   }
 }
 ```

--- a/e2e/resources/extensibility-configs/context-submenus-ext.json
+++ b/e2e/resources/extensibility-configs/context-submenus-ext.json
@@ -903,27 +903,29 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments"
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions"
-      }
-    ],
+    "sidebar": {
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata"
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments"
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions"
+        }
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/e2e/resources/extensibility-configs/document-presets-ext.json
+++ b/e2e/resources/extensibility-configs/document-presets-ext.json
@@ -821,27 +821,29 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments"
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions"
-      }
-    ],
+    "sidebar": {
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata"
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments"
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions"
+        }
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/e2e/resources/extensibility-configs/extensions-default.json
+++ b/e2e/resources/extensibility-configs/extensions-default.json
@@ -806,26 +806,28 @@
           }
         ]
       },
-      "sidebar": [
-        {
-          "id": "app.sidebar.properties",
-          "order": 100,
-          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-          "component": "app.components.tabs.metadata"
-        },
-        {
-          "id": "app.sidebar.comments",
-          "order": 200,
-          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-          "component": "app.components.tabs.comments"
-        },
-        {
-          "id": "app.sidebar.versions",
-          "order": 300,
-          "disabled": true,
-          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-          "component": "app.components.tabs.versions"
-        }
-      ]
+      "sidebar": {
+        "tabs":  [
+          {
+            "id": "app.sidebar.properties",
+            "order": 100,
+            "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+            "component": "app.components.tabs.metadata"
+          },
+          {
+            "id": "app.sidebar.comments",
+            "order": 200,
+            "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+            "component": "app.components.tabs.comments"
+          },
+          {
+            "id": "app.sidebar.versions",
+            "order": 300,
+            "disabled": true,
+            "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+            "component": "app.components.tabs.versions"
+          }
+        ]
+      }
     }
   }

--- a/e2e/resources/extensibility-configs/header-ext.json
+++ b/e2e/resources/extensibility-configs/header-ext.json
@@ -842,27 +842,29 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments"
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions"
-      }
-    ],
+    "sidebar": {
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata"
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments"
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions"
+        }
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/e2e/resources/extensibility-configs/info-drawer-ext.json
+++ b/e2e/resources/extensibility-configs/info-drawer-ext.json
@@ -1220,34 +1220,36 @@
         }
       ]
     },
-    "sidebar": [
-      {
+    "sidebar": {
+      "tabs": [
+        {
           "id": "app.sidebar.properties",
           "order": 1,
           "title": "MY PROPERTIES",
           "component": "app.components.tabs.metadata"
-      },
-      {
+        },
+        {
           "id": "app.sidebar.custom",
           "order": 2,
           "icon": "mood",
           "title": "MY CUSTOM TITLE",
           "component": "app.toolbar.toggleFavorite"
-      },
-      {
+        },
+        {
           "id": "app.sidebar.no_title",
           "order": 3,
           "icon": "check_circle",
           "component": "app.components.tabs.metadata"
-      },
-      {
+        },
+        {
           "id": "app.sidebar.comments",
           "order": 4,
           "disabled": true,
           "title": "APP.INFO_DRAWER.TABS.COMMENTS",
           "component": "app.components.tabs.comments"
-      }
-    ],
+        }
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/e2e/resources/extensibility-configs/metadata-ext.json
+++ b/e2e/resources/extensibility-configs/metadata-ext.json
@@ -841,27 +841,29 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata"
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments"
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions"
-      }
-    ],
+    "sidebar": {
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata"
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments"
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions"
+        }
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/e2e/resources/extensibility-configs/viewer-ext.json
+++ b/e2e/resources/extensibility-configs/viewer-ext.json
@@ -1244,45 +1244,47 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
+    "sidebar": {
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.library.properties",
+          "order": 500,
+          "title": "APP.INFO_DRAWER.TABS.LIBRARY_PROPERTIES",
+          "component": "app.components.tabs.library.metadata",
+          "rules": {
+            "visible": "app.libraries.toolbar"
+          }
         }
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
-        }
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
-        }
-      },
-      {
-        "id": "app.sidebar.library.properties",
-        "order": 500,
-        "title": "APP.INFO_DRAWER.TABS.LIBRARY_PROPERTIES",
-        "component": "app.components.tabs.library.metadata",
-        "rules": {
-          "visible": "app.libraries.toolbar"
-        }
-      }
-    ],
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",

--- a/extension.schema.json
+++ b/extension.schema.json
@@ -803,9 +803,18 @@
         },
         "sidebar": {
           "description": "Sidebar extensions",
-          "type": "array",
-          "items": { "$ref": "#/definitions/sidebarTabRef" },
-          "minItems": 1
+          "type": "object",
+          "properties": {
+            "actions": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/contentActionRef" }
+            },
+            "tabs": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/sidebarTabRef" },
+              "minItems": 1
+            }
+          }
         },
         "toolbar": {
           "description": "Toolbar entries",

--- a/extension.schema.json
+++ b/extension.schema.json
@@ -805,11 +805,13 @@
           "description": "Sidebar extensions",
           "type": "object",
           "properties": {
-            "actions": {
+            "toolbar": {
+              "description": "Toolbar entries",
               "type": "array",
               "items": { "$ref": "#/definitions/contentActionRef" }
             },
             "tabs": {
+              "description": "Tabs entries",
               "type": "array",
               "items": { "$ref": "#/definitions/sidebarTabRef" },
               "minItems": 1

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.html
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.html
@@ -7,9 +7,11 @@
     cdkTrapFocus
     cdkTrapFocusAutoCapture
   >
-    <info-drawer-buttons>
-      <button mat-raised-button color="primary">Primary</button>
-    </info-drawer-buttons>
+    <adf-toolbar class="adf-toolbar--inline" info-drawer-buttons>
+      <ng-container *ngFor="let entry of actions; trackBy: trackByActionId">
+        <aca-toolbar-action [actionRef]="entry"></aca-toolbar-action>
+      </ng-container>
+    </adf-toolbar>
 
     <adf-info-drawer-tab
       *ngFor="let tab of tabs"

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.html
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.html
@@ -7,6 +7,10 @@
     cdkTrapFocus
     cdkTrapFocusAutoCapture
   >
+    <info-drawer-buttons>
+      <button mat-raised-button color="primary">Primary</button>
+    </info-drawer-buttons>
+
     <adf-info-drawer-tab
       *ngFor="let tab of tabs"
       [icon]="tab.icon"

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
@@ -22,18 +22,17 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
+import { ContentActionRef } from '@alfresco/adf-extensions';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { InfoDrawerComponent } from './info-drawer.component';
-import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
-import {
-  SetInfoDrawerStateAction,
-  ToggleInfoDrawerAction
-} from '@alfresco/aca-shared/store';
+import { SetInfoDrawerStateAction, ToggleInfoDrawerAction } from '@alfresco/aca-shared/store';
+import { of, Subject } from 'rxjs';
+import { InfoDrawerComponent } from './info-drawer.component';
 import { LibTestingModule } from '../../testing/lib-testing-module';
 import { AppExtensionService } from '../../services/app.extension.service';
 import { ContentApiService } from '../../services/content-api.service';
-import { of } from 'rxjs';
+import { SharedToolbarModule } from '../tool-bar/shared-toolbar.module';
 
 describe('InfoDrawerComponent', () => {
   let fixture: ComponentFixture<InfoDrawerComponent>;
@@ -41,16 +40,24 @@ describe('InfoDrawerComponent', () => {
   let contentApiService: ContentApiService;
   let tab;
   let appExtensionService: AppExtensionService;
+  const mockStream = new Subject();
   const storeMock = {
-    dispatch: jasmine.createSpy('dispatch')
+    dispatch: jasmine.createSpy('dispatch'),
+    select: () => mockStream,
   };
   const extensionServiceMock = {
-    getSidebarTabs: () => {}
+    getSidebarTabs: () => {},
+    getAllowedInfoDrawerActions: () => [{
+      "id": "app.sidebar.close",
+      "order": 100,
+      "title": "close",
+      "icon": "highlight_off"
+    }]
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LibTestingModule],
+      imports: [LibTestingModule, SharedToolbarModule],
       declarations: [InfoDrawerComponent],
       providers: [
         ContentApiService,
@@ -165,5 +172,16 @@ describe('InfoDrawerComponent', () => {
     expect(storeMock.dispatch).toHaveBeenCalledWith(
       new ToggleInfoDrawerAction()
     );
+  });
+
+  it('should show the icons from extension', () => {
+    fixture.detectChanges();
+    mockStream.next();
+    expect(component.actions).toEqual([{
+      "id": "app.sidebar.close",
+      "order": 100,
+      "title": "close",
+      "icon": "highlight_off"
+    } as ContentActionRef]);
   });
 });

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
@@ -50,7 +50,7 @@ describe('InfoDrawerComponent', () => {
   };
   const extensionServiceMock = {
     getSidebarTabs: () => {},
-    getAllowedInfoDrawerActions: () => [
+    getAllowedSidebarActions: () => [
       {
         id: 'app.sidebar.close',
         order: 100,

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
@@ -26,7 +26,10 @@ import { ContentActionRef } from '@alfresco/adf-extensions';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
-import { SetInfoDrawerStateAction, ToggleInfoDrawerAction } from '@alfresco/aca-shared/store';
+import {
+  SetInfoDrawerStateAction,
+  ToggleInfoDrawerAction
+} from '@alfresco/aca-shared/store';
 import { of, Subject } from 'rxjs';
 import { InfoDrawerComponent } from './info-drawer.component';
 import { LibTestingModule } from '../../testing/lib-testing-module';
@@ -43,16 +46,18 @@ describe('InfoDrawerComponent', () => {
   const mockStream = new Subject();
   const storeMock = {
     dispatch: jasmine.createSpy('dispatch'),
-    select: () => mockStream,
+    select: () => mockStream
   };
   const extensionServiceMock = {
     getSidebarTabs: () => {},
-    getAllowedInfoDrawerActions: () => [{
-      "id": "app.sidebar.close",
-      "order": 100,
-      "title": "close",
-      "icon": "highlight_off"
-    }]
+    getAllowedInfoDrawerActions: () => [
+      {
+        id: 'app.sidebar.close',
+        order: 100,
+        title: 'close',
+        icon: 'highlight_off'
+      }
+    ]
   };
 
   beforeEach(() => {
@@ -177,11 +182,13 @@ describe('InfoDrawerComponent', () => {
   it('should show the icons from extension', () => {
     fixture.detectChanges();
     mockStream.next();
-    expect(component.actions).toEqual([{
-      "id": "app.sidebar.close",
-      "order": 100,
-      "title": "close",
-      "icon": "highlight_off"
-    } as ContentActionRef]);
+    expect(component.actions).toEqual([
+      {
+        id: 'app.sidebar.close',
+        order: 100,
+        title: 'close',
+        icon: 'highlight_off'
+      } as ContentActionRef
+    ]);
   });
 });

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
@@ -81,7 +81,7 @@ export class InfoDrawerComponent implements OnChanges, OnInit, OnDestroy {
       .select(getAppSelection)
       .pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {
-        this.actions = this.extensions.getAllowedInfoDrawerActions();
+        this.actions = this.extensions.getAllowedSidebarActions();
       });
   }
 

--- a/projects/aca-shared/src/lib/components/info-drawer/shared-info-drawer.module.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/shared-info-drawer.module.ts
@@ -26,16 +26,19 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InfoDrawerComponent } from './info-drawer.component';
-import { InfoDrawerModule } from '@alfresco/adf-core';
+import { InfoDrawerModule, ToolbarModule } from '@alfresco/adf-core';
 import { ExtensionsModule } from '@alfresco/adf-extensions';
 import { MatProgressBarModule } from '@angular/material';
+import { SharedToolbarModule } from '../tool-bar/shared-toolbar.module';
 
 @NgModule({
   imports: [
     CommonModule,
     InfoDrawerModule,
     MatProgressBarModule,
-    ExtensionsModule
+    ExtensionsModule,
+    ToolbarModule,
+    SharedToolbarModule
   ],
   declarations: [InfoDrawerComponent],
   exports: [InfoDrawerComponent]

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -166,7 +166,7 @@ export class AppExtensionService implements RuleContext {
     );
     this.sidebarActions = this.loader.getContentActions(
       config,
-      'features.sidebar.actions'
+      'features.sidebar.toolbar'
     );
     this.toolbarActions = this.loader.getContentActions(
       config,
@@ -491,7 +491,7 @@ export class AppExtensionService implements RuleContext {
       .reduce(reduceSeparators, []);
   }
 
-  getAllowedInfoDrawerActions(): Array<ContentActionRef> {
+  getAllowedSidebarActions(): Array<ContentActionRef> {
     return this.getAllowedActions(this.sidebarActions);
   }
 

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -83,7 +83,8 @@ export class AppExtensionService implements RuleContext {
   openWithActions: Array<ContentActionRef> = [];
   createActions: Array<ContentActionRef> = [];
   navbar: Array<NavBarGroupRef> = [];
-  sidebar: Array<SidebarTabRef> = [];
+  sidebarTabs: Array<SidebarTabRef> = [];
+  sidebarActions: Array<ContentActionRef> = [];
   contentMetadata: any;
   viewerRules: ViewerRules = {};
   userActions: Array<ContentActionRef> = [];
@@ -163,6 +164,10 @@ export class AppExtensionService implements RuleContext {
       config,
       'features.header'
     );
+    this.sidebarActions = this.loader.getContentActions(
+      config,
+      'features.sidebar.actions'
+    );
     this.toolbarActions = this.loader.getContentActions(
       config,
       'features.toolbar'
@@ -189,9 +194,9 @@ export class AppExtensionService implements RuleContext {
       'features.create'
     );
     this.navbar = this.loadNavBar(config);
-    this.sidebar = this.loader.getElements<SidebarTabRef>(
+    this.sidebarTabs = this.loader.getElements<SidebarTabRef>(
       config,
-      'features.sidebar'
+      'features.sidebar.tabs'
     );
     this.userActions = this.loader.getContentActions(
       config,
@@ -382,7 +387,7 @@ export class AppExtensionService implements RuleContext {
   }
 
   getSidebarTabs(): Array<SidebarTabRef> {
-    return this.sidebar.filter(action => this.filterVisible(action));
+    return this.sidebarTabs.filter(action => this.filterVisible(action));
   }
 
   getComponentById(id: string): Type<{}> {
@@ -484,6 +489,10 @@ export class AppExtensionService implements RuleContext {
       })
       .reduce(reduceEmptyMenus, [])
       .reduce(reduceSeparators, []);
+  }
+
+  getAllowedInfoDrawerActions(): Array<ContentActionRef> {
+    return this.getAllowedActions(this.sidebarActions);
   }
 
   getAllowedToolbarActions(): Array<ContentActionRef> {

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -1008,7 +1008,6 @@
       ]
     },
     "sidebar": {
-      "actions": [],
       "tabs": [
         {
           "id": "app.sidebar.properties",

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -1007,45 +1007,48 @@
         }
       ]
     },
-    "sidebar": [
-      {
-        "id": "app.sidebar.properties",
-        "order": 100,
-        "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
-        "component": "app.components.tabs.metadata",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
+    "sidebar": {
+      "actions": [],
+      "tabs": [
+        {
+          "id": "app.sidebar.properties",
+          "order": 100,
+          "title": "APP.INFO_DRAWER.TABS.PROPERTIES",
+          "component": "app.components.tabs.metadata",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.comments",
+          "order": 200,
+          "title": "APP.INFO_DRAWER.TABS.COMMENTS",
+          "component": "app.components.tabs.comments",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.versions",
+          "order": 300,
+          "disabled": true,
+          "title": "APP.INFO_DRAWER.TABS.VERSIONS",
+          "component": "app.components.tabs.versions",
+          "rules": {
+            "visible": "app.navigation.isNotLibraries"
+          }
+        },
+        {
+          "id": "app.sidebar.library.properties",
+          "order": 500,
+          "title": "APP.INFO_DRAWER.TABS.LIBRARY_PROPERTIES",
+          "component": "app.components.tabs.library.metadata",
+          "rules": {
+            "visible": "app.selection.library"
+          }
         }
-      },
-      {
-        "id": "app.sidebar.comments",
-        "order": 200,
-        "title": "APP.INFO_DRAWER.TABS.COMMENTS",
-        "component": "app.components.tabs.comments",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
-        }
-      },
-      {
-        "id": "app.sidebar.versions",
-        "order": 300,
-        "disabled": true,
-        "title": "APP.INFO_DRAWER.TABS.VERSIONS",
-        "component": "app.components.tabs.versions",
-        "rules": {
-          "visible": "app.navigation.isNotLibraries"
-        }
-      },
-      {
-        "id": "app.sidebar.library.properties",
-        "order": 500,
-        "title": "APP.INFO_DRAWER.TABS.LIBRARY_PROPERTIES",
-        "component": "app.components.tabs.library.metadata",
-        "rules": {
-          "visible": "app.selection.library"
-        }
-      }
-    ],
+      ]
+    },
     "content-metadata-presets": [
       {
         "id": "app.content.metadata.custom",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-3257

**What is the new behaviour?**

![image](https://user-images.githubusercontent.com/14145706/82210964-a5a73c00-992d-11ea-8b73-99413dda8446.png)


Able to create/extend the info drawer actions.



**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

In app-extension.json

```features": {
    "sidebar": {
      "actions": [ // new property added
            {
              "id": "app.sidebar.close",
              "order": 100,
              "title": "close",
              "icon": "highlight_off"
            }
      ],
      "tabs": [ // tabs extension moved here
            {
              "id": "app.sidebar.properties",
              "order": 100,
              "title": "Properties",
              "component": "app.components.tabs.metadata"
            },
            {
              "id": "app.sidebar.comments",
              "order": 200,
              "title": "Comments",
              "component": "app.components.tabs.comments"
            }
      ]
    }
  }
}

```

features.sidebar converted array object. If you are consuming, create object property called `tabs` and move all the tabs related extension there.