### PR TITLE
[ACA-376] navigate inside original folder when clicking on a folder-link

### DIFF
--- a/src/app/components/files/files.component.spec.ts
+++ b/src/app/components/files/files.component.spec.ts
@@ -323,6 +323,24 @@ describe('FilesComponent', () => {
       component.navigate(node.id);
       expect(router.navigate).toHaveBeenCalledWith(['libraries', node.id]);
     });
+
+    it('should navigate to destination folder if node is `app:folderlink`', () => {
+      node = {
+        entry: {
+          id: 'folder-link-id',
+          isFolder: true,
+          nodeType: 'app:folderlink',
+          properties: {
+            'cm:destination': 'original-folder-id'
+          }
+        }
+      } as any;
+
+      router.url = '/personal-files';
+      spyOn(route.snapshot.paramMap, 'get').and.returnValue('personal-files');
+      component.navigateTo(node);
+      expect(router.navigate).toHaveBeenCalledWith([node.entry.properties['cm:destination']]);
+    });
   });
 
   describe('isSiteContainer', () => {

--- a/src/app/components/files/files.component.ts
+++ b/src/app/components/files/files.component.ts
@@ -173,9 +173,17 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   navigateTo(node: MinimalNodeEntity) {
     if (node && node.entry) {
       this.selectedNode = node;
-      const { id, isFolder } = node.entry;
+      const { isFolder } = node.entry;
 
       if (isFolder) {
+        let id: string;
+
+        if (node.entry.nodeType === 'app:folderlink') {
+          id = node.entry.properties['cm:destination'];
+        } else {
+          id = node.entry.id;
+        }
+
         this.documentList.resetNewFolderPagination();
         this.navigate(id);
         return;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
folder-link is handled as a regular folder


**What is the new behaviour?**
clicking on a folder-link navigates inside the original folder


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
