### PR TITLE
[ACA-4203] The width of the "Size" column is too small and the text gets truncated

### DIFF
--- a/src/app/ui/custom-theme.scss
+++ b/src/app/ui/custom-theme.scss
@@ -33,7 +33,7 @@ $data-table-dividers-wrapper-border: none;
 $data-table-thumbnail-width: 35px;
 $data-table-cell-min-width: 150px;
 $data-table-cell-min-width--no-grow: 120px;
-$data-table-cell-min-width--fileSize: 80px !important;
+$data-table-cell-min-width--fileSize: 110px !important;
 $data-table-cell-text-color: mat-color($foreground, text, 0.54);
 $data-table-cell-link-color: mat-color($foreground, text);
 $data-table-hover-color: #e3fafd;


### PR DESCRIPTION
Changed min-width value of fileSize column to 110px in order to make more letters visible if sort and filter icons are present

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4203


**What is the new behaviour?**
If both sort and filter icons are present only in 5 languages text gets truncated. Also it's truncated to at least 4 letter so it's easy to guess what kind of values are stored inside cells in this column.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
