### PR TITLE
[ACA-4383] - Fix pagination when performing navigation

### DIFF
--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -27,12 +27,7 @@ import { TestBed, fakeAsync, tick, ComponentFixture } from '@angular/core/testin
 import { NO_ERRORS_SCHEMA, SimpleChange, SimpleChanges } from '@angular/core';
 import { Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { NodeFavoriteDirective, DataTableComponent, UploadService, AppConfigModule, DataTableModule, PaginationModule } from '@alfresco/adf-core';
-import {
-  DocumentListComponent,
-  DocumentListService,
-  FilterSearch,
-  PathElementEntity
-} from '@alfresco/adf-content-services';
+import { DocumentListComponent, DocumentListService, FilterSearch, PathElementEntity } from '@alfresco/adf-content-services';
 import { NodeActionsService } from '../../services/node-actions.service';
 import { FilesComponent } from './files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
@@ -387,7 +382,7 @@ describe('FilesComponent', () => {
 
     it('should reset the pagination when navigating using the breadcrumb', () => {
       const resetNewFolderPaginationSpy = spyOn(component.documentList, 'resetNewFolderPagination');
-      const breadcrumbRoute: PathElementEntity = { id: 'fake-breadcrumb-route-id', name: 'fake' }
+      const breadcrumbRoute: PathElementEntity = { id: 'fake-breadcrumb-route-id', name: 'fake' };
       component.onBreadcrumbNavigate(breadcrumbRoute);
 
       expect(resetNewFolderPaginationSpy).toHaveBeenCalled();
@@ -408,5 +403,5 @@ describe('FilesComponent', () => {
 
       expect(resetNewFolderPaginationSpy).not.toHaveBeenCalled();
     });
-  })
+  });
 });

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -27,7 +27,12 @@ import { TestBed, fakeAsync, tick, ComponentFixture } from '@angular/core/testin
 import { NO_ERRORS_SCHEMA, SimpleChange, SimpleChanges } from '@angular/core';
 import { Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { NodeFavoriteDirective, DataTableComponent, UploadService, AppConfigModule, DataTableModule, PaginationModule } from '@alfresco/adf-core';
-import { DocumentListComponent, DocumentListService, FilterSearch } from '@alfresco/adf-content-services';
+import {
+  DocumentListComponent,
+  DocumentListService,
+  FilterSearch,
+  PathElementEntity
+} from '@alfresco/adf-content-services';
 import { NodeActionsService } from '../../services/node-actions.service';
 import { FilesComponent } from './files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
@@ -374,4 +379,34 @@ describe('FilesComponent', () => {
     const header = fixture.nativeElement.querySelector('.adf-sticky-header');
     expect(header).not.toBeNull();
   });
+
+  describe('Pagination reset when navigating', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should reset the pagination when navigating using the breadcrumb', () => {
+      const resetNewFolderPaginationSpy = spyOn(component.documentList, 'resetNewFolderPagination');
+      const breadcrumbRoute: PathElementEntity = { id: 'fake-breadcrumb-route-id', name: 'fake' }
+      component.onBreadcrumbNavigate(breadcrumbRoute);
+
+      expect(resetNewFolderPaginationSpy).toHaveBeenCalled();
+    });
+
+    it('should reset the pagination when navigating to a folder', () => {
+      const resetNewFolderPaginationSpy = spyOn(component.documentList, 'resetNewFolderPagination');
+      const fakeFolderNode = new NodeEntry({ entry: { id: 'fakeFolderNode', isFolder: true, isFile: false } });
+      component.navigateTo(fakeFolderNode);
+
+      expect(resetNewFolderPaginationSpy).toHaveBeenCalled();
+    });
+
+    it('should not reset the pagination when the node to navigate is not a folder', () => {
+      const resetNewFolderPaginationSpy = spyOn(component.documentList, 'resetNewFolderPagination');
+      const fakeFileNode = new NodeEntry({ entry: { id: 'fakeFileNode', isFolder: false, isFile: true } });
+      component.navigateTo(fakeFileNode);
+
+      expect(resetNewFolderPaginationSpy).not.toHaveBeenCalled();
+    });
+  })
 });

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -176,6 +176,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       const { id, isFolder } = node.entry;
 
       if (isFolder) {
+        this.documentList.resetNewFolderPagination();
         this.navigate(id);
         return;
       }
@@ -185,13 +186,14 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   }
 
   onBreadcrumbNavigate(route: PathElementEntity) {
+    this.documentList.resetNewFolderPagination();
+
     // todo: review this approach once 5.2.3 is out
     if (this.nodePath && this.nodePath.length > 2) {
       if (this.nodePath[1].name === 'Sites' && this.nodePath[2].id === route.id) {
         return this.navigate(this.nodePath[3].id);
       }
     }
-    this.documentList.resetNewFolderPagination();
     this.navigate(route.id);
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4383


**What is the new behaviour?**
When having a pagination preference on the document list (for example page 3 of 3) on a 25 page size the skipCount of the pagination is 50. When navigating to a folder the skipCount should reset otherwise the 50 first results of the folder we are navigating to will be skipped. With the new behaviour the skipCount of the pagination will reset when performing navigation to a folder either by clicking on it or using the breadcrumb


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
