### PR TITLE
[AAE-10512] Several icons cut off due to a fix introduced in Angular 14

### DIFF
--- a/app/src/app/ui/application.scss
+++ b/app/src/app/ui/application.scss
@@ -18,6 +18,10 @@ body {
   }
 }
 
+.mat-icon {
+  overflow: unset !important;
+}
+
 [dir='rtl'] .mat-icon {
   transform: scale(-1, 1);
 }

--- a/app/src/styles.scss
+++ b/app/src/styles.scss
@@ -12,3 +12,7 @@ html {
 body {
   margin: 0;
 }
+
+.mat-icon {
+  overflow: unset !important;
+}

--- a/app/src/styles.scss
+++ b/app/src/styles.scss
@@ -12,7 +12,3 @@ html {
 body {
   margin: 0;
 }
-
-.mat-icon {
-  overflow: unset !important;
-}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

[AAE-10512](https://alfresco.atlassian.net/browse/AAE-10512)

The reason for the bug is a fix introduced in Angular 14.2.0: [fix(material/icon): clip overflowing icon elements](https://github.com/angular/components/pull/12429) 
`mat-icon` elements now have `overflow: hidden`.

**What is the new behaviour?**

We override the default overflow of mat-icon elements in every app.
This is a temporary fix and an issue is going to be raised for the upcoming epic on how to better deal with this problem.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
