### PR TITLE
Revert changes from dev-durse-ADF-5378-integration

### DIFF
--- a/projects/aca-shared/store/src/actions/upload.actions.ts
+++ b/projects/aca-shared/store/src/actions/upload.actions.ts
@@ -29,7 +29,6 @@ export enum UploadActionTypes {
   UploadFiles = 'UPLOAD_FILES',
   UploadFolder = 'UPLOAD_FOLDER',
   UploadFileVersion = 'UPLOAD_FILE_VERSION',
-  UploadImage = 'UPLOAD_IMAGE'
 }
 
 export class UploadFilesAction implements Action {
@@ -40,12 +39,6 @@ export class UploadFilesAction implements Action {
 
 export class UploadFolderAction implements Action {
   readonly type = UploadActionTypes.UploadFolder;
-
-  constructor(public payload: any) {}
-}
-
-export class UploadNewImageAction implements Action {
-  readonly type = UploadActionTypes.UploadImage;
 
   constructor(public payload: any) {}
 }

--- a/projects/aca-shared/store/src/actions/upload.actions.ts
+++ b/projects/aca-shared/store/src/actions/upload.actions.ts
@@ -28,7 +28,7 @@ import { Action } from '@ngrx/store';
 export enum UploadActionTypes {
   UploadFiles = 'UPLOAD_FILES',
   UploadFolder = 'UPLOAD_FOLDER',
-  UploadFileVersion = 'UPLOAD_FILE_VERSION',
+  UploadFileVersion = 'UPLOAD_FILE_VERSION'
 }
 
 export class UploadFilesAction implements Action {

--- a/src/app/components/layout/app-layout/app-layout.component.scss
+++ b/src/app/components/layout/app-layout/app-layout.component.scss
@@ -19,8 +19,6 @@
   adf-file-uploading-dialog {
     z-index: 1100;
   }
-
-
 }
 
 @media screen and (max-width: 599px) {

--- a/src/app/components/viewer/viewer.component.html
+++ b/src/app/components/viewer/viewer.component.html
@@ -14,8 +14,6 @@
     [allowDownload]="false"
     [allowFullScreen]="false"
     [overlayMode]="true"
-    [readOnly]="!canUpdateNode"
-    (fileSubmit)="onFileSubmit($event)"
     (showViewerChange)="onViewerVisibilityChanged()"
     [canNavigateBefore]="previousNodeId"
     [canNavigateNext]="nextNodeId"

--- a/src/app/components/viewer/viewer.component.ts
+++ b/src/app/components/viewer/viewer.component.ts
@@ -33,7 +33,6 @@ import {
   ReloadDocumentListAction,
   SetCurrentNodeVersionAction,
   SetSelectedNodesAction,
-  UploadNewImageAction,
   ViewerActionTypes,
   ViewNodeAction
 } from '@alfresco/aca-shared/store';
@@ -46,7 +45,6 @@ import { Store } from '@ngrx/store';
 import { from, Observable, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Actions, ofType } from '@ngrx/effects';
-import { ContentManagementService } from '../../services/content-management.service';
 
 @Component({
   selector: 'app-viewer',
@@ -66,7 +64,6 @@ export class AppViewerComponent implements OnInit, OnDestroy {
   selection: SelectionState;
   infoDrawerOpened$: Observable<boolean>;
 
-  canUpdateNode = false;
   showRightSide = false;
   openWith: ContentActionRef[] = [];
   toolbarActions: ContentActionRef[] = [];
@@ -115,8 +112,7 @@ export class AppViewerComponent implements OnInit, OnDestroy {
     private preferences: UserPreferencesService,
     private apiService: AlfrescoApiService,
     private uploadService: UploadService,
-    private appHookService: AppHookService,
-    private content: ContentManagementService
+    private appHookService: AppHookService
   ) {}
 
   ngOnInit() {
@@ -212,7 +208,6 @@ export class AppViewerComponent implements OnInit, OnDestroy {
     if (nodeId) {
       try {
         this.node = await this.contentApi.getNodeInfo(nodeId).toPromise();
-        this.canUpdateNode = this.content.canUpdateNode(this.node);
         this.store.dispatch(new SetSelectedNodesAction([{ entry: this.node }]));
         this.navigateMultiple = this.extensions.canShowViewerNavigation({ entry: this.node });
         if (!this.navigateMultiple) {
@@ -257,11 +252,6 @@ export class AppViewerComponent implements OnInit, OnDestroy {
 
     const location = this.getFileLocation();
     this.store.dispatch(new ViewNodeAction(this.nextNodeId, { location }));
-  }
-
-  onFileSubmit(newBlob: Blob) {
-    const newImageFile: File = new File([newBlob], this?.node?.name, { type: this?.node?.content?.mimeType });
-    this.store.dispatch(new UploadNewImageAction(newImageFile));
   }
 
   /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -301,9 +301,6 @@
                     "504": "The server timed out, try again or contact IT support [504]",
                     "403": "Insufficient permissions to upload in this location [403]",
                     "404": "Upload location no longer exists [404]"
-                },
-                "SUCCESS": {
-                  "MEDIA_MANAGEMENT_SUCCESS": "Version updated successfully"
                 }
             },
             "INFO": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://github.com/Alfresco/alfresco-ng2-components/pull/6984
https://alfresco.atlassian.net/browse/ADF-5393

**What is the new behaviour?**

Manually reverted the merged PR since automatically can't be done.
This logic has been added into Viewer-core component in ADF after a discussion with @eromano 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
