### PR TITLE
[AAE-10253] It shouldn't be possible to right click in a drag&drop empty area

### DIFF
--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
@@ -63,4 +63,23 @@ describe('ContextActionsDirective', () => {
 
     expect(storeMock.dispatch).toHaveBeenCalledWith(new ContextMenu(mouseEventMock));
   }));
+
+  it('should not call service to render context menu if the datatable is empty', fakeAsync(() => {
+    const el = document.createElement('div');
+    el.className = 'adf-no-content-container';
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(el);
+
+    const target = fragment.querySelector('div');
+    const mouseEventMock: any = { preventDefault: () => {}, target };
+
+    directive.ngOnInit();
+
+    directive.onContextMenuEvent(mouseEventMock);
+
+    tick(500);
+
+    expect(storeMock.dispatch).not.toHaveBeenCalledWith(new ContextMenu(mouseEventMock));
+  }));
 });

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
@@ -80,6 +80,6 @@ describe('ContextActionsDirective', () => {
 
     tick(500);
 
-    expect(storeMock.dispatch).not.toHaveBeenCalledWith(new ContextMenu(mouseEventMock));
+    expect(storeMock.dispatch).not.toHaveBeenCalled();
   }));
 });

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
@@ -48,7 +48,7 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
 
       if (this.enabled) {
         const target = this.getTarget(event);
-        if (target) {
+        if (target && !target.classList.contains('adf-no-content-container')) {
           this.execute(event, target);
         }
       }

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
@@ -48,7 +48,7 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
 
       if (this.enabled) {
         const target = this.getTarget(event);
-        if (target && !target.classList.contains('adf-no-content-container')) {
+        if (target) {
           this.execute(event, target);
         }
       }
@@ -73,6 +73,10 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
       target.dispatchEvent(new MouseEvent('click'));
     }
 
+    if (this.isEmptyTable(target)) {
+      return null;
+    }
+
     this.execute$.next(event);
   }
 
@@ -87,6 +91,10 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
     }
 
     return this.findAncestor(target, 'adf-datatable-row').classList.contains('adf-is-selected');
+  }
+
+  private isEmptyTable(target: Element): boolean {
+    return this.findAncestor(target, 'adf-datatable-cell').classList.contains('adf-no-content-container');
   }
 
   private findAncestor(el: Element, className: string): Element {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When we right click to drag&drop  empty area  context menu is rendered

**What is the new behaviour?**

If the drag&drop area is empty and we right-click on it, context menu is not rendered


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
