### PR TITLE
[ACS-3379] Fix unit tests for the visibility rules of the folder rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,11 @@ jobs:
       cache: false
 
     - stage: Quality and Unit tests
+      name: 'Unit tests: aca-folder-rules'
+      script: npm ci && ng test aca-folder-rules
+      cache: false
+
+    - stage: Quality and Unit tests
       name: 'Unit tests: ACA'
       script:
         - npm ci

--- a/projects/aca-folder-rules/karma.conf.js
+++ b/projects/aca-folder-rules/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false,
+    singleRun: true,
     restartOnFileChange: true
   });
 };

--- a/projects/aca-folder-rules/src/lib/folder-rules.rules.spec.ts
+++ b/projects/aca-folder-rules/src/lib/folder-rules.rules.spec.ts
@@ -24,9 +24,9 @@
  */
 
 import { AcaRuleContext } from '@alfresco/aca-shared/rules';
-import { isFolderRulesEnabled, canCreateFolderRule, canLinkFolderRule } from './folder-rules.rules';
+import { isFolderRulesEnabled, canManageFolderRules } from './folder-rules.rules';
 
-describe('Folder Rules', () => {
+describe('Folder Rules Visibility Rules', () => {
   describe('isFolderRulesEnabled', () => {
     it('should have the feature enabled', () => {
       const context: any = {
@@ -51,7 +51,7 @@ describe('Folder Rules', () => {
     });
   });
 
-  describe('canCreateFolderRule', () => {
+  describe('canManageFolderRules', () => {
     let context: AcaRuleContext;
 
     beforeEach(() => {
@@ -72,47 +72,14 @@ describe('Folder Rules', () => {
     });
 
     it('should allow creating a rule for the selected folder', () => {
-      const result = canCreateFolderRule(context);
+      const result = canManageFolderRules(context);
       expect(result).toEqual(true);
     });
 
     it('should not allow creating a rule if no folder selected', () => {
       context.selection.folder = null;
 
-      const result = canCreateFolderRule(context);
-      expect(result).toEqual(false);
-    });
-  });
-
-  describe('canLinkFolderRule', () => {
-    let context: AcaRuleContext;
-
-    beforeEach(() => {
-      context = {
-        appConfig: {
-          get: () => true
-        },
-        selection: {
-          folder: {} as any
-        },
-        navigation: {
-          url: '/personal-files'
-        },
-        permissions: {
-          check: () => true
-        }
-      } as any;
-    });
-
-    it('should allow linking rule for the selected folder', () => {
-      const result = canLinkFolderRule(context);
-      expect(result).toEqual(true);
-    });
-
-    it('should not allow linking rule if no folder selected', () => {
-      context.selection.folder = null;
-
-      const result = canLinkFolderRule(context);
+      const result = canManageFolderRules(context);
       expect(result).toEqual(false);
     });
   });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Some of the unit tests in the `aca-folder-rules` project hadn't been changed for [ACS-3379](https://alfresco.atlassian.net/browse/ACS-3379) as a result of [its PR](https://github.com/Alfresco/alfresco-content-app/pull/2575). This quick PR fixes them. This should've been caught in the original PR, but `.travis.yml` wasn't setup to run unit tests on the new `aca-folder-rules` project just yet.

**What is the new behaviour?**

The unit tests imports and tests `canManageFolderRules` rather than the already removed `canCreateFolderRule` and `canLinkFolderRule`. Added stage to `.travis.yml`.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
