### PR TITLE
[ACS-3255] Add basic dialog for create / update rule

### DIFF
--- a/app/src/app/services/content-management.service.ts
+++ b/app/src/app/services/content-management.service.ts
@@ -74,7 +74,7 @@ import { forkJoin, Observable, of, zip } from 'rxjs';
 import { catchError, map, mergeMap, take, tap } from 'rxjs/operators';
 import { NodeActionsService } from './node-actions.service';
 import { Router } from '@angular/router';
-import { EditRuleDialogSmartComponent } from '../../../../projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component';
+import { EditRuleDialogSmartComponent } from '@alfresco/aca-folder-rules';
 
 interface RestoredNode {
   status: number;

--- a/app/src/app/services/content-management.service.ts
+++ b/app/src/app/services/content-management.service.ts
@@ -1084,14 +1084,7 @@ export class ContentManagementService {
     if (node && node.entry) {
       this.dialogRef.open(EditRuleDialogSmartComponent, {
         minWidth: '70%',
-        panelClass: 'aca-edit-rule-dialog-container',
-        data: {
-          model: {
-            id: 'rule-id',
-            name: 'Test rule',
-            description: 'This is the rule description'
-          }
-        }
+        panelClass: 'aca-edit-rule-dialog-container'
       });
     }
   }

--- a/app/src/app/services/content-management.service.ts
+++ b/app/src/app/services/content-management.service.ts
@@ -74,6 +74,7 @@ import { forkJoin, Observable, of, zip } from 'rxjs';
 import { catchError, map, mergeMap, take, tap } from 'rxjs/operators';
 import { NodeActionsService } from './node-actions.service';
 import { Router } from '@angular/router';
+import { EditRuleDialogSmartComponent } from '../../../../projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component';
 
 interface RestoredNode {
   status: number;
@@ -1077,5 +1078,21 @@ export class ContentManagementService {
       )
       .onAction()
       .subscribe(() => this.undoMoveNodes(moveResponse, initialParentId));
+  }
+
+  manageRules(node: any) {
+    if (node && node.entry) {
+      this.dialogRef.open(EditRuleDialogSmartComponent, {
+        minWidth: '70%',
+        panelClass: 'aca-edit-rule-dialog-container',
+        data: {
+          model: {
+            id: 'rule-id',
+            name: 'Test rule',
+            description: 'This is the rule description'
+          }
+        }
+      });
+    }
   }
 }

--- a/app/src/app/store/effects/node.effects.ts
+++ b/app/src/app/store/effects/node.effects.ts
@@ -48,7 +48,8 @@ import {
   getAppSelection,
   ManageAspectsAction,
   NavigateRouteAction,
-  ExpandInfoDrawerAction, ManageRulesAction
+  ExpandInfoDrawerAction,
+  ManageRulesAction
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { ViewUtilService } from '@alfresco/adf-core';
@@ -440,6 +441,6 @@ export class NodeEffects {
           }
         })
       ),
-      { dispatch: false }
+    { dispatch: false }
   );
 }

--- a/app/src/app/store/effects/node.effects.ts
+++ b/app/src/app/store/effects/node.effects.ts
@@ -48,7 +48,7 @@ import {
   getAppSelection,
   ManageAspectsAction,
   NavigateRouteAction,
-  ExpandInfoDrawerAction
+  ExpandInfoDrawerAction, ManageRulesAction
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { ViewUtilService } from '@alfresco/adf-core';
@@ -420,4 +420,26 @@ export class NodeEffects {
       }
     }
   }
+
+  manageRules$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType<ManageRulesAction>(NodeActionTypes.ManageRules),
+        map((action) => {
+          if (action && action.payload) {
+            this.contentService.manageRules(action.payload);
+          } else {
+            this.store
+              .select(getAppSelection)
+              .pipe(take(1))
+              .subscribe((selection) => {
+                if (selection && !selection.isEmpty) {
+                  this.contentService.manageRules(selection.nodes[0]);
+                }
+              });
+          }
+        })
+      ),
+      { dispatch: false }
+  );
 }

