### PR TITLE
[ACA-2582]- fix: proper menuitem aria for screen reader users

### DIFF
--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.html
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.html
@@ -30,9 +30,9 @@
   <ng-container *ngSwitchDefault>
     <button
       [id]="actionRef.id"
-      role="button"
+      role="menuItem"
       mat-menu-item
-      [role]="'button'"
+      [role]="'menuItem'"
       color="primary"
       [disabled]="actionRef.disabled"
       [attr.title]="


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently each item in the menu is announcing as a button. 


**What is the new behaviour?**
Each item will now announce as a menuitem. Please note, that screen reader users will know that when a menuitem is read it is actionable, so role of button is not needed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
