### PR TITLE
ACA-4526 Alfresco Content Application Docker Images are not available in Docker Hub from 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -201,9 +201,11 @@ jobs:
       script: ./scripts/travis/deploy/publish.sh "app" "$DOCKER_REPOSITORY_DOMAIN" "$QUAY_USERNAME" "$QUAY_PASSORD"
 
     - stage: Release Tag and Publish to Dockerhub
-      script:
-        - ./scripts/travis/release/git-tag.sh
-        - ./scripts/travis/deploy/publish.sh "app" "$DOCKER_HUB_REPOSITORY_DOMAIN" "$DOCKER_HUB_USERNAME" "$DOCKER_HUB_PASSWORD"
+      name: Release Tag
+      script: ./scripts/travis/release/git-tag.sh
+
+    - name: Publish to Dockerhub
+      script: ./scripts/travis/deploy/publish.sh "app" "$DOCKER_HUB_REPOSITORY_DOMAIN" "$DOCKER_HUB_USERNAME" "$DOCKER_HUB_PASSWORD"
 
     - stage: Trigger DW
       script: ./scripts/trigger-travis.sh --pro --branch $TRAVIS_BRANCH Alfresco alfresco-digital-workspace-app $TRAVIS_ACCESS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stages:
     if: type = cron || type = pull_request
   - name: Publish Docker Registry
     if: type = push
-  - name: Release Tag
+  - name: Release Tag and Publish to Dockerhub
     if: branch = master AND type = push
   - name: e2e
     if: type = cron || type = pull_request
@@ -200,7 +200,7 @@ jobs:
       name: Publish Docker Registry
       script: ./scripts/travis/deploy/publish.sh "app" "$DOCKER_REPOSITORY_DOMAIN" "$QUAY_USERNAME" "$QUAY_PASSORD"
 
-    - stage: Release Tag
+    - stage: Release Tag and Publish to Dockerhub
       script:
         - ./scripts/travis/release/git-tag.sh
         - ./scripts/travis/deploy/publish.sh "app" "$DOCKER_HUB_REPOSITORY_DOMAIN" "$DOCKER_HUB_USERNAME" "$DOCKER_HUB_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,10 +198,12 @@ jobs:
 
     - stage: Publish Docker Registry
       name: Publish Docker Registry
-      script: ./scripts/travis/deploy/publish.sh "app"
+      script: ./scripts/travis/deploy/publish.sh "app" "$DOCKER_REPOSITORY_DOMAIN" "$QUAY_USERNAME" "$QUAY_PASSORD"
 
     - stage: Release Tag
-      script: ./scripts/travis/release/git-tag.sh
+      script:
+        - ./scripts/travis/release/git-tag.sh
+        - ./scripts/travis/deploy/publish.sh "app" "$DOCKER_HUB_REPOSITORY_DOMAIN" "$DOCKER_HUB_USERNAME" "$DOCKER_HUB_PASSWORD"
 
     - stage: Trigger DW
       script: ./scripts/trigger-travis.sh --pro --branch $TRAVIS_BRANCH Alfresco alfresco-digital-workspace-app $TRAVIS_ACCESS_TOKEN

--- a/scripts/travis/deploy/publish.sh
+++ b/scripts/travis/deploy/publish.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROJECT_AFFECTED=$1
+PROJECT_AFFECTED="$1"
+DOMAIN="$2"
+USERNAME="$3"
+PASSWORD="$4"
+
 cd $DIR/../../../
 
 npm ci && npm run build.release
@@ -10,7 +14,8 @@ npm ci && npm run build.release
 TAG_VERSION=$(./scripts/travis/deploy/get-docker-image-tag-name.sh)
 echo "Running the docker with tag" $TAG_VERSION
 DOCKER_PROJECT_ARGS="PROJECT_NAME=$PROJECT_AFFECTED"
-DOCKER_REPOSITORY="$DOCKER_REPOSITORY_DOMAIN/$REPO_SLUG"
-# Publish Image to docker
-echo "npx @alfresco/adf-cli docker-publish --loginCheck --loginUsername '$QUAY_USERNAME' --loginPassword '$QUAY_PASSWORD' --loginRepo '$DOCKER_REPOSITORY_DOMAIN' --dockerRepo '$DOCKER_REPOSITORY' --buildArgs $DOCKER_PROJECT_ARGS --dockerTags '$TAG_VERSION,$TRAVIS_BRANCH' "
-npx @alfresco/adf-cli docker-publish --loginCheck --loginUsername "$QUAY_USERNAME" --loginPassword "$QUAY_PASSWORD" --loginRepo "$DOCKER_REPOSITORY_DOMAIN" --dockerRepo "$DOCKER_REPOSITORY" --buildArgs "$DOCKER_PROJECT_ARGS" --dockerTags "$TAG_VERSION,$TRAVIS_BRANCH" --pathProject "$(pwd)"
+DOCKER_REPOSITORY="$DOMAIN/$REPO_SLUG"
+
+# Publish Image to quay.io or dockerhub or another domain
+echo "npx @alfresco/adf-cli docker-publish --loginCheck --loginUsername '$USERNAME' --loginPassword '$PASSWORD' --loginRepo '$DOMAIN' --dockerRepo '$DOCKER_REPOSITORY' --buildArgs  $DOCKER_PROJECT_ARGS  --dockerTags '$TAG_VERSION,$TRAVIS_BRANCH' "
+npx       @alfresco/adf-cli docker-publish --loginCheck --loginUsername "$USERNAME" --loginPassword "$PASSWORD" --loginRepo "$DOMAIN" --dockerRepo "$DOCKER_REPOSITORY" --buildArgs "$DOCKER_PROJECT_ARGS" --dockerTags "$TAG_VERSION,$TRAVIS_BRANCH" --pathProject "$(pwd)"


### PR DESCRIPTION
* Publish images to dockerhub when pushing to master in addition to the tag

**Please check if the PR fulfills these requirements**

> - [*] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [n/a] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [*] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Images are just pushed to quay.io. Pror to 2.4.0 they were only pushed to dockerhub

**What is the new behaviour?**
Images are just pushed to quay.io and dockerhub

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [*] No
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