--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -5,6 +5,27 @@
       "CREATE_RULES_DESC": "[tbd] Creates new rules",
       "LINK_RULES": "Link to rules set",
       "LINK_RULES_DESC": "[tbd] Link to existing rules"
+    },
+    "EDIT_RULE_DIALOG": {
+      "CANCEL": "Cancel",
+      "CREATE": "Create",
+      "CREATE_TITLE": "Create a rule",
+      "UPDATE": "Update",
+      "UPDATE_TITLE": "Update a rule"
+    },
+    "RULE_DETAILS": {
+      "LABEL": {
+        "NAME": "Name",
+        "DESCRIPTION": "Description"
+      },
+      "PLACEHOLDER": {
+        "NAME": "Enter rule name",
+        "DESCRIPTION": "Enter rule description",
+        "NO_DESCRIPTION": "No description"
+      },
+      "ERROR": {
+        "REQUIRED": "This field is required"
+      }
     }
   }
 }

--- a/projects/aca-folder-rules/src/lib/model/rule-composite-condition.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/rule-composite-condition.model.ts
@@ -23,27 +23,11 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { CoreModule, TranslationService } from '@alfresco/adf-core';
-import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { NgModule } from '@angular/core';
-import * as rules from './folder-rules.rules';
-import { CommonModule } from '@angular/common';
+import { RuleSimpleCondition } from './rule-simple-condition.model';
 
