### PR TITLE
[ACA-4384] [ADW] Empty template or error template should be displayed in case error occurred when clicking a folder

### DIFF
--- a/src/app/components/files/files.component.html
+++ b/src/app/components/files/files.component.html
@@ -35,7 +35,7 @@
           (name-click)="navigateTo($event.detail?.node)"
           (sorting-changed)="onSortingChanged($event)"
           (filterSelection)="onFilterSelected($event)"
-          (error)="onError($event)"
+          (error)="onError()"
         >
           <data-columns>
             <ng-container *ngFor="let column of columns; trackBy: trackById">

--- a/src/app/components/files/files.component.html
+++ b/src/app/components/files/files.component.html
@@ -35,6 +35,7 @@
           (name-click)="navigateTo($event.detail?.node)"
           (sorting-changed)="onSortingChanged($event)"
           (filterSelection)="onFilterSelected($event)"
+          (error)="onError($event)"
         >
           <data-columns>
             <ng-container *ngFor="let column of columns; trackBy: trackById">

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -133,11 +133,15 @@ describe('FilesComponent', () => {
     it('should set current page as invalid path when loadFolderByNodeId API fails with 500 status code', fakeAsync(() => {
       fixture.detectChanges();
       spyContent.and.returnValue(throwError(null));
-      loadFolderByNodeIdSpy.and.returnValue(throwError(Error(`{
+      loadFolderByNodeIdSpy.and.returnValue(
+        throwError(
+          Error(`{
         "error":{
            "statusCode":500
         }
-     }`)))
+     }`)
+        )
+      );
       component.documentList.loadFolder();
       tick();
 

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -130,18 +130,10 @@ describe('FilesComponent', () => {
       expect(component.isValidPath).toBe(true);
     }));
 
-    it('should set current page as invalid path when loadFolderByNodeId API fails with 500 status code', fakeAsync(() => {
+    it('should set current page as invalid path when loadFolderByNodeId API fails', fakeAsync(() => {
       fixture.detectChanges();
       spyContent.and.returnValue(throwError(null));
-      loadFolderByNodeIdSpy.and.returnValue(
-        throwError(
-          Error(`{
-        "error":{
-           "statusCode":500
-        }
-     }`)
-        )
-      );
+      loadFolderByNodeIdSpy.and.returnValue(throwError(Error('error')));
       component.documentList.loadFolder();
       tick();
 

--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -51,6 +51,7 @@ describe('FilesComponent', () => {
   };
 
   let spyContent = null;
+  let loadFolderByNodeIdSpy: jasmine.Spy;
 
   function verifyEmptyFilterTemplate() {
     const template = fixture.debugElement.query(By.css('.empty-search__block')).nativeElement as HTMLElement;
@@ -91,7 +92,7 @@ describe('FilesComponent', () => {
     const fakeNodeEntry: NodeEntry = { entry: { id: 'fake-node-entry' } } as NodeEntry;
     const fakeNodePaging: NodePaging = { list: { pagination: { count: 10, maxItems: 10, skipCount: 0 } } };
     const documentLoaderNode = { children: fakeNodePaging, currentNode: fakeNodeEntry };
-    spyOn(documentListService, 'loadFolderByNodeId').and.returnValue(of(documentLoaderNode));
+    loadFolderByNodeIdSpy = spyOn(documentListService, 'loadFolderByNodeId').and.returnValue(of(documentLoaderNode));
 
     uploadService = TestBed.inject(UploadService);
     router = TestBed.inject(Router);
@@ -127,6 +128,20 @@ describe('FilesComponent', () => {
       tick();
 
       expect(component.isValidPath).toBe(true);
+    }));
+
+    it('should set current page as invalid path when loadFolderByNodeId API fails with 500 status code', fakeAsync(() => {
+      fixture.detectChanges();
+      spyContent.and.returnValue(throwError(null));
+      loadFolderByNodeIdSpy.and.returnValue(throwError(Error(`{
+        "error":{
+           "statusCode":500
+        }
+     }`)))
+      component.documentList.loadFolder();
+      tick();
+
+      expect(component.isValidPath).toBe(false);
     }));
   });
 

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -345,13 +345,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     return this.showHeader === ShowHeaderMode.Always;
   }
 
-  onError(error: any) {
-    if (error?.message) {
-      try {
-        if (JSON.parse(error.message).error.statusCode === 500) {
-          this.isValidPath = false;
-        }
-      } catch (error) {}
-    }
+  onError() {
+    this.isValidPath = false;
   }
 }

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -348,11 +348,10 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   onError(error: any) {
     if (error?.message) {
       try {
-          if (JSON.parse(error.message).error.statusCode === 500) {
-            this.isValidPath = false;
-          }
-      } catch (error) {
-      }
+        if (JSON.parse(error.message).error.statusCode === 500) {
+          this.isValidPath = false;
+        }
+      } catch (error) {}
     }
   }
 }

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -344,4 +344,15 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   isFilterHeaderActive(): boolean {
     return this.showHeader === ShowHeaderMode.Always;
   }
+
+  onError(error: any) {
+    if (error?.message) {
+      try {
+          if (JSON.parse(error.message).error.statusCode === 500) {
+            this.isValidPath = false;
+          }
+      } catch (error) {
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4384

We were not showing an error template in case of BE 500 error 

**What is the new behaviour?**

![image](https://user-images.githubusercontent.com/25585550/117999135-2db5fb00-b362-11eb-9dd2-bd12c68a833a.png)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
