### PR TITLE
[ACS-3575] Update FolderRulesService to provide a list of available aspects

### DIFF
--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -35,7 +35,7 @@
       "OPTIONS": {
         "CASCADE":  "Rule applies to subfolders",
         "ASYNCHRONOUS": "Run rule in the background",
-        "ENABLED": "Disable rule",
+        "DISABLE_RULE": "Disable rule",
         "ERROR_SCRIPT": "If errors occur run script",
         "SELECT_ACTION": "Select action"
       },

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -76,6 +76,7 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
       this.nodeId = params.nodeId;
       if (this.nodeId) {
         this.folderRulesService.loadRules(this.nodeId);
+        this.folderRulesService.loadAspects()
       }
     });
   }

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -76,7 +76,6 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
       this.nodeId = params.nodeId;
       if (this.nodeId) {
         this.folderRulesService.loadRules(this.nodeId);
-        this.folderRulesService.loadAspects()
       }
     });
   }

--- a/projects/aca-folder-rules/src/lib/model/aspect.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/aspect.model.ts
@@ -1,0 +1,40 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface AspectModel {
+  id: string;
+  description: string;
+  namespaceUri: string;
+  namespacePrefix: string;
+}
+
+export interface Aspect {
+  includedInSupertypeQuery: boolean;
+  isContainer: boolean;
+  model: AspectModel;
+  id: string;
+  title: string;
+  parentId: string;
+}

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
@@ -27,7 +27,7 @@
       [attr.data-automation-id]="'rule-option-checkbox-enabled'"
       [checked]="!form.value.enabled" *ngIf="!preview"
       (change)="form.get('enabled').setValue(!$event.checked)">
-      {{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.ENABLED' | translate }}
+      {{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.DISABLE_RULE' | translate }}
     </mat-checkbox>
   </div>
 </div>

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -125,4 +125,17 @@ describe('FolderRulesService', () => {
       expect(apiCallSpy).toHaveBeenCalledWith(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules/${ruleId}`, 'PUT', paramsWithBody);
     });
   });
+
+  describe('loadAspects', () => {
+    beforeEach(async () => {
+      apiCallSpy = spyOn<any>(folderRulesService, 'apiCall').withArgs(`/aspects`, 'GET', params).and.returnValue([]);
+
+      folderRulesService.loadAspects();
+    });
+
+    it('should send correct GET request', async () => {
+      expect(apiCallSpy).toHaveBeenCalled();
+      expect(apiCallSpy).toHaveBeenCalledWith(`/aspects`, 'GET', params);
+    });
+  });
 });

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -186,8 +186,19 @@ export class FolderRulesService {
       inverted: obj.inverted ?? false,
       booleanMode: obj.booleanMode ?? 'and',
       compositeConditions: (obj.compositeConditions || []).map((condition) => this.formatCompositeCondition(condition)),
-      simpleConditions: (obj.simpleConditions || []).map((condition) => this.formatSimpleCondition(condition))
+      simpleConditions: this.parseSimpleCondition(obj.simpleConditions)
     };
+  }
+
+  private parseSimpleCondition(arr) {
+    if (arr) {
+      if (arr.every((element) => element === null)) {
+        return [];
+      }
+      return arr.map((condition) => this.formatSimpleCondition(condition));
+    } else {
+      return [];
+    }
   }
 
   private formatSimpleCondition(obj): RuleSimpleCondition {

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -70,6 +70,8 @@ export class FolderRulesService {
   loading$ = this.loadingSource.asObservable();
   private deletedRuleIdSource = new BehaviorSubject<string>(null);
   deletedRuleId$: Observable<string> = this.deletedRuleIdSource.asObservable();
+  private aspectsSource = new BehaviorSubject<any>([]);
+  aspects$: Observable<any> = this.aspectsSource.asObservable();
 
   constructor(private apiService: AlfrescoApiService, private contentApi: ContentApiService) {}
 
@@ -79,7 +81,7 @@ export class FolderRulesService {
       from(
         this.apiCall(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules`, 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']])
       ).pipe(
-        map((res) => this.formatRules(res)),
+        map((res) => this.formatResponse(res)),
         catchError((error) => {
           if (error.status === 404) {
             return of([]);
@@ -146,11 +148,24 @@ export class FolderRulesService {
     ).subscribe({ error: (error) => console.error(error) });
   }
 
+  loadAspects(): void {
+    from(
+      this.apiCall('/aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']])
+    ).pipe(
+      map((res) => this.formatResponse(res))
+    ).subscribe(
+      (res) => {
+        console.log(res)
+        this.aspectsSource.next(res)
+      }
+    )
+  }
+
   private apiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {
     return this.apiService.getInstance().contentClient.callApi(path, httpMethod, ...params);
   }
 
-  private formatRules(res): Rule[] {
+  private formatResponse(res): Rule[] {
     return res.list.entries.map((entry) => this.formatRule(entry.entry));
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently there is no possibility to get list of aspects.

**What is the new behaviour?**

`loadAspects` method was added to `FolderRulesService`, which loads list of aspects to observable 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
