### PR TITLE
[ACA-4438] The document list gets reloaded when closing the document viewer

### DIFF
--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -479,6 +479,19 @@ export function canToggleFavorite(context: RuleContext): boolean {
 }
 
 /**
+ * Checks if user can toggle **Favorite** state for a node on preview mode.
+ * @param context Rule execution context
+ */
+export function canToggleFavoriteOnPreview(context: RuleContext): boolean {
+  return [
+    [canAddFavorite(context), canRemoveFavorite(context)].some(Boolean),
+    [navigation.isPreview(context)].some(
+      Boolean
+    )
+  ].every(Boolean);
+}
+
+/**
  * Checks if application should render logout option.
  * JSON ref: `canShowLogout`
  * @param context Rule execution context

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -483,12 +483,7 @@ export function canToggleFavorite(context: RuleContext): boolean {
  * @param context Rule execution context
  */
 export function canToggleFavoriteOnPreview(context: RuleContext): boolean {
-  return [
-    [canAddFavorite(context), canRemoveFavorite(context)].some(Boolean),
-    [navigation.isPreview(context)].some(
-      Boolean
-    )
-  ].every(Boolean);
+  return [[canAddFavorite(context), canRemoveFavorite(context)].some(Boolean), [navigation.isPreview(context)].some(Boolean)].every(Boolean);
 }
 
 /**

--- a/src/app/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/src/app/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -23,9 +23,9 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppStore, DownloadNodesAction, EditOfflineAction, SnackbarErrorAction, getAppSelection } from '@alfresco/aca-shared/store';
+import { AppStore, DownloadNodesAction, EditOfflineAction, SnackbarErrorAction, getAppSelection, ReloadDocumentListAction } from '@alfresco/aca-shared/store';
 import { MinimalNodeEntity, NodeEntry, SharedLinkEntry, Node } from '@alfresco/js-api';
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { isLocked } from '@alfresco/aca-shared';
 import { AlfrescoApiService } from '@alfresco/adf-core';
@@ -53,6 +53,7 @@ import { AlfrescoApiService } from '@alfresco/adf-core';
   host: { class: 'app-toggle-edit-offline' }
 })
 export class ToggleEditOfflineComponent implements OnInit {
+  @Input() data: any;
   selection: MinimalNodeEntity;
 
   constructor(private store: Store<AppStore>, private alfrescoApiService: AlfrescoApiService) {}
@@ -69,6 +70,7 @@ export class ToggleEditOfflineComponent implements OnInit {
 
   async onClick() {
     await this.toggleLock(this.selection);
+    this.reload();
   }
 
   private async toggleLock(node: NodeEntry | SharedLinkEntry) {
@@ -121,6 +123,12 @@ export class ToggleEditOfflineComponent implements OnInit {
 
   unlockNode(nodeId: string) {
     return this.alfrescoApiService.nodesApi.unlockNode(nodeId);
+  }
+
+  private reload() {
+    if (this.data?.reload) {
+      this.store.dispatch(new ReloadDocumentListAction());
+    }
   }
 
   private update(data: Node) {

--- a/src/app/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/src/app/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -23,7 +23,14 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppStore, DownloadNodesAction, EditOfflineAction, SnackbarErrorAction, getAppSelection, ReloadDocumentListAction } from '@alfresco/aca-shared/store';
+import {
+  AppStore,
+  DownloadNodesAction,
+  EditOfflineAction,
+  SnackbarErrorAction,
+  getAppSelection,
+  ReloadDocumentListAction
+} from '@alfresco/aca-shared/store';
 import { MinimalNodeEntity, NodeEntry, SharedLinkEntry, Node } from '@alfresco/js-api';
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';

--- a/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.spec.ts
+++ b/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.spec.ts
@@ -70,7 +70,7 @@ describe('ToggleFavoriteComponent', () => {
   });
 
   it('should not dispatch reload if route is not specified', () => {
-    component.data = "['/reload_on_this_route']";
+    component.data = { url: "['/reload_on_this_route']" };
     router.url = '/somewhere_over_the_rainbow';
 
     fixture.detectChanges();
@@ -80,7 +80,7 @@ describe('ToggleFavoriteComponent', () => {
   });
 
   it('should dispatch reload if route is specified', () => {
-    component.data = "['/reload_on_this_route']";
+    component.data = { url: "['/reload_on_this_route']" };
     router.url = '/reload_on_this_route';
 
     fixture.detectChanges();

--- a/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.ts
+++ b/src/app/components/toolbar/toggle-favorite/toggle-favorite.component.ts
@@ -52,13 +52,13 @@ export class ToggleFavoriteComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.data) {
-      this.reloadOnRoutes = JSON.parse(this.data.replace(/'/g, '"'));
+    if (this.data?.url) {
+      this.reloadOnRoutes = JSON.parse(this.data.url.replace(/'/g, '"'));
     }
   }
 
   onToggleEvent() {
-    if (this.reloadOnRoutes.includes(this.router.url)) {
+    if (this.reloadOnRoutes.includes(this.router.url) || this.data?.reload) {
       this.store.dispatch(new ReloadDocumentListAction());
     }
   }

--- a/src/app/components/viewer/viewer.component.ts
+++ b/src/app/components/viewer/viewer.component.ts
@@ -30,7 +30,6 @@ import {
   getRuleContext,
   isInfoDrawerOpened,
   RefreshPreviewAction,
-  ReloadDocumentListAction,
   SetCurrentNodeVersionAction,
   SetSelectedNodesAction,
   ViewerActionTypes,
@@ -190,7 +189,6 @@ export class AppViewerComponent implements OnInit, OnDestroy {
   }
 
   onViewerVisibilityChanged() {
-    this.store.dispatch(new ReloadDocumentListAction());
     this.navigateToFileLocation();
   }
 

--- a/src/app/extensions/core.extensions.module.ts
+++ b/src/app/extensions/core.extensions.module.ts
@@ -130,6 +130,7 @@ export class CoreExtensionsModule {
       canManagePermissions: rules.canManagePermissions,
       canToggleEditOffline: rules.canToggleEditOffline,
       canToggleFavorite: rules.canToggleFavorite,
+      canToggleFavoriteOnPreview: rules.canToggleFavoriteOnPreview,
       isLibraryManager: rules.isLibraryManager,
       canEditAspects: rules.canEditAspects,
       canInfoPreview: rules.canInfoPreview,

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -928,6 +928,9 @@
               "id": "app.viewer.toggleLock",
               "order": 100,
               "type": "custom",
+              "data": {
+                "reload": true
+              },
               "component": "app.toolbar.toggleEditOffline",
               "rules": {
                 "visible": "canToggleEditOffline"

--- a/src/assets/app.extensions.json
+++ b/src/assets/app.extensions.json
@@ -452,7 +452,9 @@
             "comment": "workaround for Recent Files and Search API issue",
             "type": "custom",
             "order": 400,
-            "data": "['/favorites', '/favorite/libraries']",
+            "data": {
+              "url": "['/favorites', '/favorite/libraries']"
+            },
             "component": "app.toolbar.toggleFavorite",
             "rules": {
               "visible": "canToggleFavorite"
@@ -693,7 +695,9 @@
         "comment": "workaround for Recent Files and Search API issue",
         "type": "custom",
         "order": 802,
-        "data": "['/favorites', '/favorite/libraries']",
+        "data": {
+          "url": "['/favorites', '/favorite/libraries']"
+        },
         "component": "app.toolbar.toggleFavorite",
         "rules": {
           "visible": "canToggleFavorite"
@@ -949,37 +953,16 @@
               }
             },
             {
-              "id": "app.viewer.favorite.add",
-              "order": 300,
-              "title": "APP.ACTIONS.FAVORITE",
-              "icon": "star_border",
-              "actions": {
-                "click": "ADD_FAVORITE"
-              },
-              "rules": {
-                "visible": "app.toolbar.favorite.canAdd"
-              }
-            },
-            {
-              "id": "app.viewer.favorite.remove",
-              "order": 301,
-              "title": "APP.ACTIONS.REMOVE_FAVORITE",
-              "icon": "star",
-              "actions": {
-                "click": "REMOVE_FAVORITE"
-              },
-              "rules": {
-                "visible": "app.toolbar.favorite.canRemove"
-              }
-            },
-            {
               "id": "app.viewer.favorite",
               "comment": "workaround for Recent Files and Search API issue",
               "type": "custom",
               "order": 302,
+              "data": {
+                "reload": true
+              },
               "component": "app.toolbar.toggleFavorite",
               "rules": {
-                "visible": "canToggleFavorite"
+                "visible": "canToggleFavoriteOnPreview"
               }
             },
             {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4438

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
