### PR TITLE
[ACA-3379] Routing & skeleton for manage rules screen

### DIFF
--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -8,7 +8,8 @@
   "loginRoute": "login",
   "plugins": {
     "aosPlugin": ${APP_CONFIG_PLUGIN_AOS},
-    "contentService": ${APP_CONFIG_PLUGIN_CONTENT_SERVICE}
+    "contentService": ${APP_CONFIG_PLUGIN_CONTENT_SERVICE},
+    "folderRules": ${APP_CONFIG_PLUGIN_FOLDER_RULES}
   },
   "oauth2": {
     "host": "${APP_CONFIG_OAUTH2_HOST}",

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -38,7 +38,6 @@ import { RecentFilesComponent } from './components/recent-files/recent-files.com
 import { SharedFilesComponent } from './components/shared-files/shared-files.component';
 import { DetailsComponent } from './components/details/details.component';
 import { HomeComponent } from './components/home/home.component';
-import { ManageRulesSmartComponent } from '@alfresco/aca-folder-rules';
 
 export const APP_ROUTES: Routes = [
   {
@@ -553,8 +552,8 @@ export const APP_ROUTES: Routes = [
         path: 'nodes/:nodeId',
         children: [
           {
-            path: 'rules',
-            component: ManageRulesSmartComponent
+            path: '',
+            loadChildren: () => import('@alfresco/aca-folder-rules').then((m) => m.AcaFolderRulesModule)
           }
         ]
       },

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -38,6 +38,7 @@ import { RecentFilesComponent } from './components/recent-files/recent-files.com
 import { SharedFilesComponent } from './components/shared-files/shared-files.component';
 import { DetailsComponent } from './components/details/details.component';
 import { HomeComponent } from './components/home/home.component';
+import { ManageRulesSmartComponent } from '@alfresco/aca-folder-rules';
 
 export const APP_ROUTES: Routes = [
   {
@@ -553,11 +554,7 @@ export const APP_ROUTES: Routes = [
         children: [
           {
             path: 'rules',
-            loadChildren: () => import('@alfresco/aca-folder-rules').then((m) => m.AcaFolderRulesModule)
-          },
-          {
-            path: '**',
-            component: GenericErrorComponent
+            component: ManageRulesSmartComponent
           }
         ]
       },

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -549,6 +549,19 @@ export const APP_ROUTES: Routes = [
         ]
       },
       {
+        path: 'nodes/:nodeId',
+        children: [
+          {
+            path: 'rules',
+            loadChildren: () => import('@alfresco/aca-folder-rules').then((m) => m.AcaFolderRulesModule)
+          },
+          {
+            path: '**',
+            component: GenericErrorComponent
+          }
+        ]
+      },
+      {
         path: '**',
         component: GenericErrorComponent
       }

--- a/app/src/app/services/content-management.service.ts
+++ b/app/src/app/services/content-management.service.ts
@@ -74,7 +74,6 @@ import { forkJoin, Observable, of, zip } from 'rxjs';
 import { catchError, map, mergeMap, take, tap } from 'rxjs/operators';
 import { NodeActionsService } from './node-actions.service';
 import { Router } from '@angular/router';
-import { EditRuleDialogSmartComponent } from '@alfresco/aca-folder-rules';
 
 interface RestoredNode {
   status: number;
@@ -1078,14 +1077,5 @@ export class ContentManagementService {
       )
       .onAction()
       .subscribe(() => this.undoMoveNodes(moveResponse, initialParentId));
-  }
-
-  manageRules(node: any) {
-    if (node && node.entry) {
-      this.dialogRef.open(EditRuleDialogSmartComponent, {
-        minWidth: '70%',
-        panelClass: 'aca-edit-rule-dialog-container'
-      });
-    }
   }
 }

--- a/app/src/app/store/effects/node.effects.ts
+++ b/app/src/app/store/effects/node.effects.ts
@@ -428,14 +428,14 @@ export class NodeEffects {
         ofType<ManageRulesAction>(NodeActionTypes.ManageRules),
         map((action) => {
           if (action && action.payload) {
-            this.contentService.manageRules(action.payload);
+            this.store.dispatch(new NavigateRouteAction(['nodes', action.payload.entry.id, 'rules']));
           } else {
             this.store
               .select(getAppSelection)
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.manageRules(selection.nodes[0]);
+                  this.store.dispatch(new NavigateRouteAction(['nodes', selection.first.entry.id, 'rules']));
                 }
               });
           }

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -597,6 +597,18 @@
             }
           },
           {
+            "id": "app.toolbar.rules",
+            "title": "ACA_FOLDER_RULES.ACTIONS.MANAGE_RULES",
+            "icon": "gavel",
+            "order": 1300,
+            "actions": {
+              "click": "MANAGE_RULES"
+            },
+            "rules": {
+              "visible": "rules.canManageFolderRules"
+            }
+          },
+          {
             "id": "app.toolbar.deleteLibrary",
             "order": 100,
             "title": "APP.ACTIONS.DELETE",
@@ -811,6 +823,18 @@
         },
         "rules": {
           "visible": "canManagePermissions"
+        }
+      },
+      {
+        "id": "app.context.menu.rules",
+        "title": "ACA_FOLDER_RULES.ACTIONS.MANAGE_RULES",
+        "icon": "gavel",
+        "order": 1600,
+        "actions": {
+          "click": "MANAGE_RULES"
+        },
+        "rules": {
+          "visible": "rules.canManageFolderRules"
         }
       },
       {

--- a/e2e/suites/actions-available/files-folders/test-data.ts
+++ b/e2e/suites/actions-available/files-folders/test-data.ts
@@ -808,20 +808,20 @@ export const folder2InTrash = {
 
 // ---- folders ---
 
-const folderContextMenu = ['Download', 'Edit', 'Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions'];
-const folderFavContextMenu = ['Download', 'Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions'];
+const folderContextMenu = ['Download', 'Edit', 'Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions', 'Manage rules'];
+const folderFavContextMenu = ['Download', 'Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions', 'Manage rules'];
 const folderToolbarPrimary = ['Download', 'View Details', 'More Actions'];
-const folderToolbarMore = ['Edit', 'Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions'];
-const folderFavToolbarMore = ['Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions'];
+const folderToolbarMore = ['Edit', 'Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions', 'Manage rules'];
+const folderFavToolbarMore = ['Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete', 'Edit Aspects', 'Permissions', 'Manage rules'];
 
 const favoritesFolderFavContextMenu = ['Download', 'Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete'];
 const favoritesFolderFavToolbarMore = ['Edit', 'Remove Favorite', 'Move', 'Copy', 'Delete'];
 
-const searchFolderContextMenu = ['Download', 'Edit', 'Favorite', 'Copy', 'Edit Aspects', 'Permissions'];
+const searchFolderContextMenu = ['Download', 'Edit', 'Favorite', 'Copy', 'Edit Aspects', 'Permissions', 'Manage rules'];
 const searchFolderToolbarPrimary = ['Download', 'View Details', 'More Actions'];
-const searchFolderToolbarMore = ['Edit', 'Favorite', 'Copy', 'Edit Aspects', 'Permissions'];
-const searchFolderFavContextMenu = ['Download', 'Edit', 'Remove Favorite', 'Copy', 'Edit Aspects', 'Permissions'];
-const searchFolderFavToolbarMore = ['Edit', 'Remove Favorite', 'Copy', 'Edit Aspects', 'Permissions'];
+const searchFolderToolbarMore = ['Edit', 'Favorite', 'Copy', 'Edit Aspects', 'Permissions', 'Manage rules'];
+const searchFolderFavContextMenu = ['Download', 'Edit', 'Remove Favorite', 'Copy', 'Edit Aspects', 'Permissions', 'Manage rules'];
+const searchFolderFavToolbarMore = ['Edit', 'Remove Favorite', 'Copy', 'Edit Aspects', 'Permissions', 'Manage rules'];
 
 export const folder = {
   name: `folderActions-${random}`,

--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -1,10 +1,7 @@
 {
   "ACA_FOLDER_RULES": {
-    "MENU": {
-      "CREATE_RULES": "Create rules",
-      "CREATE_RULES_DESC": "[tbd] Creates new rules",
-      "LINK_RULES": "Link to rules set",
-      "LINK_RULES_DESC": "[tbd] Link to existing rules"
+    "ACTIONS": {
+      "MANAGE_RULES": "Manage rules"
     },
     "EDIT_RULE_DIALOG": {
       "CANCEL": "Cancel",

--- a/projects/aca-folder-rules/src/lib/folder-rules.module.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.module.ts
@@ -28,14 +28,22 @@ import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensio
 import { NgModule } from '@angular/core';
 import * as rules from './folder-rules.rules';
 import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
 
 import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
 import { ManageRulesSmartComponent } from './manage-rules/manage-rules.smart-component';
 import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
 
+const routes: Routes = [
+  {
+    path: 'rules',
+    component: ManageRulesSmartComponent
+  }
+];
+
 @NgModule({
   providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
+  imports: [CommonModule, RouterModule.forChild(routes), CoreModule.forChild()],
   declarations: [EditRuleDialogSmartComponent, ManageRulesSmartComponent, RuleDetailsUiComponent]
 })
 export class AcaFolderRulesModule {

--- a/projects/aca-folder-rules/src/lib/folder-rules.module.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.module.ts
@@ -39,15 +39,11 @@ const routes: Routes = [
     path: '',
     component: ManageRulesSmartComponent
   }
-]
+];
 
 @NgModule({
   providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [
-    CommonModule,
-    CoreModule.forChild(),
-    RouterModule.forChild(routes)
-  ],
+  imports: [CommonModule, CoreModule.forChild(), RouterModule.forChild(routes)],
   declarations: [EditRuleDialogSmartComponent, ManageRulesSmartComponent, RuleDetailsUiComponent]
 })
 export class AcaFolderRulesModule {

--- a/projects/aca-folder-rules/src/lib/folder-rules.module.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.module.ts
@@ -28,22 +28,34 @@ import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensio
 import { NgModule } from '@angular/core';
 import * as rules from './folder-rules.rules';
 import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
 
 import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
+import { ManageRulesSmartComponent } from './manage-rules/manage-rules.smart-component';
 import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ManageRulesSmartComponent
+  }
+]
 
 @NgModule({
   providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild()],
-  declarations: [EditRuleDialogSmartComponent, RuleDetailsUiComponent]
+  imports: [
+    CommonModule,
+    CoreModule.forChild(),
+    RouterModule.forChild(routes)
+  ],
+  declarations: [EditRuleDialogSmartComponent, ManageRulesSmartComponent, RuleDetailsUiComponent]
 })
 export class AcaFolderRulesModule {
   constructor(translation: TranslationService, extensions: ExtensionService) {
     translation.addTranslationFolder('aca-folder-rules', 'assets/aca-folder-rules');
 
     extensions.setEvaluators({
-      'rules.canCreateFolderRule': rules.canCreateFolderRule,
-      'rules.canLinkFolderRule': rules.canLinkFolderRule
+      'rules.canManageFolderRules': rules.canManageFolderRules
     });
   }
 }

--- a/projects/aca-folder-rules/src/lib/folder-rules.module.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.module.ts
@@ -28,22 +28,14 @@ import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensio
 import { NgModule } from '@angular/core';
 import * as rules from './folder-rules.rules';
 import { CommonModule } from '@angular/common';
-import { RouterModule, Routes } from '@angular/router';
 
 import { EditRuleDialogSmartComponent } from './rule-details/edit-rule-dialog.smart-component';
 import { ManageRulesSmartComponent } from './manage-rules/manage-rules.smart-component';
 import { RuleDetailsUiComponent } from './rule-details/rule-details.ui-component';
 
-const routes: Routes = [
-  {
-    path: '',
-    component: ManageRulesSmartComponent
-  }
-];
-
 @NgModule({
   providers: [provideExtensionConfig(['folder-rules.plugin.json'])],
-  imports: [CommonModule, CoreModule.forChild(), RouterModule.forChild(routes)],
+  imports: [CommonModule, CoreModule.forChild()],
   declarations: [EditRuleDialogSmartComponent, ManageRulesSmartComponent, RuleDetailsUiComponent]
 })
 export class AcaFolderRulesModule {

--- a/projects/aca-folder-rules/src/lib/folder-rules.rules.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.rules.ts
@@ -23,10 +23,10 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AcaRuleContext, hasFolderSelected, canEditFolder } from '@alfresco/aca-shared/rules';
+import { AcaRuleContext, hasFolderSelected, canEditFolder, isNotFavorites } from '@alfresco/aca-shared/rules';
 
 export const isFolderRulesEnabled = (context: AcaRuleContext) => context.appConfig.get<boolean>('plugins.folderRules', false);
 export const isFolderRulesAllowed = (context: AcaRuleContext) =>
-  isFolderRulesEnabled(context) && canEditFolder(context) && hasFolderSelected(context);
+  isFolderRulesEnabled(context) && canEditFolder(context) && hasFolderSelected(context) && isNotFavorites(context);
 
 export const canManageFolderRules = (context: AcaRuleContext): boolean => isFolderRulesAllowed(context);

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -23,10 +23,12 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AcaRuleContext, hasFolderSelected, canEditFolder } from '@alfresco/aca-shared/rules';
+import { Component } from '@angular/core';
 
-export const isFolderRulesEnabled = (context: AcaRuleContext) => context.appConfig.get<boolean>('plugins.folderRules', false);
-export const isFolderRulesAllowed = (context: AcaRuleContext) =>
-  isFolderRulesEnabled(context) && canEditFolder(context) && hasFolderSelected(context);
+@Component({
+  selector: 'aca-manage-rules',
+  template: `<div>This is the Manage Rules component</div>`
+})
+export class ManageRulesSmartComponent {
 
-export const canManageFolderRules = (context: AcaRuleContext): boolean => isFolderRulesAllowed(context);
+}

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -29,6 +29,4 @@ import { Component } from '@angular/core';
   selector: 'aca-manage-rules',
   template: `<div>This is the Manage Rules component</div>`
 })
-export class ManageRulesSmartComponent {
-
-}
+export class ManageRulesSmartComponent {}

--- a/projects/aca-folder-rules/src/public-api.ts
+++ b/projects/aca-folder-rules/src/public-api.ts
@@ -24,4 +24,4 @@
  */
 
 export * from './lib/folder-rules.module';
-export { EditRuleDialogSmartComponent } from './lib/rule-details/edit-rule-dialog.smart-component';
+export { ManageRulesSmartComponent } from './lib/manage-rules/manage-rules.smart-component';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-3379

**What is the new behaviour?**

- Very basic skeleton for manage rules component
- Routing to navigate to it
- Action which shows only according to specific criteria (folder rules plugin enabled, folder node, not in trashcan)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
