### PR TITLE
Edit Online for XLAM files

### DIFF
--- a/projects/adf-office-services-ext/src/lib/utils.ts
+++ b/projects/adf-office-services-ext/src/lib/utils.ts
@@ -38,6 +38,7 @@ export const supportedExtensions = {
   xlt: 'ms-excel',
   xltx: 'ms-excel',
   xltm: 'ms-excel',
+  xlam: 'ms-excel',
   ppt: 'ms-powerpoint',
   pptx: 'ms-powerpoint',
   pot: 'ms-powerpoint',


### PR DESCRIPTION
> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
XLAM files are cannot be edited online 


**What is the new behaviour?**
Similar to PPAM files (for MS Powerpoint), those are Macro-Enabled Add-ins for MS Excel and can now be opened


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
