### PR TITLE
[ACA-1992] Keep favorite libraries navigation under same path

### DIFF
--- a/projects/aca-shared/store/src/actions/library.actions.ts
+++ b/projects/aca-shared/store/src/actions/library.actions.ts
@@ -47,7 +47,7 @@ export class CreateLibraryAction implements Action {
 export class NavigateLibraryAction implements Action {
   readonly type = LibraryActionTypes.Navigate;
 
-  constructor(public payload?: string) {}
+  constructor(public payload?: string, public route?: string) {}
 }
 
 export class UpdateLibraryAction implements Action {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -212,15 +212,47 @@ export const APP_ROUTES: Routes = [
         ]
       },
       {
-        path: 'favorite/libraries',
+        path: 'favorite',
         children: [
           {
             path: '',
+            pathMatch: 'full',
+            redirectTo: 'libraries'
+          },
+          {
+            path: 'libraries',
             component: FavoriteLibrariesComponent,
             data: {
               title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
               sortingPreferenceKey: 'favorite-libraries'
             }
+          }
+        ]
+      },
+      {
+        path: 'favorite/libraries/:folderId',
+        children: [
+          {
+            path: '',
+            component: FilesComponent,
+            data: {
+              title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
+              sortingPreferenceKey: 'libraries-files'
+            }
+          },
+          {
+            path: 'view/:nodeId',
+            outlet: 'viewer',
+            children: [
+              {
+                path: '',
+                data: {
+                  navigateSource: 'libraries'
+                },
+                loadChildren:
+                  './components/viewer/viewer.module#AppViewerModule'
+              }
+            ]
           }
         ]
       },

--- a/src/app/components/favorite-libraries/favorite-libraries.component.spec.ts
+++ b/src/app/components/favorite-libraries/favorite-libraries.component.spec.ts
@@ -144,7 +144,10 @@ describe('FavoriteLibrariesComponent', () => {
       spyOn(router, 'navigate').and.stub();
       component.navigateTo({ entry: { guid: 'guid' } } as any);
 
-      expect(router.navigate).toHaveBeenCalledWith(['libraries', 'libraryId']);
+      expect(router.navigate).toHaveBeenCalledWith([
+        'favorite/libraries',
+        'libraryId'
+      ]);
     });
   });
 

--- a/src/app/components/favorite-libraries/favorite-libraries.component.ts
+++ b/src/app/components/favorite-libraries/favorite-libraries.component.ts
@@ -82,7 +82,9 @@ export class FavoriteLibrariesComponent extends PageComponent
 
   navigateTo(node: SiteEntry) {
     if (node && node.entry && node.entry.guid) {
-      this.store.dispatch(new NavigateLibraryAction(node.entry.guid));
+      this.store.dispatch(
+        new NavigateLibraryAction(node.entry.guid, 'favorite/libraries')
+      );
     }
   }
 

--- a/src/app/store/effects/library.effects.ts
+++ b/src/app/store/effects/library.effects.ts
@@ -107,7 +107,8 @@ export class LibraryEffects {
           .pipe(map(node => node.entry.id))
           .subscribe(
             id => {
-              this.store.dispatch(new NavigateRouteAction(['libraries', id]));
+              const route = action.route ? action.route : 'libraries';
+              this.store.dispatch(new NavigateRouteAction([route, id]));
             },
             () => {
               this.store.dispatch(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-1992


**What is the new behaviour?**
Until now, when a user selected a library from the Favorite Libraries section he would be redirected to libraries (My Libraries) which loads the Files component. This way the user would lose track of where he was as the browser url and the breadcrumb where pointing to a different place.

Now, when the user navigates through his favorite libraries everything stays under the same path providing this way a useful and working breadcrumb.

<img width="818" alt="Screen Shot 2020-05-19 at 11 30 00" src="https://user-images.githubusercontent.com/18293044/82316016-1ac55080-99c4-11ea-8395-687794191584.png">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
