### PR TITLE
[ACA-4532] Flaky ACA unit test

### DIFF
--- a/src/app/components/page.component.spec.ts
+++ b/src/app/components/page.component.spec.ts
@@ -259,7 +259,7 @@ describe('Info Drawer state', () => {
     store.setState({
       app: {
         ...appState,
-        infoDrawerOpened: false
+        infoDrawerOpened: true
       }
     });
   });

--- a/src/app/components/page.component.spec.ts
+++ b/src/app/components/page.component.spec.ts
@@ -187,18 +187,20 @@ describe('Info Drawer state', () => {
   let fixture: ComponentFixture<TestComponent>;
 
   let store: MockStore<{ app: Partial<AppState> }>;
-  const appState: Partial<AppState> = {
-    selection: {
-      count: 2,
-      isEmpty: false,
-      libraries: [],
-      nodes: []
-    },
-    navigation: {},
-    infoDrawerOpened: false
-  };
+  let appState: Partial<AppState> = {};
 
   beforeEach(() => {
+    appState = {
+      selection: {
+        count: 2,
+        isEmpty: false,
+        libraries: [],
+        nodes: []
+      },
+      navigation: {},
+      infoDrawerOpened: false
+    };
+
     TestBed.configureTestingModule({
       imports: [AppTestingModule, EffectsModule.forRoot([ViewerEffects])],
       declarations: [TestComponent],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4532

The `Info Drawer state` tests overrides/spy on `store.select` and return always e.g. `true`, on page where the store was used, every `select` method returns boolean then, which caused errors while running tests (this is the only reason which comes to my mind why these tests failed randomly) therefore rewrite these test and uses mocked store (`provideMockStore`).   

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
