### PR TITLE
Bug fix. Don't lose the contentService property after page refresh.

### DIFF
--- a/app/src/app/services/content-service-extension.service.ts
+++ b/app/src/app/services/content-service-extension.service.ts
@@ -15,7 +15,17 @@ import { take } from 'rxjs/operators';
 })
 export class ContentServiceExtensionService {
   constructor(private appConfigService: AppConfigService) {
-    this.updateContentServiceAvailability();
+    this.prepareContentServiceProperty();
+  }
+
+  private prepareContentServiceProperty() {
+    if (!this.existsContentServicePropertyLocalStorage()) {
+      this.updateContentServiceAvailability();
+    }
+  }
+
+  private existsContentServicePropertyLocalStorage() {
+    return localStorage && localStorage.getItem('contentService');
   }
 
   updateContentServiceAvailability() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

With each page refresh, the `contentService` property is reset to the environment variable setting. This makes setting this property through the interface meaningless. I'm refer to the configuration screen currently accessed via the `#/settings` route and checkbox "Enable Content Services Extensions".

**What is the new behaviour?**
The configuration preference will be the one in the browser's storage. If not exists, it will follow the flow that was already exists and create the respective property.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
