### PR TITLE
cleanup unused theming

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,11 +54,6 @@
               },
               {
                 "glob": "**/*",
-                "input": "node_modules/@alfresco/adf-core/prebuilt-themes",
-                "output": "/assets/prebuilt-themes"
-              },
-              {
-                "glob": "**/*",
                 "input": "node_modules/@alfresco/adf-core/bundles/assets",
                 "output": "/assets"
               },

--- a/app/src/styles.scss
+++ b/app/src/styles.scss
@@ -1,5 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~@alfresco/adf-core/lib/prebuilt-themes/adf-blue-orange.css';
 @import 'app/ui/application';
 @import './app/ui/variables/font-family';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- remove the need for breaking change for the scss path
- remove the prebuilt theme reference (being replaced with custom variables anyway)
- cleanup the `angular.json` from the themes that are not needed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
