### PR TITLE
[ACA-4224] DocumentList - clear filterers action renders previous selection toolbar actions

### DIFF
--- a/src/app/directives/document-list.directive.spec.ts
+++ b/src/app/directives/document-list.directive.spec.ts
@@ -151,11 +151,12 @@ describe('DocumentListDirective', () => {
     expect(storeMock.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([]));
   });
 
-  it('should reset store selection and document list on `reset` event', () => {
+  it('should reset selection state on `reset` event', () => {
     documentListDirective.ngOnInit();
-    contentManagementServiceMock.reload.next();
+    contentManagementServiceMock.reset.next();
 
     expect(documentListMock.resetSelection).toHaveBeenCalled();
     expect(storeMock.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([]));
+    expect(documentListDirective.selectedNode).toBeNull();
   });
 });

--- a/src/app/directives/document-list.directive.ts
+++ b/src/app/directives/document-list.directive.ts
@@ -142,6 +142,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
   }
 
   private reset() {
+    this.selectedNode = null;
     this.documentList.resetSelection();
     this.store.dispatch(new SetSelectedNodesAction([]));
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ACA-4224](https://alfresco.atlassian.net/browse/ACA-4224)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
