### PR TITLE
[ACA-4320] Correctly trigger linksUnshared event after unsharing a file

### DIFF
--- a/src/app/services/content-management.service.spec.ts
+++ b/src/app/services/content-management.service.spec.ts
@@ -1418,7 +1418,7 @@ describe('ContentManagementService', () => {
       expect(store.dispatch['calls'].argsFor(1)[0]).toEqual(new SetSelectedNodesAction([node]));
     }));
 
-    it('should emit event when node is un-shared', fakeAsync(() => {
+    fit('should emit event when node is un-shared', fakeAsync(() => {
       const node = { entry: { id: '1', name: 'name1' } } as NodeEntry;
       spyOn(contentManagementService.linksUnshared, 'next').and.callThrough();
       spyOn(dialog, 'open').and.returnValue({
@@ -1429,7 +1429,7 @@ describe('ContentManagementService', () => {
       tick();
       flush();
 
-      expect(contentManagementService.linksUnshared.next).toHaveBeenCalledWith(jasmine.any(Object));
+      expect(contentManagementService.linksUnshared.next).toHaveBeenCalledWith();
     }));
   });
 

--- a/src/app/services/content-management.service.spec.ts
+++ b/src/app/services/content-management.service.spec.ts
@@ -1418,7 +1418,7 @@ describe('ContentManagementService', () => {
       expect(store.dispatch['calls'].argsFor(1)[0]).toEqual(new SetSelectedNodesAction([node]));
     }));
 
-    fit('should emit event when node is un-shared', fakeAsync(() => {
+    it('should emit event when node is un-shared', fakeAsync(() => {
       const node = { entry: { id: '1', name: 'name1' } } as NodeEntry;
       spyOn(contentManagementService.linksUnshared, 'next').and.callThrough();
       spyOn(dialog, 'open').and.returnValue({
@@ -1429,7 +1429,7 @@ describe('ContentManagementService', () => {
       tick();
       flush();
 
-      expect(contentManagementService.linksUnshared.next).toHaveBeenCalledWith();
+      expect(contentManagementService.linksUnshared.next).toHaveBeenCalled();
     }));
   });
 

--- a/src/app/services/content-management.service.ts
+++ b/src/app/services/content-management.service.ts
@@ -245,11 +245,9 @@ export class ContentManagementService {
             }
           })
           .afterClosed()
-          .subscribe((deletedSharedLink) => {
+          .subscribe(() => {
             this.store.dispatch(new SetSelectedNodesAction([node]));
-            if (deletedSharedLink) {
-              this.linksUnshared.next(deletedSharedLink);
-            }
+            this.linksUnshared.next();
           });
       });
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

`deletedSharedLink` would always return false causing the check on it to always fail, the `linksUnshared` event to never trigger and for the "Shared by" column to not be emptied.

**What is the new behaviour?**

`linksUnshared` event is now triggered and the "Shared by" column is emptied after unsharing a file.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
