### PR TITLE
Fix FilterSearch import path

### DIFF
--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -35,8 +35,7 @@ import { AppExtensionService, ContentApiService } from '@alfresco/aca-shared';
 import { SetCurrentFolderAction, isAdmin, AppStore, UploadFileVersionAction } from '@alfresco/aca-shared/store';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { ShareDataRow } from '@alfresco/adf-content-services';
-import { FilterSearch } from '@alfresco/adf-content-services/lib/search/filter-search.interface';
+import { FilterSearch, ShareDataRow } from '@alfresco/adf-content-services';
 
 @Component({
   templateUrl: './files.component.html'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
ERROR in apps/content-ce/src/app/components/files/files.component.ts:39:30 - error TS2307: Cannot find module '@alfresco/adf-content-services/lib/search/filter-search.interface' or its corresponding type declarations.
39 import { FilterSearch } from '@alfresco/adf-content-services/lib/search/filter-search.interface';


**What is the new behaviour?**
Fix import path for FilterSearch


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
