### PR TITLE
[ACA-4045] Show Document List header if filter header is active

### DIFF
--- a/src/app/components/files/files.component.html
+++ b/src/app/components/files/files.component.html
@@ -68,6 +68,16 @@
               </ng-container>
             </ng-container>
           </data-columns>
+
+          <adf-custom-empty-content-template *ngIf="isFilterHeaderActive()">
+            <ng-container>
+              <div class="empty-search__block">
+                <p class="empty-search__text">
+                  {{ 'APP.BROWSE.SEARCH.NO_FILTER_RESULTS' | translate }}
+                </p>
+              </div>
+            </ng-container>
+          </adf-custom-empty-content-template>
         </adf-document-list>
 
         <adf-pagination acaPagination [target]="documentList"> </adf-pagination>

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -32,14 +32,16 @@ import {
   UploadService,
   AppConfigPipe,
   AlfrescoApiService,
-  AlfrescoApiServiceMock
+  AlfrescoApiServiceMock,
+  DataTableModule
 } from '@alfresco/adf-core';
-import { DocumentListComponent } from '@alfresco/adf-content-services';
+import { DocumentListComponent, FilterSearch } from '@alfresco/adf-content-services';
 import { NodeActionsService } from '../../services/node-actions.service';
 import { FilesComponent } from './files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { of, throwError } from 'rxjs';
+import { By } from '@angular/platform-browser';
 
 describe('FilesComponent', () => {
   let node;
@@ -55,7 +57,7 @@ describe('FilesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AppTestingModule],
+      imports: [AppTestingModule, DataTableModule],
       declarations: [FilesComponent, DataTableComponent, NodeFavoriteDirective, DocumentListComponent, AppConfigPipe],
       providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
@@ -297,6 +299,20 @@ describe('FilesComponent', () => {
       const mock: any = { aspectNames: ['st:siteContainer'] };
 
       expect(component.isSiteContainer(mock)).toBe(true);
+    });
+  });
+
+  fdescribe('filter header', () => {
+    it('should show custom empty template if filter headers are applied', async () => {
+      fixture.detectChanges();
+      spyOn(component.documentList, 'loadFolder').and.callFake(() => {});
+      component.onFilterSelected([{ key: 'name', value: 'aaa' } as FilterSearch]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const emptyContentTemplate: HTMLElement = fixture.debugElement.query(By.css('.empty-search__block')).nativeElement;
+      expect(emptyContentTemplate).toBeDefined();
+      expect(emptyContentTemplate.innerText).toBe('APP.BROWSE.SEARCH.NO_FILTER_RESULTS');
     });
   });
 });

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -302,7 +302,7 @@ describe('FilesComponent', () => {
     });
   });
 
-  fdescribe('filter header', () => {
+  describe('filter header', () => {
     it('should show custom empty template if filter headers are applied', async () => {
       fixture.detectChanges();
       spyOn(component.documentList, 'loadFolder').and.callFake(() => {});

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { FileUploadEvent, UploadService } from '@alfresco/adf-core';
+import { FileUploadEvent, ShowHeaderMode, UploadService } from '@alfresco/adf-core';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -293,8 +293,10 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
 
   onFilterSelected(activeFilters: FilterSearch[]) {
     if (activeFilters.length) {
+      this.showHeader = ShowHeaderMode.Always;
       this.navigateToFilter(activeFilters);
     } else {
+      this.showHeader = ShowHeaderMode.Data;
       this.onAllFilterCleared();
     }
   }
@@ -312,5 +314,9 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     });
 
     this.router.navigate([], { relativeTo: this.route, queryParams: objectFromMap });
+  }
+
+  isFilterHeaderActive(): boolean {
+    return this.showHeader === ShowHeaderMode.Always;
   }
 }

--- a/src/app/testing/translation.service.ts
+++ b/src/app/testing/translation.service.ts
@@ -30,7 +30,7 @@ import { Observable, of } from 'rxjs';
 @Injectable()
 export class TranslateServiceMock extends TranslateService {
   constructor() {
-    super(null, null, null, null, null, null, null, null, null);
+    super(null, null, null, null, null, null, true, null, null);
   }
 
   get(key: string | Array<string> /*,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -175,6 +175,7 @@
                 },
                 "UNKNOWN_LOCATION": "Unknown",
                 "NO_RESULTS": "Your search returned 0 results",
+                "NO_FILTER_RESULTS": "Your filter returned 0 results",
                 "TOGGLE_SEARCH_FILTER": "Toggle search filter",
                 "ERRORS": {
                     "500": "There was an error processing the search query [500]",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-4045


**What is the new behaviour?**
Show Document List header if filter header is active
<img width="1680" alt="Screen Shot 2020-10-12 at 16 23 56" src="https://user-images.githubusercontent.com/18293044/95759047-7fea4d00-0ca9-11eb-9f7b-c7ff8339d223.png">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
