### PR TITLE
[ACA-3729] Join library action for Admin Users

### DIFF
--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -26,6 +26,7 @@
 import { RuleContext } from '@alfresco/adf-extensions';
 import * as navigation from './navigation.rules';
 import * as repository from './repository.rules';
+import { isAdmin } from './user.rules';
 
 export interface AcaRuleContext extends RuleContext {
   withCredentials: boolean;
@@ -81,7 +82,10 @@ export function canShareFile(context: RuleContext): boolean {
  * JSON ref: `canToggleJoinLibrary`
  */
 export function canToggleJoinLibrary(context: RuleContext): boolean {
-  return [hasLibrarySelected(context), !isPrivateLibrary(context), hasNoLibraryRole(context)].every(Boolean);
+  return (
+    [hasLibrarySelected(context), !isPrivateLibrary(context), hasNoLibraryRole(context)].every(Boolean) ||
+    [hasLibrarySelected(context), isPrivateLibrary(context), hasNoLibraryRole(context), isAdmin(context)].every(Boolean)
+  );
 }
 
 /**

--- a/projects/aca-shared/store/src/actions/library.actions.ts
+++ b/projects/aca-shared/store/src/actions/library.actions.ts
@@ -31,7 +31,8 @@ export enum LibraryActionTypes {
   Create = 'CREATE_LIBRARY',
   Navigate = 'NAVIGATE_LIBRARY',
   Update = 'UPDATE_LIBRARY',
-  Leave = 'LEAVE_LIBRARY'
+  Leave = 'LEAVE_LIBRARY',
+  Reload = 'RELOAD_LIBRARY'
 }
 
 export class DeleteLibraryAction implements Action {
@@ -60,4 +61,7 @@ export class LeaveLibraryAction implements Action {
   readonly type = LibraryActionTypes.Leave;
 
   constructor(public payload?: string) {}
+}
+export class ReloadLibraryAction implements Action {
+  readonly type = LibraryActionTypes.Reload;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,7 +79,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.alfrescoApiService.getInstance().on('error', (error: { status: number; response: any }) => {
-      if (error.status === 401 && !this.alfrescoApiService.isExcludedErrorListener(error?.response?.req?.url)) {
+      if (error.status === 401) {
         if (!this.authenticationService.isLoggedIn()) {
           this.store.dispatch(new CloseModalDialogsAction());
 

--- a/src/app/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
+++ b/src/app/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
@@ -23,8 +23,16 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppStore, SetSelectedNodesAction, SnackbarErrorAction, SnackbarInfoAction, getAppSelection } from '@alfresco/aca-shared/store';
-import { SelectionState } from '@alfresco/adf-extensions';
+import {
+  AppStore,
+  SetSelectedNodesAction,
+  SnackbarErrorAction,
+  SnackbarInfoAction,
+  getAppSelection,
+  getUserProfile,
+  ReloadLibraryAction
+} from '@alfresco/aca-shared/store';
+import { ProfileState, SelectionState } from '@alfresco/adf-extensions';
 import { Component, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
@@ -41,6 +49,7 @@ import { ContentManagementService } from '../../../services/content-management.s
       (toggle)="onToggleEvent($event)"
       (error)="onErrorEvent($event)"
       [acaLibraryMembership]="(selection$ | async).library"
+      [isAdmin]="(profile$ | async).isAdmin"
       [attr.title]="(membership.isJoinRequested | async) ? ('APP.ACTIONS.CANCEL_JOIN' | translate) : ('APP.ACTIONS.JOIN' | translate)"
     >
       <mat-icon *ngIf="membership.isJoinRequested | async">cancel</mat-icon>
@@ -52,9 +61,11 @@ import { ContentManagementService } from '../../../services/content-management.s
 })
 export class ToggleJoinLibraryButtonComponent {
   selection$: Observable<SelectionState>;
+  profile$: Observable<ProfileState>;
 
   constructor(private store: Store<AppStore>, private content: ContentManagementService) {
     this.selection$ = this.store.select(getAppSelection);
+    this.profile$ = this.store.select(getUserProfile);
   }
 
   onToggleEvent(event: LibraryMembershipToggleEvent) {
@@ -62,6 +73,7 @@ export class ToggleJoinLibraryButtonComponent {
 
     if (event.shouldReload) {
       this.content.libraryJoined.next();
+      this.store.dispatch(new ReloadLibraryAction());
     } else {
       if (event.updatedEntry) {
         this.store.dispatch(new SetSelectedNodesAction([{ entry: event.updatedEntry, isLibrary: true } as any]));

--- a/src/app/components/toolbar/toggle-join-library/toggle-join-library.component.spec.ts
+++ b/src/app/components/toolbar/toggle-join-library/toggle-join-library.component.spec.ts
@@ -29,7 +29,7 @@ import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
 import { LibraryMembershipDirective } from '../../../directives/library-membership.directive';
 import { Store } from '@ngrx/store';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { SnackbarErrorAction, SnackbarInfoAction } from '@alfresco/aca-shared/store';
+import { ReloadLibraryAction, SnackbarErrorAction, SnackbarInfoAction } from '@alfresco/aca-shared/store';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 import { ContentManagementService } from '../../../services/content-management.service';
 import { ToggleJoinLibraryButtonComponent } from './toggle-join-library-button.component';
@@ -96,6 +96,13 @@ describe('ToggleJoinLibraryComponent', () => {
     component.onToggleEvent(event);
 
     expect(storeMock.dispatch).toHaveBeenCalledWith(new SnackbarInfoAction(event.i18nKey));
+  });
+
+  it('should dispatch `ReloadLibraryAction` action on onToggleEvent', () => {
+    const event = { shouldReload: true, i18nKey: 'SOME_i18nKey' };
+    component.onToggleEvent(event);
+
+    expect(storeMock.dispatch).toHaveBeenCalledWith(new ReloadLibraryAction());
   });
 
   it('should call libraryJoined.next on contentManagementService onToggleEvent', (done) => {

--- a/src/app/store/effects/library.effects.ts
+++ b/src/app/store/effects/library.effects.ts
@@ -33,7 +33,8 @@ import {
   NavigateRouteAction,
   SnackbarErrorAction,
   UpdateLibraryAction,
-  getAppSelection
+  getAppSelection,
+  ReloadLibraryAction
 } from '@alfresco/aca-shared/store';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
@@ -86,6 +87,7 @@ export class LibraryEffects {
             }
           });
       }
+      this.store.dispatch(new ReloadLibraryAction());
     })
   );
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-3729


**What is the new behaviour?**
At the moment admin users have to ask for permission to join a library. This should not be the case as admin users can join any library directly as a consumer. 

This PR brings that functionality. It'll stay the same for normal users, sending an invitation to join a library. In the case of Admin users they will be able to join directly.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
