### PR TITLE
[ACA-4374] FE - [ADW] Navigate to Smart Folder subfolders throws "This item no longer exists or you don't have permission to view it."

### DIFF
--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -75,7 +75,7 @@ describe('FilesComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: { data: { preferencePrefix: 'prefix' }, paramMap: convertToParamMap({ folderId: 'someId' }) },
+            snapshot: { data: { preferencePrefix: 'prefix' }, paramMap: convertToParamMap({ folderId: undefined }) },
             params: of({ folderId: 'someId' }),
             queryParamMap: of({})
           }
@@ -95,7 +95,7 @@ describe('FilesComponent', () => {
 
     uploadService = TestBed.inject(UploadService);
     router = TestBed.inject(Router);
-    route = TestBed.get(ActivatedRoute)
+    route = TestBed.get(ActivatedRoute);
     nodeActionsService = TestBed.inject(NodeActionsService);
     contentApi = TestBed.inject(ContentApiService);
     spyContent = spyOn(contentApi, 'getNode');
@@ -245,7 +245,6 @@ describe('FilesComponent', () => {
 
     it('should navigates to node when is more that one sub node', () => {
       router.url = '/personal-files/favourites';
-      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.navigate(node.id);
 
       expect(router.navigate).toHaveBeenCalledWith(['personal-files', 'favourites', node.id]);
@@ -253,14 +252,12 @@ describe('FilesComponent', () => {
 
     it('should remove the header filters param on click of folders', () => {
       router.url = '/personal-files?name=abc';
-      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.navigate(node.id);
 
       expect(router.navigate).toHaveBeenCalledWith(['personal-files', node.id]);
     });
 
     it('should navigates to node when id provided', () => {
-      spyOn(route.snapshot.paramMap, 'get').and.returnValue('currentNodeId');
       router.url = '/personal-files';
       component.navigate(node.id);
 
@@ -268,7 +265,6 @@ describe('FilesComponent', () => {
     });
 
     it('should navigates to home when id not provided', () => {
-      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       router.url = '/personal-files';
       component.navigate();
 
@@ -276,7 +272,6 @@ describe('FilesComponent', () => {
     });
 
     it('should navigate home if node is root', () => {
-      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.node = {
         path: {
           elements: [{ id: 'node-id' }]
@@ -290,6 +285,7 @@ describe('FilesComponent', () => {
     });
 
     it('should navigate home if node is root also if it contain a uuid', () => {
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue('some-node-id');
       component.node = {
         path: {
           elements: [{ id: 'node-id' }]
@@ -300,6 +296,21 @@ describe('FilesComponent', () => {
       component.navigate(node.id);
 
       expect(router.navigate).toHaveBeenCalledWith(['personal-files']);
+    });
+
+    it('should navigate to sub folder from a parent folder', () => {
+      router.url = '/personal-files/parent-folder-node-id';
+      const childFolderNodeId = node.id;
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue('parent-folder-node-id');
+      component.navigate(childFolderNodeId);
+      expect(router.navigate).toHaveBeenCalledWith(['personal-files', childFolderNodeId]);
+    });
+
+    it('should navigate to smart folder content', () => {
+      router.url = '/libraries/vH1-6-1-1-115wji7092f0-41-MTg%3D-1-115hpo76l3h2e1f';
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue('vH1-6-1-1-115wji7092f0-41-MTg=-1-115hpo76l3h2e1f');
+      component.navigate(node.id);
+      expect(router.navigate).toHaveBeenCalledWith(['libraries', node.id]);
     });
   });
 

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -25,7 +25,7 @@
 
 import { TestBed, fakeAsync, tick, ComponentFixture } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, SimpleChange, SimpleChanges } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { NodeFavoriteDirective, DataTableComponent, UploadService, AppConfigModule, DataTableModule, PaginationModule } from '@alfresco/adf-core';
 import { DocumentListComponent, DocumentListService, FilterSearch } from '@alfresco/adf-content-services';
 import { NodeActionsService } from '../../services/node-actions.service';
@@ -44,6 +44,7 @@ describe('FilesComponent', () => {
   let uploadService: UploadService;
   let nodeActionsService: NodeActionsService;
   let contentApi: ContentApiService;
+  let route: ActivatedRoute;
   let router: any = {
     url: '',
     navigate: jasmine.createSpy('navigate')
@@ -74,7 +75,7 @@ describe('FilesComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: { data: { preferencePrefix: 'prefix' } },
+            snapshot: { data: { preferencePrefix: 'prefix' }, paramMap: convertToParamMap({ folderId: 'someId' }) },
             params: of({ folderId: 'someId' }),
             queryParamMap: of({})
           }
@@ -94,6 +95,7 @@ describe('FilesComponent', () => {
 
     uploadService = TestBed.inject(UploadService);
     router = TestBed.inject(Router);
+    route = TestBed.get(ActivatedRoute)
     nodeActionsService = TestBed.inject(NodeActionsService);
     contentApi = TestBed.inject(ContentApiService);
     spyContent = spyOn(contentApi, 'getNode');
@@ -243,6 +245,7 @@ describe('FilesComponent', () => {
 
     it('should navigates to node when is more that one sub node', () => {
       router.url = '/personal-files/favourites';
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.navigate(node.id);
 
       expect(router.navigate).toHaveBeenCalledWith(['personal-files', 'favourites', node.id]);
@@ -250,12 +253,14 @@ describe('FilesComponent', () => {
 
     it('should remove the header filters param on click of folders', () => {
       router.url = '/personal-files?name=abc';
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.navigate(node.id);
 
       expect(router.navigate).toHaveBeenCalledWith(['personal-files', node.id]);
     });
 
     it('should navigates to node when id provided', () => {
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue('currentNodeId');
       router.url = '/personal-files';
       component.navigate(node.id);
 
@@ -263,6 +268,7 @@ describe('FilesComponent', () => {
     });
 
     it('should navigates to home when id not provided', () => {
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       router.url = '/personal-files';
       component.navigate();
 
@@ -270,6 +276,7 @@ describe('FilesComponent', () => {
     });
 
     it('should navigate home if node is root', () => {
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue(undefined);
       component.node = {
         path: {
           elements: [{ id: 'node-id' }]

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -123,32 +123,59 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   }
 
   navigate(nodeId: string = null) {
-    let urlToNavigate: string[];
-    const currentFolderId = this.route.snapshot.paramMap.get('folderId');
+    const currentNodeId = this.route.snapshot.paramMap.get('folderId');
     const urlWithoutParams = decodeURIComponent(this.router.url).split('?')[0];
+    const urlToNavigate: string[] = this.prepareUrlToNavigate(urlWithoutParams, currentNodeId, nodeId);
+    this.router.navigate(urlToNavigate);
+  }
 
-    if (currentFolderId) {
-      if (nodeId && !this.isRootNode(nodeId)) {
-        const currentURL = urlWithoutParams.split('/');
-        const index = currentURL.indexOf(currentFolderId);
-        if (index > 0) {
-          currentURL[index] = nodeId;
-        }
-        urlToNavigate = currentURL;
-      } else {
-        urlToNavigate = urlWithoutParams.replace(currentFolderId, '').split('/');
-        urlToNavigate.pop();
-      }
-      urlToNavigate.shift();
+  private prepareUrlToNavigate(previousUrl: string, currentNodeId: string, nodeId: string): string[] {
+    let url: string[];
+    if (currentNodeId) {
+      url = this.getUrlToNavigateFromPreviousUrl(previousUrl, currentNodeId, nodeId);
     } else {
-      urlToNavigate = urlWithoutParams.split('/');
-      if (nodeId && !this.isRootNode(nodeId)) {
-        urlToNavigate.push(nodeId);
-      }
-      urlToNavigate.shift();
+      url = this.getNavigateToNodeUrl(previousUrl, nodeId);
     }
 
-    this.router.navigate(urlToNavigate);
+    return url;
+  }
+
+  private getUrlToNavigateFromPreviousUrl(previousUrl: string, currentNodeId: string, nextNodeId: string): string[] {
+    let urlToNavigate: string[];
+
+    if (nextNodeId && !this.isRootNode(nextNodeId)) {
+      urlToNavigate = this.getNavigateToSubNodeUrlFromPreviousUrl(previousUrl, currentNodeId, nextNodeId);
+    } else {
+      urlToNavigate = this.getNavigateToRootUrlFromPreviousUrl(previousUrl, currentNodeId);
+    }
+
+    urlToNavigate.shift();
+    return urlToNavigate;
+  }
+
+  private getNavigateToSubNodeUrlFromPreviousUrl(previousUrl: string, currentNodeId: string, nextNodeId: string): string[] {
+    const currentURL = previousUrl.split('/');
+    const index = currentURL.indexOf(currentNodeId);
+    if (index > 0) {
+      currentURL[index] = nextNodeId;
+    }
+    return currentURL;
+  }
+
+  private getNavigateToRootUrlFromPreviousUrl(previousUrl: string, currentNodeId: string): string[] {
+    const rootUrl: string[] = previousUrl.replace(currentNodeId, '').split('/');
+    rootUrl.pop();
+    return rootUrl;
+  }
+
+  private getNavigateToNodeUrl(previousUrl: string, nodeId: string): string[] {
+    const navigateToNodeURL = previousUrl.split('/');
+    if (nodeId && !this.isRootNode(nodeId)) {
+      navigateToNodeURL.push(nodeId);
+    }
+    navigateToNodeURL.shift();
+
+    return navigateToNodeURL;
   }
 
   onUploadNewVersion(ev: CustomEvent) {

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -125,45 +125,45 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   navigate(nodeId: string = null) {
     const currentNodeId = this.route.snapshot.paramMap.get('folderId');
     const urlWithoutParams = decodeURIComponent(this.router.url).split('?')[0];
-    const urlToNavigate: string[] = this.prepareUrlToNavigate(urlWithoutParams, currentNodeId, nodeId);
+    const urlToNavigate: string[] = this.getUrlToNavigate(urlWithoutParams, currentNodeId, nodeId);
     this.router.navigate(urlToNavigate);
   }
 
-  private prepareUrlToNavigate(currentURL: string, currentNodeId: string, nodeId: string): string[] {
-    return currentNodeId ? this.prepareNextNodeUrlToNavigate(currentURL, currentNodeId, nodeId) : this.getRootToNodeUrlToNavigate(currentURL, nodeId);
+  private getUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
+    return currentNodeId ? this.getNextNodeUrlToNavigate(currentURL, currentNodeId, nextNodeId) : this.appendNextNodeIdToUrl(currentURL, nextNodeId);
   }
 
-  private prepareNextNodeUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
+  private getNextNodeUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
     const urlToNavigate: string[] =
       nextNodeId && !this.isRootNode(nextNodeId)
-        ? this.getNextNodeUrlToNavigate(currentURL, currentNodeId, nextNodeId)
-        : this.getRootUrlToNavigate(currentURL, currentNodeId);
+        ? this.replaceCurrentNodeIdWithNextNodeId(currentURL, currentNodeId, nextNodeId)
+        : this.removeNodeIdFromUrl(currentURL, currentNodeId);
     urlToNavigate.shift();
     return urlToNavigate;
   }
 
-  private getNextNodeUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
+  private replaceCurrentNodeIdWithNextNodeId(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
     const nextNodeUrlToNavigate = currentURL.split('/');
-    const index = currentURL.indexOf(currentNodeId);
+    const index = nextNodeUrlToNavigate.indexOf(currentNodeId);
     if (index > 0) {
       nextNodeUrlToNavigate[index] = nextNodeId;
     }
     return nextNodeUrlToNavigate;
   }
 
-  private getRootUrlToNavigate(currentURL: string, currentNodeId: string): string[] {
+  private removeNodeIdFromUrl(currentURL: string, currentNodeId: string): string[] {
     const rootUrl: string[] = currentURL.replace(currentNodeId, '').split('/');
     rootUrl.pop();
     return rootUrl;
   }
 
-  private getRootToNodeUrlToNavigate(currentURL: string, nodeId: string): string[] {
-    const navigateToNodeURL = currentURL.split('/');
+  private appendNextNodeIdToUrl(currentURL: string, nodeId: string): string[] {
+    const navigateToNodeUrl = currentURL.split('/');
     if (nodeId && !this.isRootNode(nodeId)) {
-      navigateToNodeURL.push(nodeId);
+      navigateToNodeUrl.push(nodeId);
     }
-    navigateToNodeURL.shift();
-    return navigateToNodeURL;
+    navigateToNodeUrl.shift();
+    return navigateToNodeUrl;
   }
 
   onUploadNewVersion(ev: CustomEvent) {

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -130,8 +130,15 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     if (currentFolderId) {
       if (nodeId && !this.isRootNode(nodeId)) {
         const currentURL = urlWithoutParams.split('/');
-        currentURL[currentURL.indexOf(currentFolderId)] = nodeId;
-        urlToNavigate = currentURL;
+        urlToNavigate =
+          currentURL.indexOf(currentFolderId) > 0
+            ? currentURL.map((value, index) => {
+                if (index === currentURL.indexOf(currentFolderId)) {
+                  value = nodeId;
+                }
+                return value;
+              })
+            : currentURL;
       } else {
         urlToNavigate = urlWithoutParams.replace(currentFolderId, '').split('/');
         urlToNavigate.pop();

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -129,52 +129,40 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     this.router.navigate(urlToNavigate);
   }
 
-  private prepareUrlToNavigate(previousUrl: string, currentNodeId: string, nodeId: string): string[] {
-    let url: string[];
-    if (currentNodeId) {
-      url = this.getUrlToNavigateFromPreviousUrl(previousUrl, currentNodeId, nodeId);
-    } else {
-      url = this.getNavigateToNodeUrl(previousUrl, nodeId);
-    }
-
-    return url;
+  private prepareUrlToNavigate(currentURL: string, currentNodeId: string, nodeId: string): string[] {
+    return currentNodeId ? this.prepareNextNodeUrlToNavigate(currentURL, currentNodeId, nodeId) : this.getRootToNodeUrlToNavigate(currentURL, nodeId);
   }
 
-  private getUrlToNavigateFromPreviousUrl(previousUrl: string, currentNodeId: string, nextNodeId: string): string[] {
-    let urlToNavigate: string[];
-
-    if (nextNodeId && !this.isRootNode(nextNodeId)) {
-      urlToNavigate = this.getNavigateToSubNodeUrlFromPreviousUrl(previousUrl, currentNodeId, nextNodeId);
-    } else {
-      urlToNavigate = this.getNavigateToRootUrlFromPreviousUrl(previousUrl, currentNodeId);
-    }
-
+  private prepareNextNodeUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
+    const urlToNavigate: string[] =
+      nextNodeId && !this.isRootNode(nextNodeId)
+        ? this.getNextNodeUrlToNavigate(currentURL, currentNodeId, nextNodeId)
+        : this.getRootUrlToNavigate(currentURL, currentNodeId);
     urlToNavigate.shift();
     return urlToNavigate;
   }
 
-  private getNavigateToSubNodeUrlFromPreviousUrl(previousUrl: string, currentNodeId: string, nextNodeId: string): string[] {
-    const currentURL = previousUrl.split('/');
+  private getNextNodeUrlToNavigate(currentURL: string, currentNodeId: string, nextNodeId: string): string[] {
+    const nextNodeUrlToNavigate = currentURL.split('/');
     const index = currentURL.indexOf(currentNodeId);
     if (index > 0) {
-      currentURL[index] = nextNodeId;
+      nextNodeUrlToNavigate[index] = nextNodeId;
     }
-    return currentURL;
+    return nextNodeUrlToNavigate;
   }
 
-  private getNavigateToRootUrlFromPreviousUrl(previousUrl: string, currentNodeId: string): string[] {
-    const rootUrl: string[] = previousUrl.replace(currentNodeId, '').split('/');
+  private getRootUrlToNavigate(currentURL: string, currentNodeId: string): string[] {
+    const rootUrl: string[] = currentURL.replace(currentNodeId, '').split('/');
     rootUrl.pop();
     return rootUrl;
   }
 
-  private getNavigateToNodeUrl(previousUrl: string, nodeId: string): string[] {
-    const navigateToNodeURL = previousUrl.split('/');
+  private getRootToNodeUrlToNavigate(currentURL: string, nodeId: string): string[] {
+    const navigateToNodeURL = currentURL.split('/');
     if (nodeId && !this.isRootNode(nodeId)) {
       navigateToNodeURL.push(nodeId);
     }
     navigateToNodeURL.shift();
-
     return navigateToNodeURL;
   }
 

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -123,15 +123,17 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   }
 
   navigate(nodeId: string = null) {
-    const uuidRegEx = /[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-4[0-9A-Za-z]{3}-[89ABab][0-9A-Za-z]{3}-[0-9A-Za-z]{12}/gi;
     let urlToNavigate: string[];
-    const urlWithoutParams = this.router.url.split('?')[0];
+    const currentFolderId = this.route.snapshot.paramMap.get('folderId');
+    const urlWithoutParams = decodeURIComponent(this.router.url).split('?')[0];
 
-    if (urlWithoutParams.match(uuidRegEx)) {
+    if (currentFolderId) {
       if (nodeId && !this.isRootNode(nodeId)) {
-        urlToNavigate = urlWithoutParams.replace(uuidRegEx, nodeId).split('/');
+        const currentURL = urlWithoutParams.split('/');
+        currentURL[currentURL.indexOf(currentFolderId)] = nodeId;
+        urlToNavigate = currentURL;
       } else {
-        urlToNavigate = urlWithoutParams.replace(uuidRegEx, '').split('/');
+        urlToNavigate = urlWithoutParams.replace(currentFolderId, '').split('/');
         urlToNavigate.pop();
       }
       urlToNavigate.shift();

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -130,15 +130,11 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     if (currentFolderId) {
       if (nodeId && !this.isRootNode(nodeId)) {
         const currentURL = urlWithoutParams.split('/');
-        urlToNavigate =
-          currentURL.indexOf(currentFolderId) > 0
-            ? currentURL.map((value, index) => {
-                if (index === currentURL.indexOf(currentFolderId)) {
-                  value = nodeId;
-                }
-                return value;
-              })
-            : currentURL;
+        const index = currentURL.indexOf(currentFolderId);
+        if (index > 0) {
+          currentURL[index] = nodeId;
+        }
+        urlToNavigate = currentURL;
       } else {
         urlToNavigate = urlWithoutParams.replace(currentFolderId, '').split('/');
         urlToNavigate.pop();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/MNT-22241


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