-import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
-import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
-
-@NgModule({
-  providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
-  declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent]
-})
-export class AcaFolderRulesModule {
-  constructor(translation: TranslationService, extensions: ExtensionService) {
-    translation.addTranslationFolder('aca-folder-rules', 'assets/aca-folder-rules');
-
-    extensions.setEvaluators({
-      'rules.canCreateFolderRule': rules.canCreateFolderRule,
-      'rules.canLinkFolderRule': rules.canLinkFolderRule
-    });
-  }
+export interface RuleCompositeCondition {
+  inverted: boolean;
+  booleanMode: 'and' | 'or';
+  compositeConditions: RuleCompositeCondition[];
+  simpleConditions: RuleSimpleCondition[];
 }

--- a/projects/aca-folder-rules/src/lib/model/rule-simple-condition.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/rule-simple-condition.model.ts
@@ -23,27 +23,8 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { CoreModule, TranslationService } from '@alfresco/adf-core';
-import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { NgModule } from '@angular/core';
-import * as rules from './folder-rules.rules';
-import { CommonModule } from '@angular/common';
-
-import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
-import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
-
-@NgModule({
-  providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
-  declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent]
-})
-export class AcaFolderRulesModule {
-  constructor(translation: TranslationService, extensions: ExtensionService) {
-    translation.addTranslationFolder('aca-folder-rules', 'assets/aca-folder-rules');
-
-    extensions.setEvaluators({
-      'rules.canCreateFolderRule': rules.canCreateFolderRule,
-      'rules.canLinkFolderRule': rules.canLinkFolderRule
-    });
-  }
+export interface RuleSimpleCondition {
+  field: string;
+  comparator: string;
+  parameter: string;
 }

--- a/projects/aca-folder-rules/src/lib/model/rule.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/rule.model.ts
@@ -23,27 +23,18 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { CoreModule, TranslationService } from '@alfresco/adf-core';
-import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { NgModule } from '@angular/core';
-import * as rules from './folder-rules.rules';
-import { CommonModule } from '@angular/common';
+import { RuleCompositeCondition } from './rule-composite-condition.model';
 
-import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
-import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
-
-@NgModule({
-  providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
-  declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent]
-})
-export class AcaFolderRulesModule {
-  constructor(translation: TranslationService, extensions: ExtensionService) {
-    translation.addTranslationFolder('aca-folder-rules', 'assets/aca-folder-rules');
-
-    extensions.setEvaluators({
-      'rules.canCreateFolderRule': rules.canCreateFolderRule,
-      'rules.canLinkFolderRule': rules.canLinkFolderRule
-    });
-  }
+export interface Rule {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  cascade: boolean;
+  asynchronous: boolean;
+  errorScript: string;
+  shared: boolean;
+  triggers: ('inbound' | 'update' | 'outbound')[];
+  conditions: RuleCompositeCondition;
+  actions: string[];
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -1,0 +1,17 @@
+<div mat-dialog-title class="aca-edit-rule-dialog__header">
+  <div class="aca-edit-rule-dialog__header__title" data-automation-id="edit-rule-dialog-title">
+    {{ title | translate }}
+  </div>
+  <button mat-icon-button mat-dialog-close class="aca-edit-rule-dialog__header__close" tabindex="-1">
+    <mat-icon>close</mat-icon>
+  </button>
+</div>
+
+<mat-dialog-content class="aca-edit-rule-dialog__content">
+  <aca-rule-details (formValidationChanged)="formValid = $event" [initialValue]="model"></aca-rule-details>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="aca-edit-rule-dialog__footer">
+  <button mat-flat-button mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</button>
+  <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit">{{ submitLabel | translate }}</button>
+</mat-dialog-actions>

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.scss
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.scss
@@ -1,0 +1,42 @@
+.aca-edit-rule-dialog-container {
+  --edit-rule-dialog-padding: 8px 20px;
+
+  .mat-dialog-container {
+    padding: 0;
+  }
+}
+
+.aca-edit-rule-dialog {
+  &__header {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: var(--edit-rule-dialog-padding);
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--theme-border-color);
+
+    &__title {
+      font-size: 16px;
+      font-weight: bold;
+      flex-grow: 1;
+    }
+
+    &__close {
+      & mat-icon {
+        font-size: 18px;
+      }
+    }
+  }
+
+  &__content {
+    margin: 0;
+    padding: 0;
+  }
+
+  &__footer {
+    margin: 0;
+    padding: var(--edit-rule-dialog-padding);
+    box-sizing: border-box;
+    border-top: 1px solid var(--theme-border-color);
+  }
+}

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.spec.ts
@@ -1,0 +1,115 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditRuleDialogOptions, EditRuleDialogSmartComponent } from './edit-rule-dialog.smart-component';
+import { By } from '@angular/platform-browser';
+import { RuleDetailsUiComponent } from './rule-details.ui-component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { CoreTestingModule } from '@alfresco/adf-core';
+
+describe('EditRuleDialogComponent', () => {
+  let fixture: ComponentFixture<EditRuleDialogSmartComponent>;
+
+  const dialogRef = {
+    close: jasmine.createSpy('close'),
+    open: jasmine.createSpy('open')
+  };
+
+  const setupBeforeEach = (dialogOptions: EditRuleDialogOptions = {}) => {
+    TestBed.configureTestingModule({
+      imports: [CoreTestingModule],
+      declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: dialogOptions }
+      ]
+    });
+
+    fixture = TestBed.createComponent(EditRuleDialogSmartComponent);
+  };
+
+  describe('No dialog options passed / indifferent', () => {
+    beforeEach(() => {
+      setupBeforeEach();
+    });
+
+    it('should activate the submit button only when a valid state is received', () => {
+      fixture.detectChanges();
+      const submitButton = fixture.debugElement.query(By.css('[data-automation-id="edit-rule-dialog-submit"]')).nativeElement as HTMLButtonElement;
+      const ruleDetails = fixture.debugElement.query(By.directive(RuleDetailsUiComponent)).componentInstance as RuleDetailsUiComponent;
+      ruleDetails.formValidationChanged.emit(true);
+
+      fixture.detectChanges();
+      expect(submitButton.disabled).toBeFalsy();
+      ruleDetails.formValidationChanged.emit(false);
+
+      fixture.detectChanges();
+      expect(submitButton.disabled).toBeTruthy();
+    });
+
+    it('should show a "create" label in the title', () => {
+      fixture.detectChanges();
+      const titleElement = fixture.debugElement.query(By.css('[data-automation-id="edit-rule-dialog-title"]')).nativeElement as HTMLDivElement;
+
+      expect(titleElement.innerText.trim()).toBe('ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CREATE_TITLE');
+    });
+
+    it('should show a "create" label in the submit button', () => {
+      fixture.detectChanges();
+      const titleElement = fixture.debugElement.query(By.css('[data-automation-id="edit-rule-dialog-submit"]')).nativeElement as HTMLButtonElement;
+
+      expect(titleElement.innerText.trim()).toBe('ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CREATE');
+    });
+  });
+
+  describe('With dialog options passed', () => {
+    const dialogOptions: EditRuleDialogOptions = {
+      model: {
+        id: 'rule-id',
+        name: 'Rule name',
+        description: 'This is the description of the rule'
+      }
+    };
+
+    beforeEach(() => {
+      setupBeforeEach(dialogOptions);
+    });
+
+    it('should show an "update" label in the title', () => {
+      fixture.detectChanges();
+      const titleElement = fixture.debugElement.query(By.css('[data-automation-id="edit-rule-dialog-title"]')).nativeElement as HTMLDivElement;
+
+      expect(titleElement.innerText.trim()).toBe('ACA_FOLDER_RULES.EDIT_RULE_DIALOG.UPDATE_TITLE');
+    });
+
+    it('should show a "create" label in the submit button', () => {
+      fixture.detectChanges();
+      const titleElement = fixture.debugElement.query(By.css('[data-automation-id="edit-rule-dialog-submit"]')).nativeElement as HTMLButtonElement;
+
+      expect(titleElement.innerText.trim()).toBe('ACA_FOLDER_RULES.EDIT_RULE_DIALOG.UPDATE');
+    });
+  });
+});

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -23,27 +23,38 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { CoreModule, TranslationService } from '@alfresco/adf-core';
-import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { NgModule } from '@angular/core';
-import * as rules from './folder-rules.rules';
-import { CommonModule } from '@angular/common';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Rule } from '../model/rule.model';
 
