### PR TITLE
[ACS-3441] Fix aos plugin not detected on app deploy, failing e2e tests

### DIFF
--- a/projects/adf-office-services-ext/src/lib/aos-extension.module.ts
+++ b/projects/adf-office-services-ext/src/lib/aos-extension.module.ts
@@ -38,14 +38,8 @@ import { canOpenWithOffice } from './evaluators';
 export class AosExtensionModule {
   constructor(extensions: ExtensionService, translation: TranslationService, aosService: AlfrescoOfficeExtensionService) {
     translation.addTranslationFolder('adf-office-services-ext', 'assets/adf-office-services-ext');
-    if (!aosService.isAosPluginEnabled()) {
-      extensions.setEvaluators({
-        'aos.canOpenWithOffice': () => false
-      });
-    } else {
-      extensions.setEvaluators({
-        'aos.canOpenWithOffice': canOpenWithOffice
-      });
-    }
+    extensions.setEvaluators({
+      'aos.canOpenWithOffice': (context) => aosService.isAosPluginEnabled() && canOpenWithOffice(context)
+    });
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-3441
Most/all tests in office-files-action.test.ts fail due to the "Edit in Microsoft Office" action not appearing during e2es.
This is caused by a call to `isAosPluginEnabled` being made too soon, before even the config is read and the localStorage value is set to true.

**What is the new behaviour?**

`isAosPluginEnabled` is no longer just called once at the beginning, but multiple times throughout the app's lifespan, guaranteeing that the localStorage will have been written to.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
