### PR TITLE
Fix first extension instruction

### DIFF
--- a/docs/tutorials/how-to-create-your-first-extension.md
+++ b/docs/tutorials/how-to-create-your-first-extension.md
@@ -44,7 +44,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { CoreModule, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
+import { CoreModule, MaterialModule, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
 
 import { MyExtensionComponent } from './my-extension.component';
 import { MyExtensionService } from './my-extension.service';
@@ -70,13 +70,10 @@ export function components() {
     declarations: components(),
     exports: components(),
 })
-export class MyViewModule {
-    constructor(extensions: ExtensionService, myService: MyExtensionService) {
+export class MyExtensionModule {
+    constructor(extensions: ExtensionService) {
         extensions.setComponents({
           'my-extension.main.component' : MyExtensionComponent,
-        });
-        extensions.setEvaluators({
-           'my-extensionr.disabled': () => !myService.mySmartViewerEnabled(),
         });
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
```
ERROR: projects/my-extension/src/lib/my-extension.module.ts:16:53 - error TS2304: Cannot find name 'MaterialModule'.

projects/my-extension/src/lib/my-extension.module.ts:38:50 - error TS2339: Property 'mySmartViewerEnabled' does not exist on type 'MyExtensionService'.

ERROR in app/src/app/extensions.module.ts:31:10 - error TS2305: Module '"my-extension"' has no exported member 'MyExtensionModule'.
```

**What is the new behaviour?**
`Built my-extension`


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