-import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
-import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
+export interface EditRuleDialogOptions {
+  model?: Partial<Rule>;
+}
 
-@NgModule({
-  providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
-  declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent]
+@Component({
+  selector: 'aca-edit-rule-dialog',
+  templateUrl: './edit-rule-dialog.smart-component.html',
+  styleUrls: ['./edit-rule-dialog.smart-component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  host: { class: 'aca-edit-rule-dialog' }
 })
-export class AcaFolderRulesModule {
-  constructor(translation: TranslationService, extensions: ExtensionService) {
-    translation.addTranslationFolder('aca-folder-rules', 'assets/aca-folder-rules');
+export class EditRuleDialogSmartComponent {
+  formValid = false;
+  model: Partial<Rule>;
 
-    extensions.setEvaluators({
-      'rules.canCreateFolderRule': rules.canCreateFolderRule,
-      'rules.canLinkFolderRule': rules.canLinkFolderRule
-    });
+  constructor(@Inject(MAT_DIALOG_DATA) public options: EditRuleDialogOptions) {
+    this.model = this.options?.model || {};
+  }
+
+  get isUpdateMode(): boolean {
+    return !!this.options?.model?.id;
+  }
+
+  get title(): string {
+    return 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.' + (this.isUpdateMode ? 'UPDATE_TITLE' : 'CREATE_TITLE');
+  }
+
+  get submitLabel(): string {
+    return 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.' + (this.isUpdateMode ? 'UPDATE' : 'CREATE');
   }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
@@ -1,0 +1,27 @@
+<form class="aca-rule-details__form" [formGroup]="form">
+  <div class="aca-rule-details__form__row">
+    <label for="rule-details-name-input">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LABEL.NAME' | translate }}</label>
+    <div>
+      <mat-form-field floatLabel='never'>
+        <input
+          id="rule-details-name-input"
+          matInput type="text" formControlName="name" data-automation-id="rule-details-name-input"
+          [placeholder]="getPlaceholder('name') | translate">
+        <mat-error>{{ getErrorMessage(name) | translate }}</mat-error>
+      </mat-form-field>
+    </div>
+  </div>
+
+  <div class="aca-rule-details__form__row">
+    <label for="rule-details-description-textarea">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LABEL.DESCRIPTION' | translate }}</label>
+    <div>
+      <mat-form-field floatLabel='never'>
+        <textarea
+          id="rule-details-description-textarea"
+          matInput formControlName="description" data-automation-id="rule-details-description-textarea"
+          [placeholder]="getPlaceholder('description') | translate">
+        </textarea>
+      </mat-form-field>
+    </div>
+  </div>
+</form>

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.scss
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.scss
@@ -1,0 +1,44 @@
+.aca-rule-details {
+  &__form {
+    padding: 20px;
+
+    &__row {
+      display: flex;
+      gap: 8px;
+
+      & > label {
+        font-weight: bold;
+        width: 20%;
+        min-width: 100px;
+        max-width: 150px;
+        padding-top: 0.75em;
+      }
+
+      & > div {
+        flex-grow: 1;
+
+        mat-form-field {
+          width: 100%;
+          font-size: inherit;
+
+          .mat-form-field-infix {
+            border: none;
+          }
+        }
+      }
+    }
+
+    hr {
+      border: none;
+      border-bottom: 1px solid var(--theme-border-color);
+    }
+
+    *:disabled {
+      color: #000000;
+    }
+
+    textarea {
+      min-height: 4em;
+    }
+  }
+}

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.spec.ts
@@ -1,0 +1,87 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CoreTestingModule } from '@alfresco/adf-core';
+import { RuleDetailsUiComponent } from './rule-details.ui-component';
+import { Rule } from '../model/rule.model';
+import { By } from '@angular/platform-browser';
+
+describe('RuleDetailsUiComponent', () => {
+  let fixture: ComponentFixture<RuleDetailsUiComponent>;
+  let component: RuleDetailsUiComponent;
+
+  const initialValue: Partial<Rule> = {
+    id: 'rule-id',
+    name: 'Rule name',
+    description: 'This is the description of the rule'
+  };
+
+  const getHtmlElement = <T>(dataAutomationId: string) =>
+    fixture.debugElement.query(By.css(`[data-automation-id="${dataAutomationId}"]`)).nativeElement as T;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CoreTestingModule],
+      declarations: [RuleDetailsUiComponent]
+    });
+
+    fixture = TestBed.createComponent(RuleDetailsUiComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should fill the form out with initial values', () => {
+    component.initialValue = initialValue;
+    fixture.detectChanges();
+
+    const nameInput = getHtmlElement<HTMLInputElement>('rule-details-name-input');
+    const descriptionTextarea = getHtmlElement<HTMLTextAreaElement>('rule-details-description-textarea');
+
+    expect(nameInput.value).toBe(initialValue.name);
+    expect(descriptionTextarea.value).toBe(initialValue.description);
+  });
+
+  it('should be editable if not read-only', () => {
+    component.readOnly = false;
+    fixture.detectChanges();
+
+    const nameInput = getHtmlElement<HTMLInputElement>('rule-details-name-input');
+    const descriptionTextarea = getHtmlElement<HTMLTextAreaElement>('rule-details-description-textarea');
+
+    expect(nameInput.disabled).toBeFalsy();
+    expect(descriptionTextarea.disabled).toBeFalsy();
+  });
+
+  it('should not be editable if read-only', () => {
+    component.readOnly = true;
+    fixture.detectChanges();
+
+    const nameInput = getHtmlElement<HTMLInputElement>('rule-details-name-input');
+    const descriptionTextarea = getHtmlElement<HTMLTextAreaElement>('rule-details-description-textarea');
+
+    expect(nameInput.disabled).toBeTruthy();
+    expect(descriptionTextarea.disabled).toBeTruthy();
+  });
+});

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
@@ -1,0 +1,125 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
+import { Rule } from '../model/rule.model';
+
+@Component({
+  selector: 'aca-rule-details',
+  templateUrl: './rule-details.ui-component.html',
+  styleUrls: ['./rule-details.ui-component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  host: { class: 'aca-rule-details' }
+})
+export class RuleDetailsUiComponent implements OnInit, OnDestroy {
+  private _readOnly = false;
+  @Input()
+  get readOnly(): boolean {
+    return this._readOnly;
+  }
+  set readOnly(value: boolean) {
+    this._readOnly = value;
+    if (this.form?.disable) {
+      if (value) {
+        this.form.disable();
+      } else {
+        this.form.enable();
+      }
+    }
+  }
+  @Input()
+  initialValue: Partial<Rule> = {};
+
+  @Output()
+  formValidationChanged = new EventEmitter<boolean>();
+  @Output()
+  formValueChanged = new EventEmitter<Partial<Rule>>();
+
+  private onDestroy$ = new Subject();
+  form: FormGroup;
+
+  get name(): AbstractControl {
+    return this.form.get('name');
+  }
+
+  get description(): AbstractControl {
+    return this.form.get('description');
+  }
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.form = this.formBuilder.group({
+      name: [this.initialValue.name || '', Validators.required],
+      description: [this.initialValue.description || '']
+    });
+    this.readOnly = this._readOnly;
+
+    this.form.statusChanges
+      .pipe(
+        map(() => this.form.valid),
+        distinctUntilChanged(),
+        takeUntil(this.onDestroy$)
+      )
+      .subscribe((value: boolean) => {
+        this.formValidationChanged.emit(value);
+      });
+    this.formValidationChanged.emit(this.form.valid);
+
+    this.form.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe((newFormValue: any) => {
+      this.formValueChanged.emit(newFormValue);
+    });
+  }
+
+  ngOnDestroy() {
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
+  }
+
+  getErrorMessage(control: AbstractControl): string {
+    if (control.hasError('required')) {
+      return 'ACA_FOLDER_RULES.RULE_DETAILS.ERROR.REQUIRED';
+    }
+    return '';
+  }
+
+  getPlaceholder(fieldName: string): string {
+    let str = 'ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.';
+    switch (fieldName) {
+      case 'name':
+        str += 'NAME';
+        break;
+      case 'description':
+        str += this.readOnly ? 'NO_DESCRIPTION' : 'DESCRIPTION';
+        break;
+      default:
+        return '';
+    }
+    return str;
+  }
+}

