### PR TITLE
[ACA-4038] Fix Description error message not showing

### DIFF
--- a/src/app/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/src/app/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -1,8 +1,6 @@
 <mat-card *ngIf="node">
   <mat-card-content *ngIf="!edit">
-    <div
-      class="mat-form-field mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width"
-    >
+    <div class="mat-form-field mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width">
       <div class="mat-form-field-wrapper">
         <div class="mat-form-field-flex">
           <div class="mat-form-field-infix">
@@ -20,9 +18,7 @@
       </div>
     </div>
 
-    <div
-      class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width"
-    >
+    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width">
       <div class="mat-form-field-wrapper">
         <div class="mat-form-field-flex">
           <div class="mat-form-field-infix">
@@ -40,9 +36,7 @@
       </div>
     </div>
 
-    <div
-      class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width"
-    >
+    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width">
       <div class="mat-form-field-wrapper">
         <div class="mat-form-field-flex">
           <div class="mat-form-field-infix">
@@ -53,18 +47,14 @@
             </span>
 
             <span class="mat-input-element">
-              {{
-                getVisibilityLabel(form.controls.visibility.value) | translate
-              }}
+              {{ getVisibilityLabel(form.controls.visibility.value) | translate }}
             </span>
           </div>
         </div>
       </div>
     </div>
 
-    <div
-      class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width"
-    >
+    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float adf-full-width">
       <div class="mat-form-field-wrapper">
         <div class="mat-form-field-flex">
           <div class="mat-form-field-infix">
@@ -98,29 +88,20 @@
           required
           placeholder="{{ 'LIBRARY.DIALOG.FORM.NAME' | translate }}"
           formControlName="title"
+          [errorStateMatcher]="matcher"
         />
-
-        <mat-hint *ngIf="libraryTitleExists">{{
-          'LIBRARY.HINTS.SITE_TITLE_EXISTS' | translate
-        }}</mat-hint>
-        <mat-error *ngIf="form.controls['title'].hasError('maxlength')">
+        <mat-hint *ngIf="libraryTitleExists">{{ 'LIBRARY.HINTS.SITE_TITLE_EXISTS' | translate }}</mat-hint>
+        <mat-error>
           {{ 'LIBRARY.ERRORS.TITLE_TOO_LONG' | translate }}
         </mat-error>
       </mat-form-field>
 
       <mat-form-field class="adf-full-width">
-        <input
-          matInput
-          placeholder="{{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}"
-          formControlName="id"
-        />
+        <input matInput placeholder="{{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}" formControlName="id" />
       </mat-form-field>
 
       <mat-form-field class="adf-full-width">
-        <mat-select
-          placeholder="{{ 'LIBRARY.DIALOG.FORM.VISIBILITY' | translate }}"
-          formControlName="visibility"
-        >
+        <mat-select placeholder="{{ 'LIBRARY.DIALOG.FORM.VISIBILITY' | translate }}" formControlName="visibility">
           <mat-option [value]="type.value" *ngFor="let type of libraryType">
             {{ type.label | translate }}
           </mat-option>
@@ -133,9 +114,9 @@
           placeholder="{{ 'LIBRARY.DIALOG.FORM.DESCRIPTION' | translate }}"
           rows="3"
           formControlName="description"
+          [errorStateMatcher]="matcher"
         ></textarea>
-
-        <mat-error *ngIf="form.controls['description'].hasError('maxlength')">
+        <mat-error>
           {{ 'LIBRARY.ERRORS.DESCRIPTION_TOO_LONG' | translate }}
         </mat-error>
       </mat-form-field>
@@ -146,12 +127,7 @@
     <button mat-button color="secondary" (click)="cancel()">
       {{ 'LIBRARY.DIALOG.CANCEL' | translate }}
     </button>
-    <button
-      mat-button
-      color="primary"
-      [disabled]="form.invalid || form.pristine"
-      (click)="update()"
-    >
+    <button mat-button color="primary" [disabled]="form.invalid || form.pristine" (click)="update()">
       {{ 'LIBRARY.DIALOG.UPDATE' | translate }}
     </button>
   </mat-card-actions>

--- a/src/app/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/src/app/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -24,13 +24,21 @@
  */
 
 import { Component, Input, OnInit, OnChanges, OnDestroy } from '@angular/core';
-import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { FormGroup, FormControl, Validators, FormGroupDirective, NgForm } from '@angular/forms';
 import { SiteEntry, SitePaging } from '@alfresco/js-api';
 import { Store } from '@ngrx/store';
 import { AppStore, UpdateLibraryAction } from '@alfresco/aca-shared/store';
 import { debounceTime, mergeMap, takeUntil } from 'rxjs/operators';
 import { AlfrescoApiService } from '@alfresco/adf-core';
 import { Observable, from, Subject } from 'rxjs';
+import { ErrorStateMatcher } from '@angular/material/core';
+
+export class InstantErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted));
+  }
+}
 
 @Component({
   selector: 'app-library-metadata-form',
@@ -55,6 +63,8 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
     description: new FormControl({ value: '' }, [Validators.maxLength(512)]),
     visibility: new FormControl(this.libraryType[0].value)
   });
+
+  matcher = new InstantErrorStateMatcher();
 
   onDestroy$: Subject<boolean> = new Subject<boolean>();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4038


**What is the new behaviour?**
The Description error message was failing to be displayed unless the user clicked outside the field (on blur). A new matcher has been added to trigger the error as soon as it's produced without needing to click outside.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
