### PR TITLE
[ACS-3586] ACA/Folder Rules: Adding a rule to a Folder seems to break the Folder Rules UI

### DIFF
--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -175,17 +175,15 @@ export class FolderRulesService {
       inverted: obj.inverted ?? false,
       booleanMode: obj.booleanMode ?? 'and',
       compositeConditions: (obj.compositeConditions || []).map((condition) => this.formatCompositeCondition(condition)),
-      simpleConditions: (obj.simpleConditions || []).map((condition) => this.formatSimpleCondition(condition))
+      simpleConditions: (obj.simpleConditions || []).map((condition) => condition ? this.formatSimpleCondition(condition) : [])
     };
   }
 
-  private formatSimpleCondition(obj): RuleSimpleCondition | [] {
-    if (obj){
+  private formatSimpleCondition(obj): RuleSimpleCondition {
       return {
         field: obj.field || 'cm:name',
         comparator: obj.comparator || 'equals',
         parameter: obj.parameter || ''
       }
-    } else return []
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -175,15 +175,15 @@ export class FolderRulesService {
       inverted: obj.inverted ?? false,
       booleanMode: obj.booleanMode ?? 'and',
       compositeConditions: (obj.compositeConditions || []).map((condition) => this.formatCompositeCondition(condition)),
-      simpleConditions: (obj.simpleConditions || []).map((condition) => condition ? this.formatSimpleCondition(condition) : [])
+      simpleConditions: (obj.simpleConditions || []).map((condition) => (condition ? this.formatSimpleCondition(condition) : []))
     };
   }
 
   private formatSimpleCondition(obj): RuleSimpleCondition {
-      return {
-        field: obj.field || 'cm:name',
-        comparator: obj.comparator || 'equals',
-        parameter: obj.parameter || ''
-      }
+    return {
+      field: obj.field || 'cm:name',
+      comparator: obj.comparator || 'equals',
+      parameter: obj.parameter || ''
+    };
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -179,11 +179,13 @@ export class FolderRulesService {
     };
   }
 
-  private formatSimpleCondition(obj): RuleSimpleCondition {
-    return {
-      field: obj.field || 'cm:name',
-      comparator: obj.comparator || 'equals',
-      parameter: obj.parameter || ''
-    };
+  private formatSimpleCondition(obj): RuleSimpleCondition | [] {
+    if (obj){
+      return {
+        field: obj.field || 'cm:name',
+        comparator: obj.comparator || 'equals',
+        parameter: obj.parameter || ''
+      }
+    } else return []
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -175,8 +175,19 @@ export class FolderRulesService {
       inverted: obj.inverted ?? false,
       booleanMode: obj.booleanMode ?? 'and',
       compositeConditions: (obj.compositeConditions || []).map((condition) => this.formatCompositeCondition(condition)),
-      simpleConditions: (obj.simpleConditions || []).map((condition) => (condition ? this.formatSimpleCondition(condition) : []))
+      simpleConditions: this.parseSimpleCondition(obj.simpleConditions)
     };
+  }
+
+  private parseSimpleCondition(arr) {
+    if (arr) {
+      if (arr.every((element) => element === null)) {
+        return [];
+      }
+      return arr.map((condition) => this.formatSimpleCondition(condition));
+    } else {
+      return [];
+    }
   }
 
   private formatSimpleCondition(obj): RuleSimpleCondition {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Creating a rule without a conditions returns `simpleConditions: [null] `. It results to an error and managing rule screen crashes.

**What is the new behaviour?**

Everything works as it supposed to.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