--- a/projects/aca-folder-rules/src/public-api.ts
+++ b/projects/aca-folder-rules/src/public-api.ts
@@ -24,3 +24,4 @@
  */
 
 export * from './lib/folder-rules.module';
+export { EditRuleDialogSmartComponent } from './lib/rule-details/edit-rule-dialog.smart-component';

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -47,7 +47,8 @@ export enum NodeActionTypes {
   AddFavorite = 'ADD_FAVORITE',
   RemoveFavorite = 'REMOVE_FAVORITE',
   ChangeAspects = 'ASPECT_LIST',
-  ExpandInfoDrawer = 'EXPAND_INFO_DRAWER'
+  ExpandInfoDrawer = 'EXPAND_INFO_DRAWER',
+  ManageRules = 'MANAGE_RULES'
 }
 
 export class SetSelectedNodesAction implements Action {
@@ -170,6 +171,12 @@ export class RemoveFavoriteAction implements Action {
 }
 export class ManageAspectsAction implements Action {
   readonly type = NodeActionTypes.ChangeAspects;
+
+  constructor(public payload: MinimalNodeEntity) {}
+}
+
+export class ManageRulesAction implements Action {
+  readonly type = NodeActionTypes.ManageRules;
 
   constructor(public payload: MinimalNodeEntity) {}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-3255

**What is the new behaviour?**

New dialog for creating / updating a rule.

This first PR contains the following:
- Basic rule details component with name & description fields which can be reused for both the create / update dialog as well as simply viewing the rule details on the manage rules page
- Read-only functionality
- Possibility to provide with existing values to fill out the form (and put the dialog in "update" mode)
- Models for the Rule as well as the Simple and Composite conditions
- Some code for opening the dialog from a context menu

This PR does NOT contain:
- Addition to the `app.extensions.json` file, meaning that upon merging the PR, no context menu item will appear yet (to avoid releasing unfinished work)
- Any API call which creates/updates the rule as a result of pressing the submit button

These will both be covered in [ACS-3260](https://alfresco.atlassian.net/browse/ACS-3260)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
