### PR TITLE
[ACS-3596] Create / Update rule dialog - display errors

### DIFF
--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -26,7 +26,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AcaFolderRulesModule, ManageRulesSmartComponent } from '@alfresco/aca-folder-rules';
 import { DebugElement } from '@angular/core';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { CoreTestingModule, NotificationService } from '@alfresco/adf-core';
 import { FolderRulesService } from '../services/folder-rules.service';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
@@ -43,12 +43,14 @@ describe('ManageRulesSmartComponent', () => {
 
   beforeEach(
     waitForAsync(() => {
-      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule']);
+      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule', 'createRule']);
+      const notificationServiceSpy = jasmine.createSpyObj('NotificationService', ['showError']);
       TestBed.configureTestingModule({
         imports: [CoreTestingModule, AcaFolderRulesModule],
         providers: [
           { provide: FolderRulesService, useValue: folderRulesServiceSpy },
-          { provide: ActivatedRoute, useValue: { params: of({ nodeId: 1 }) } }
+          { provide: ActivatedRoute, useValue: { params: of({ nodeId: 1 }) } },
+          { provide: NotificationService, useValue: notificationServiceSpy }
         ]
       })
         .compileComponents()

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -26,7 +26,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AcaFolderRulesModule, ManageRulesSmartComponent } from '@alfresco/aca-folder-rules';
 import { DebugElement } from '@angular/core';
-import { CoreTestingModule, NotificationService } from '@alfresco/adf-core';
+import { CoreTestingModule } from '@alfresco/adf-core';
 import { FolderRulesService } from '../services/folder-rules.service';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
@@ -43,14 +43,12 @@ describe('ManageRulesSmartComponent', () => {
 
   beforeEach(
     waitForAsync(() => {
-      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule', 'createRule']);
-      const notificationServiceSpy = jasmine.createSpyObj('NotificationService', ['showError']);
+      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule']);
       TestBed.configureTestingModule({
         imports: [CoreTestingModule, AcaFolderRulesModule],
         providers: [
           { provide: FolderRulesService, useValue: folderRulesServiceSpy },
-          { provide: ActivatedRoute, useValue: { params: of({ nodeId: 1 }) } },
-          { provide: NotificationService, useValue: notificationServiceSpy }
+          { provide: ActivatedRoute, useValue: { params: of({ nodeId: 1 }) } }
         ]
       })
         .compileComponents()

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -85,7 +85,6 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.deletedRuleSubscription$.unsubscribe();
-    this.ruleDialogOnSubmitSubscription$.unsubscribe();
   }
 
   goBack(): void {
@@ -102,20 +101,18 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
       panelClass: 'aca-edit-rule-dialog-container'
     });
 
-    this.onRuleCreate(dialogRef)
+    this.onSubmitRuleDialog(dialogRef);
   }
 
-  onRuleCreate(dialogRef) {
-    this.ruleDialogOnSubmitSubscription$ = dialogRef.componentInstance.submitted.subscribe((rule) => {
-      this.folderRulesService
-        .createRule(this.nodeId, rule)
-        .then((_) => {
-          this.folderRulesService.loadRules(this.nodeId);
-          dialogRef.close();
-        })
-        .catch((err) => {
-          this.notificationService.showError(err.response.body.error.errorKey);
-        });
+  onSubmitRuleDialog(dialogRef) {
+    dialogRef.componentInstance.submitted.subscribe(async (rule) => {
+      try {
+        await this.folderRulesService.createRule(this.nodeId, rule);
+        this.folderRulesService.loadRules(this.nodeId);
+        dialogRef.close();
+      } catch (error) {
+        this.notificationService.showError(error.response.body.error.errorKey);
+      }
     });
   }
 

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -76,6 +76,7 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
       this.nodeId = params.nodeId;
       if (this.nodeId) {
         this.folderRulesService.loadRules(this.nodeId);
+        // this.folderRulesService.createRule('7b1e2bd9-fcdb-4de6-a330-dc687bb25117')
       }
     });
   }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -8,11 +8,11 @@
 </div>
 
 <mat-dialog-content class="aca-edit-rule-dialog__content">
-  <aca-rule-details (formValidationChanged)="formValid = $event" (formValueChanged)="model = $event" [value]="model"></aca-rule-details>
+  <aca-rule-details (formValidationChanged)="formValid = $event" (formValueChanged)="formValue = $event" [value]="model"></aca-rule-details>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="aca-edit-rule-dialog__footer">
   <button mat-flat-button mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</button>
   <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</button>
 </mat-dialog-actions>
-
+{{model | json}}

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -8,10 +8,11 @@
 </div>
 
 <mat-dialog-content class="aca-edit-rule-dialog__content">
-  <aca-rule-details (formValidationChanged)="formValid = $event" [value]="model"></aca-rule-details>
+  <aca-rule-details (formValidationChanged)="formValid = $event" (formValueChanged)="model = $event" [value]="model"></aca-rule-details>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="aca-edit-rule-dialog__footer">
   <button mat-flat-button mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</button>
-  <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit">{{ submitLabel | translate }}</button>
+  <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</button>
 </mat-dialog-actions>
+

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -15,4 +15,3 @@
   <button mat-flat-button mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</button>
   <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</button>
 </mat-dialog-actions>
-{{model | json}}

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -57,4 +57,8 @@ export class EditRuleDialogSmartComponent {
   get submitLabel(): string {
     return 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.' + (this.isUpdateMode ? 'UPDATE' : 'CREATE');
   }
+
+  onSubmit() {
+    console.log(this.model)
+  }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Inject, Output, ViewEncapsulation } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Rule } from '../model/rule.model';
 
@@ -41,6 +41,8 @@ export interface EditRuleDialogOptions {
 export class EditRuleDialogSmartComponent {
   formValid = false;
   model: Partial<Rule>;
+  formValue: Partial<Rule>;
+  @Output() submitted = new EventEmitter<Partial<Rule>>();
 
   constructor(@Inject(MAT_DIALOG_DATA) public options: EditRuleDialogOptions) {
     this.model = this.options?.model || {};
@@ -58,7 +60,15 @@ export class EditRuleDialogSmartComponent {
     return 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.' + (this.isUpdateMode ? 'UPDATE' : 'CREATE');
   }
 
+  // check(e) {
+  //   console.log("event")
+  //   console.log(e)
+  //   console.log("this.model")
+  //   console.log(this.model)
+  // }
   onSubmit() {
-    console.log(this.model)
+    this.submitted.emit(this.formValue);
+    // console.log("submit")
+    console.log(this.formValue)
   }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -60,15 +60,7 @@ export class EditRuleDialogSmartComponent {
     return 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.' + (this.isUpdateMode ? 'UPDATE' : 'CREATE');
   }
 
-  // check(e) {
-  //   console.log("event")
-  //   console.log(e)
-  //   console.log("this.model")
-  //   console.log(this.model)
-  // }
   onSubmit() {
     this.submitted.emit(this.formValue);
-    // console.log("submit")
-    console.log(this.formValue)
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -50,6 +50,7 @@ describe('FolderRulesService', () => {
   const ruleId = '********-fake-rule-****-********';
   const ruleSetId = '-default-';
   const params = [{}, {}, {}, {}, {}, ['application/json'], ['application/json']];
+  const paramsWithBody = [{}, {}, {}, {}, dummyRules[0], ['application/json'], ['application/json']];
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -111,7 +112,6 @@ describe('FolderRulesService', () => {
   });
 
   describe('toggleRule', () => {
-    const paramsWithBody = [{}, {}, {}, {}, dummyRules[0], ['application/json'], ['application/json']];
     beforeEach(async () => {
       apiCallSpy = spyOn<any>(folderRulesService, 'apiCall')
         .withArgs(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules/${ruleId}`, 'PUT', paramsWithBody)
@@ -136,6 +136,21 @@ describe('FolderRulesService', () => {
     it('should send correct GET request', async () => {
       expect(apiCallSpy).toHaveBeenCalled();
       expect(apiCallSpy).toHaveBeenCalledWith(`/aspects`, 'GET', params);
+    });
+  });
+
+  describe('createRule', () => {
+    beforeEach(async () => {
+      spyOn<any>(folderRulesService, 'apiCall')
+        .withArgs(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules`, 'POST', paramsWithBody)
+        .and.returnValue(Promise.resolve(dummyRules[0]));
+    });
+
+    it('should send correct POST request and return created rule', function () {
+      folderRulesService.createRule(nodeId, dummyRules[0]).then((result) => {
+        expect(folderRulesService.createRule).toHaveBeenCalledWith(nodeId, dummyRules[0]);
+        expect(result).toEqual(dummyRules[0]);
+      });
     });
   });
 });

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -172,13 +172,20 @@ export class FolderRulesService {
   }
 
   private addFakeAction(rule): Partial<Rule> {
-    return {
-      ...rule,
-      actions: [
-        {
-          actionDefinitionId: 'counter'
-        }
-      ],
+    if (rule.actions) {
+      return rule;
+    } else {
+      return {
+        ...rule,
+        actions: [
+          {
+            actionDefinitionId: 'add-features',
+            params: {
+              'aspect-name': 'ai:creativeWorks'
+            }
+          }
+        ]
+      };
     }
   }
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -112,6 +112,16 @@ export class FolderRulesService {
       );
   }
 
+  createRule(nodeId: string, rule = FolderRulesService.emptyRule, ruleSetId: string = '-default-'): void {
+    from(
+      this.apiCall(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules`, 'POST',
+        [{}, {}, {}, {}, {...rule}, ['application/json'], ['application/json']])
+    ).subscribe(
+      (res) => {console.log(res)},
+    (error) => { console.log(error)}
+    )
+  }
+
   deleteRule(nodeId: string, ruleId: string, ruleSetId: string = '-default-'): void {
     this.loadingSource.next(true);
     from(

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -73,8 +73,6 @@ export class FolderRulesService {
   deletedRuleId$: Observable<string> = this.deletedRuleIdSource.asObservable();
   private aspectsSource = new BehaviorSubject<Aspect[]>([]);
   aspects$: Observable<Aspect[]> = this.aspectsSource.asObservable();
-  // private createRuleErrorsSource = new BehaviorSubject('');
-  // createRuleErrors = this.createRuleErrorsSource.asObservable();
 
   constructor(private apiService: AlfrescoApiService, private contentApi: ContentApiService) {}
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -73,6 +73,8 @@ export class FolderRulesService {
   deletedRuleId$: Observable<string> = this.deletedRuleIdSource.asObservable();
   private aspectsSource = new BehaviorSubject<Aspect[]>([]);
   aspects$: Observable<Aspect[]> = this.aspectsSource.asObservable();
+  // private createRuleErrorsSource = new BehaviorSubject('');
+  // createRuleErrors = this.createRuleErrorsSource.asObservable();
 
   constructor(private apiService: AlfrescoApiService, private contentApi: ContentApiService) {}
 
@@ -112,14 +114,16 @@ export class FolderRulesService {
       );
   }
 
-  createRule(nodeId: string, rule = FolderRulesService.emptyRule, ruleSetId: string = '-default-'): void {
-    from(
-      this.apiCall(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules`, 'POST',
-        [{}, {}, {}, {}, {...rule}, ['application/json'], ['application/json']])
-    ).subscribe(
-      (res) => {console.log(res)},
-    (error) => { console.log(error)}
-    )
+  createRule(nodeId: string, rule: Partial<Rule>, ruleSetId: string = '-default-') {
+    return this.apiCall(`/nodes/${nodeId}/rule-sets/${ruleSetId}/rules`, 'POST', [
+      {},
+      {},
+      {},
+      {},
+      { ...this.addFakeAction(rule) },
+      ['application/json'],
+      ['application/json']
+    ]);
   }
 
   deleteRule(nodeId: string, ruleId: string, ruleSetId: string = '-default-'): void {
@@ -165,6 +169,17 @@ export class FolderRulesService {
       .subscribe((res) => {
         this.aspectsSource.next(res);
       });
+  }
+
+  private addFakeAction(rule): Partial<Rule> {
+    return {
+      ...rule,
+      actions: [
+        {
+          actionDefinitionId: 'counter'
+        }
+      ],
+    }
   }
 
   private apiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently there is no possibility to create rules and display errors if any occurs.

**What is the new behaviour?**

Create / Update rule dialog - displays errors using notificationService. Now it is possible to create a rule (with mocked actions)
<img width="1792" alt="Screenshot 2022-10-04 at 09 56 46" src="https://user-images.githubusercontent.com/84377976/193765780-cd500fe6-cbf4-47c7-a959-5102c670608d.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
