### PR TITLE
[ACS-3315] Alfresco Administrators - private and moderate libraries-can't join to libraries issue resolved

### DIFF
--- a/app/src/app/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
+++ b/app/src/app/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
@@ -38,6 +38,7 @@ import { ToggleJoinLibraryButtonComponent } from './toggle-join-library-button.c
       (toggle)="onToggleEvent($event)"
       (error)="onErrorEvent($event)"
       [adf-library-membership]="(selection$ | async).library"
+      [isAdmin]="(profile$ | async).isAdmin"
       [attr.title]="(membership.isJoinRequested | async) ? ('APP.ACTIONS.CANCEL_JOIN' | translate) : ('APP.ACTIONS.JOIN' | translate)"
     >
       <mat-icon *ngIf="membership.isJoinRequested | async">cancel</mat-icon>


### PR DESCRIPTION
…aries - can't join to libraries issue resolved

**Please check if the PR fulfills these requirements**

> - [x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
While logging in using hruser credentials and creating a private or moderate library and logging out and logging again with superadminuser credentials and going to all libraries section and right click on private or moderate library and click join, we were not able to join the library as an admin user.


**What is the new behaviour?**
Logging in using hruser credentials and creating a private or moderate library and logging out and logging again with superadminuser credentials and going to all libraries section and right click on private or moderate library and click join, we are now able to join the library as an admin user.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
