### PR TITLE
[ACS-3576] Map aspect actions with the aspect picker dropdown

### DIFF
--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -35,6 +35,7 @@ import { By } from '@angular/platform-browser';
 import { dummyNodeInfo } from '../mock/node.mock';
 import { MatDialog } from '@angular/material/dialog';
 import { ActionsService } from '../services/actions.service';
+import { dummyAspects } from '../mock/aspects.mock';
 
 describe('ManageRulesSmartComponent', () => {
   let fixture: ComponentFixture<ManageRulesSmartComponent>;
@@ -45,7 +46,7 @@ describe('ManageRulesSmartComponent', () => {
 
   beforeEach(
     waitForAsync(() => {
-      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule']);
+      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule', 'loadAspects']);
       TestBed.configureTestingModule({
         imports: [CoreTestingModule, AcaFolderRulesModule],
         providers: [
@@ -60,6 +61,7 @@ describe('ManageRulesSmartComponent', () => {
           debugElement = fixture.debugElement;
           folderRulesService = TestBed.inject<FolderRulesService>(FolderRulesService);
           actionsService = TestBed.inject<ActionsService>(ActionsService);
+          folderRulesService.aspects$ = of(dummyAspects)
         });
     })
   );

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -46,7 +46,7 @@ describe('ManageRulesSmartComponent', () => {
 
   beforeEach(
     waitForAsync(() => {
-      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule', 'loadAspects']);
+      const folderRulesServiceSpy = jasmine.createSpyObj('FolderRulesService', ['loadRules', 'deleteRule']);
       TestBed.configureTestingModule({
         imports: [CoreTestingModule, AcaFolderRulesModule],
         providers: [
@@ -61,7 +61,7 @@ describe('ManageRulesSmartComponent', () => {
           debugElement = fixture.debugElement;
           folderRulesService = TestBed.inject<FolderRulesService>(FolderRulesService);
           actionsService = TestBed.inject<ActionsService>(ActionsService);
-          folderRulesService.aspects$ = of(dummyAspects);
+          actionsService.aspects$ = of(dummyAspects);
         });
     })
   );

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -61,7 +61,7 @@ describe('ManageRulesSmartComponent', () => {
           debugElement = fixture.debugElement;
           folderRulesService = TestBed.inject<FolderRulesService>(FolderRulesService);
           actionsService = TestBed.inject<ActionsService>(ActionsService);
-          folderRulesService.aspects$ = of(dummyAspects)
+          folderRulesService.aspects$ = of(dummyAspects);
         });
     })
   );

--- a/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
@@ -51,6 +51,12 @@ export const actionDefListMock: ActionDefinitionList = {
             type: 'd:boolean',
             multiValued: false,
             mandatory: false
+          },
+          {
+            name: 'aspect-name',
+            type: 'd:qname',
+            multiValued: false,
+            mandatory: false
           }
         ],
         name: 'mock-action-1-definition',
@@ -85,6 +91,14 @@ const actionParam2TransformedMock: ActionParameterDefinitionTransformed = {
   displayLabel: 'mock-action-parameter-boolean'
 };
 
+const actionParam3TransformedMock: ActionParameterDefinitionTransformed = {
+  name: 'aspect-name',
+  type: 'd:qname',
+  multiValued: false,
+  mandatory: false,
+  displayLabel: 'aspect-name'
+};
+
 const action1TransformedMock: ActionDefinitionTransformed = {
   id: 'mock-action-1-definition',
   name: 'mock-action-1-definition',
@@ -92,7 +106,7 @@ const action1TransformedMock: ActionDefinitionTransformed = {
   title: 'Action 1 title',
   applicableTypes: [],
   trackStatus: false,
-  parameterDefinitions: [actionParam1TransformedMock, actionParam2TransformedMock]
+  parameterDefinitions: [actionParam1TransformedMock, actionParam2TransformedMock, actionParam3TransformedMock]
 };
 
 const action2TransformedMock: ActionDefinitionTransformed = {

--- a/projects/aca-folder-rules/src/lib/mock/aspects.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/aspects.mock.ts
@@ -38,4 +38,4 @@ export const dummyAspects: Aspect[] = [
     value: 'cm:aspect3',
     label: 'Label 3'
   }
-]
+];

--- a/projects/aca-folder-rules/src/lib/mock/aspects.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/aspects.mock.ts
@@ -1,0 +1,41 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Aspect } from '../model/aspect.model';
+
+export const dummyAspects: Aspect[] = [
+  {
+    value: 'cm:aspect1',
+    label: 'Label 1'
+  },
+  {
+    value: 'cm:aspect2',
+    label: 'Label 2'
+  },
+  {
+    value: 'cm:aspect3',
+    label: 'Label 3'
+  }
+]

--- a/projects/aca-folder-rules/src/lib/model/aspect.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/aspect.model.ts
@@ -23,18 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export interface AspectModel {
-  id: string;
-  description: string;
-  namespaceUri: string;
-  namespacePrefix: string;
-}
-
 export interface Aspect {
-  includedInSupertypeQuery: boolean;
-  isContainer: boolean;
-  model: AspectModel;
-  id: string;
-  title: string;
-  parentId: string;
+  value: string;
+  label: string;
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.html
@@ -1,6 +1,7 @@
 <div class="aca-rule-action-list__item  " *ngFor="let control of formControls">
   <aca-rule-action
     [actionDefinitions]="actionDefinitions"
+    [aspects]="aspects"
     [readOnly]="readOnly"
     [formControl]="control">
   </aca-rule-action>

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
@@ -28,6 +28,7 @@ import { ControlValueAccessor, FormArray, FormControl, NG_VALUE_ACCESSOR, Valida
 import { ActionDefinitionTransformed, RuleAction } from '../../model/rule-action.model';
 import { Subscription } from 'rxjs';
 import { ruleActionValidator } from '../validators/rule-actions.validator';
+import { Aspect } from '../../model/aspect.model';
 
 @Component({
   selector: 'aca-rule-action-list',
@@ -48,6 +49,8 @@ export class RuleActionListUiComponent implements ControlValueAccessor, OnDestro
   actionDefinitions: ActionDefinitionTransformed[] = [];
   @Input()
   readOnly = false;
+  @Input()
+  aspects: Aspect[] = [];
 
   formArray = new FormArray([]);
   private formArraySubscription: Subscription;

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.html
@@ -16,6 +16,7 @@
   <adf-card-view
     data-automation-id="rule-action-card-view"
     [properties]="cardViewItems"
+    [ngStyle]="isFullWidth && {'width': '100%'}"
     [editable]="!readOnly">
   </adf-card-view>
 

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.html
@@ -16,7 +16,7 @@
   <adf-card-view
     data-automation-id="rule-action-card-view"
     [properties]="cardViewItems"
-    [ngStyle]="isFullWidth && {'width': '100%'}"
+    [ngStyle]="cardViewStyle"
     [editable]="!readOnly">
   </adf-card-view>
 

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
@@ -24,7 +24,13 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CardViewBoolItemModel, CardViewComponent, CardViewTextItemModel, CoreTestingModule } from '@alfresco/adf-core';
+import {
+  CardViewBoolItemModel,
+  CardViewComponent,
+  CardViewSelectItemModel,
+  CardViewTextItemModel,
+  CoreTestingModule
+} from '@alfresco/adf-core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
 import { actionsTransformedListMock } from '../../mock/actions.mock';
 import { DebugElement } from '@angular/core';
@@ -77,9 +83,10 @@ describe('RuleActionUiComponent', () => {
     expect(cardView.properties.length).toBe(0);
 
     changeMatSelectValue('rule-action-select', 'mock-action-1-definition');
-    expect(cardView.properties.length).toBe(2);
+    expect(cardView.properties.length).toBe(3);
     expect(cardView.properties[0]).toBeInstanceOf(CardViewTextItemModel);
     expect(cardView.properties[1]).toBeInstanceOf(CardViewBoolItemModel);
+    expect(cardView.properties[2]).toBeInstanceOf(CardViewSelectItemModel);
 
     changeMatSelectValue('rule-action-select', 'mock-action-2-definition');
     expect(cardView.properties.length).toBe(0);

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
@@ -24,13 +24,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  CardViewBoolItemModel,
-  CardViewComponent,
-  CardViewSelectItemModel,
-  CardViewTextItemModel,
-  CoreTestingModule
-} from '@alfresco/adf-core';
+import { CardViewBoolItemModel, CardViewComponent, CardViewSelectItemModel, CardViewTextItemModel, CoreTestingModule } from '@alfresco/adf-core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
 import { actionsTransformedListMock } from '../../mock/actions.mock';
 import { DebugElement } from '@angular/core';

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -183,7 +183,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             value: this.parameters[paramDef.name] ?? false
           });
         case 'd:qname':
-          if (paramDef.name === 'aspect-name') {
+          if (paramDef.name === 'aspect-name' && !this.readOnly) {
             this.isFullWidth = true;
             return new CardViewSelectItemModel({
               ...cardViewPropertiesModel,

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -102,7 +102,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   get cardViewStyle() {
-    return this.isFullWidth ? { ' width': '100%' } : {};
+    return this.isFullWidth ? { width: '100%' } : {};
   }
 
   onChange: (action: RuleAction) => void = () => undefined;
@@ -226,17 +226,14 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
 
   private parseAspectsToSelectOptions(aspects: Aspect[]): CardViewSelectItemOption<unknown>[] {
     return aspects
-      .sort(function (a, b) {
-        if (a.label === '' || a.label === null) {
+      .sort((a, b) => {
+        if (!a.label && b.label) {
           return 1;
         }
-        if (b.label === '' || b.label === null) {
+        if (!b.label && a.label) {
           return -1;
         }
-        if (a.label === b.label) {
-          return 0;
-        }
-        return a.label < b.label ? -1 : 1;
+        return a.label?.localeCompare(b.label) ?? -1;
       })
       .map((aspect) => ({
         key: aspect.value,

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -36,9 +36,8 @@ import {
   UpdateNotification
 } from '@alfresco/adf-core';
 import { ActionParameterDefinition } from '@alfresco/js-api';
-import { Subject } from 'rxjs';
-import { takeUntil, map } from 'rxjs/operators';
-import { FolderRulesService } from '../../services/folder-rules.service';
+import { of, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { Aspect } from '../../model/aspect.model';
 
 @Component({
@@ -75,7 +74,15 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     this.setDisabledState(isReadOnly);
   }
 
-  private aspects$;
+  private _aspects;
+  @Input()
+  get aspects(): Aspect[] {
+    return this._aspects;
+  }
+  set aspects(value) {
+    this._aspects = this.parseAspectsToSelectOptions(value);
+  }
+
   isFullWidth = false;
 
   form = new FormGroup({
@@ -101,7 +108,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   onChange: (action: RuleAction) => void = () => undefined;
   onTouch: () => void = () => undefined;
 
-  constructor(private cardViewUpdateService: CardViewUpdateService, private folderRulesService: FolderRulesService) {}
+  constructor(private cardViewUpdateService: CardViewUpdateService) {}
 
   writeValue(action: RuleAction) {
     this.form.setValue({
@@ -144,9 +151,6 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
       });
       this.onTouch();
     });
-
-    this.aspects$ = this.folderRulesService.aspects$.pipe(map((aspects) => this.parseAspectsToSelectOptions(aspects)));
-    this.folderRulesService.loadAspects();
   }
 
   ngOnDestroy() {
@@ -184,7 +188,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             return new CardViewSelectItemModel({
               ...cardViewPropertiesModel,
               value: (this.parameters[paramDef.name] as string) ?? '',
-              options$: this.aspects$
+              options$: of(this._aspects)
             });
           }
         /* falls through */

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -75,6 +75,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   private aspects$
+  isFullWidth = false
 
   form = new FormGroup({
     actionDefinitionId: new FormControl('', Validators.required)
@@ -152,7 +153,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
 
   setCardViewProperties() {
     this.cardViewItems = (this.selectedActionDefinition?.parameterDefinitions ?? []).map((paramDef) => {
-      console.log(this.parameters[paramDef.name])
+      this.isFullWidth = false
       const cardViewPropertiesModel = {
         label: paramDef.displayLabel + (paramDef.mandatory ? ' *' : ''),
         key: paramDef.name,
@@ -176,6 +177,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
           });
         case 'd:qname':
           if (paramDef.name === 'aspect-name'){
+            this.isFullWidth = true;
             return new CardViewSelectItemModel({
               ...cardViewPropertiesModel,
               value:  this.parameters[paramDef.name] as string ?? '',
@@ -215,12 +217,16 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   private formatAspects(aspects) {
-    return aspects.sort((a, b) => a.title.localeCompare(b.title))
-      .filter( aspect => aspect.title.length > 0)
+    return aspects.sort(function(a, b) {
+      if(a.label === "" || a.label === null) return 1;
+      if(b.label === "" || b.label === null) return -1;
+      if(a.label === b.label) return 0;
+      return a.label < b.label ? -1 : 1;
+    })
       .map( (aspect) => {
       return {
-        key: aspect.id,
-        label: aspect.title
+        key: aspect.value,
+        label: aspect.label ? `${aspect.label} [${aspect.value}]` : aspect.value
       }
     })
   }

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -27,11 +27,19 @@ import { Component, forwardRef, Input, OnDestroy, OnInit, ViewEncapsulation } fr
 import { ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
 import { ActionDefinitionTransformed, RuleAction } from '../../model/rule-action.model';
 import { CardViewItem } from '@alfresco/adf-core/lib/card-view/interfaces/card-view-item.interface';
-import { CardViewBoolItemModel, CardViewSelectItemModel, CardViewTextItemModel, CardViewUpdateService, UpdateNotification } from '@alfresco/adf-core';
+import {
+  CardViewBoolItemModel,
+  CardViewSelectItemModel,
+  CardViewSelectItemOption,
+  CardViewTextItemModel,
+  CardViewUpdateService,
+  UpdateNotification
+} from '@alfresco/adf-core';
 import { ActionParameterDefinition } from '@alfresco/js-api';
 import { Subject } from 'rxjs';
 import { takeUntil, map } from 'rxjs/operators';
 import { FolderRulesService } from '../../services/folder-rules.service';
+import { Aspect } from '../../model/aspect.model';
 
 @Component({
   selector: 'aca-rule-action',
@@ -133,7 +141,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
       this.onTouch();
     });
 
-    this.aspects$ = this.folderRulesService.aspects$.pipe(map((aspects) => this.formatAspects(aspects)));
+    this.aspects$ = this.folderRulesService.aspects$.pipe(map((aspects) => this.parseAspectsToSelectOptions(aspects)));
     this.folderRulesService.loadAspects();
   }
 
@@ -208,7 +216,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     }
   }
 
-  private formatAspects(aspects) {
+  private parseAspectsToSelectOptions(aspects: Aspect[]): CardViewSelectItemOption<unknown>[] {
     return aspects
       .sort(function (a, b) {
         if (a.label === '' || a.label === null) {

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -94,6 +94,10 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     return this.actionDefinitions.find((actionDefinition: ActionDefinitionTransformed) => actionDefinition.id === this.selectedActionDefinitionId);
   }
 
+  get cardViewStyle() {
+    return this.isFullWidth ? { ' width': '100%' } : {};
+  }
+
   onChange: (action: RuleAction) => void = () => undefined;
   onTouch: () => void = () => undefined;
 

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -18,6 +18,7 @@
   <ng-template #ruleDetails>
     <aca-rule-details
       [actionDefinitions]="actionDefinitions$ | async"
+      [aspects]="aspects$ | async"
       [value]="model"
       (formValueChanged)="formValue = $event"
       (formValidationChanged)="formValid = $event">

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -27,7 +27,6 @@ import { Component, EventEmitter, Inject, OnInit, Output, ViewEncapsulation } fr
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Rule } from '../model/rule.model';
 import { ActionsService } from '../services/actions.service';
-import { FolderRulesService } from '../services/folder-rules.service';
 
 export interface EditRuleDialogOptions {
   model?: Partial<Rule>;
@@ -47,13 +46,9 @@ export class EditRuleDialogSmartComponent implements OnInit {
   @Output() submitted = new EventEmitter<Partial<Rule>>();
   actionDefinitions$ = this.actionsService.actionDefinitionsListing$;
   loading$ = this.actionsService.loading$;
-  aspects$ = this.folderRulesService.aspects$;
+  aspects$ = this.actionsService.aspects$;
 
-  constructor(
-    @Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions,
-    private actionsService: ActionsService,
-    private folderRulesService: FolderRulesService
-  ) {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions, private actionsService: ActionsService) {
     this.model = this.data?.model || {};
   }
 
@@ -75,6 +70,6 @@ export class EditRuleDialogSmartComponent implements OnInit {
 
   ngOnInit() {
     this.actionsService.loadActionDefinitions();
-    this.folderRulesService.loadAspects();
+    this.actionsService.loadAspects();
   }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -69,7 +69,7 @@ export class EditRuleDialogSmartComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.actionsService.loadActionDefinitions();
     this.actionsService.loadAspects();
+    this.actionsService.loadActionDefinitions();
   }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -27,6 +27,7 @@ import { Component, EventEmitter, Inject, OnInit, Output, ViewEncapsulation } fr
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Rule } from '../model/rule.model';
 import { ActionsService } from '../services/actions.service';
+import { FolderRulesService } from '../services/folder-rules.service';
 
 export interface EditRuleDialogOptions {
   model?: Partial<Rule>;
@@ -46,8 +47,13 @@ export class EditRuleDialogSmartComponent implements OnInit {
   @Output() submitted = new EventEmitter<Partial<Rule>>();
   actionDefinitions$ = this.actionsService.actionDefinitionsListing$;
   loading$ = this.actionsService.loading$;
+  aspects$ = this.folderRulesService.aspects$;
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions, private actionsService: ActionsService) {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions,
+    private actionsService: ActionsService,
+    private folderRulesService: FolderRulesService
+  ) {
     this.model = this.data?.model || {};
   }
 
@@ -69,5 +75,6 @@ export class EditRuleDialogSmartComponent implements OnInit {
 
   ngOnInit() {
     this.actionsService.loadActionDefinitions();
+    this.folderRulesService.loadAspects();
   }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
@@ -50,6 +50,7 @@
     <aca-rule-action-list
       formControlName="actions"
       [actionDefinitions]="actionDefinitions"
+      [aspects]="aspects"
       [readOnly]="readOnly">
     </aca-rule-action-list>
   </div>

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
@@ -32,6 +32,7 @@ import { ruleCompositeConditionValidator } from './validators/rule-composite-con
 import { FolderRulesService } from '../services/folder-rules.service';
 import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ruleActionsValidator } from './validators/rule-actions.validator';
+import { Aspect } from '../model/aspect.model';
 
 @Component({
   selector: 'aca-rule-details',
@@ -84,6 +85,8 @@ export class RuleDetailsUiComponent implements OnInit, OnDestroy {
   preview: boolean;
   @Input()
   actionDefinitions: ActionDefinitionTransformed[] = [];
+  @Input()
+  aspects: Aspect[] = [];
 
   @Output()
   formValidationChanged = new EventEmitter<boolean>();

--- a/projects/aca-folder-rules/src/lib/services/actions.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/actions.service.spec.ts
@@ -32,6 +32,8 @@ import { take } from 'rxjs/operators';
 
 describe('ActionsService', () => {
   let actionsService: ActionsService;
+  let apiCallSpy;
+  const params = [{}, {}, {}, {}, {}, ['application/json'], ['application/json']];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -61,5 +63,24 @@ describe('ActionsService', () => {
 
     expect(await loadingTruePromise).toBeTrue();
     expect(await loadingFalsePromise).toBeFalse();
+  });
+
+  it('should load the data into the observable', async () => {
+    spyOn(ActionsApi.prototype, 'listActions').and.returnValue(Promise.resolve(actionDefListMock));
+    const actionsPromise = actionsService.actionDefinitionsListing$.pipe(take(2)).toPromise();
+
+    actionsService.loadActionDefinitions();
+
+    const actionsList = await actionsPromise;
+    expect(actionsList).toEqual(actionsTransformedListMock);
+  });
+
+  it('loadAspects should send correct GET request', async () => {
+    apiCallSpy = spyOn<any>(actionsService, 'publicApiCall').withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params).and.returnValue([]);
+
+    actionsService.loadAspects();
+
+    expect(apiCallSpy).toHaveBeenCalled();
+    expect(apiCallSpy).toHaveBeenCalledWith(`/action-parameter-constraints/ac-aspects`, 'GET', params);
   });
 });

--- a/projects/aca-folder-rules/src/lib/services/actions.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/actions.service.spec.ts
@@ -65,16 +65,6 @@ describe('ActionsService', () => {
     expect(await loadingFalsePromise).toBeFalse();
   });
 
-  it('should load the data into the observable', async () => {
-    spyOn(ActionsApi.prototype, 'listActions').and.returnValue(Promise.resolve(actionDefListMock));
-    const actionsPromise = actionsService.actionDefinitionsListing$.pipe(take(2)).toPromise();
-
-    actionsService.loadActionDefinitions();
-
-    const actionsList = await actionsPromise;
-    expect(actionsList).toEqual(actionsTransformedListMock);
-  });
-
   it('loadAspects should send correct GET request', async () => {
     apiCallSpy = spyOn<any>(actionsService, 'publicApiCall').withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params).and.returnValue([]);
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -128,7 +128,9 @@ describe('FolderRulesService', () => {
 
   describe('loadAspects', () => {
     beforeEach(async () => {
-      apiCallSpy = spyOn<any>(folderRulesService, 'apiCall').withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params).and.returnValue([]);
+      apiCallSpy = spyOn<any>(folderRulesService, 'publicApiCall')
+        .withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params)
+        .and.returnValue([]);
 
       folderRulesService.loadAspects();
     });

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -128,14 +128,14 @@ describe('FolderRulesService', () => {
 
   describe('loadAspects', () => {
     beforeEach(async () => {
-      apiCallSpy = spyOn<any>(folderRulesService, 'apiCall').withArgs(`/aspects`, 'GET', params).and.returnValue([]);
+      apiCallSpy = spyOn<any>(folderRulesService, 'apiCall').withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params).and.returnValue([]);
 
       folderRulesService.loadAspects();
     });
 
     it('should send correct GET request', async () => {
       expect(apiCallSpy).toHaveBeenCalled();
-      expect(apiCallSpy).toHaveBeenCalledWith(`/aspects`, 'GET', params);
+      expect(apiCallSpy).toHaveBeenCalledWith(`/action-parameter-constraints/ac-aspects`, 'GET', params);
     });
   });
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -126,21 +126,6 @@ describe('FolderRulesService', () => {
     });
   });
 
-  describe('loadAspects', () => {
-    beforeEach(async () => {
-      apiCallSpy = spyOn<any>(folderRulesService, 'publicApiCall')
-        .withArgs(`/action-parameter-constraints/ac-aspects`, 'GET', params)
-        .and.returnValue([]);
-
-      folderRulesService.loadAspects();
-    });
-
-    it('should send correct GET request', async () => {
-      expect(apiCallSpy).toHaveBeenCalled();
-      expect(apiCallSpy).toHaveBeenCalledWith(`/action-parameter-constraints/ac-aspects`, 'GET', params);
-    });
-  });
-
   describe('createRule', () => {
     beforeEach(async () => {
       spyOn<any>(folderRulesService, 'apiCall')

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -32,7 +32,7 @@ import { ContentApiService } from '@alfresco/aca-shared';
 import { NodeInfo } from '@alfresco/aca-shared/store';
 import { RuleCompositeCondition } from '../model/rule-composite-condition.model';
 import { RuleSimpleCondition } from '../model/rule-simple-condition.model';
-import { Aspect, AspectModel } from '../model/aspect.model';
+import { Aspect } from '../model/aspect.model';
 
 @Injectable({
   providedIn: 'root'
@@ -174,8 +174,8 @@ export class FolderRulesService {
   }
 
   loadAspects(): void {
-    from(this.apiCall('/aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']]))
-      .pipe(map((res) => res.list.entries.map((entry) => this.formatAspect(entry.entry))))
+    from(this.apiCall('/action-parameter-constraints/ac-aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']]))
+      .pipe(map((res) => res.entry.constraintValues.map((entry) => this.formatAspect(entry))))
       .subscribe((res) => {
         this.aspectsSource.next(res);
       });
@@ -234,23 +234,10 @@ export class FolderRulesService {
     };
   }
 
-  private formatAspect(obj): Aspect {
+  private formatAspect(aspect): Aspect {
     return {
-      includedInSupertypeQuery: obj.includedInSupertypeQuery ?? false,
-      isContainer: obj.isContainer ?? false,
-      model: this.formatAspectModel(obj.model),
-      id: obj.id ?? '',
-      title: obj.title ?? '',
-      parentId: obj.parentId ?? ''
-    };
-  }
-
-  private formatAspectModel(obj): AspectModel {
-    return {
-      id: obj.id ?? '',
-      description: obj.description ?? '',
-      namespaceUri: obj.namespaceUri ?? '',
-      namespacePrefix: obj.namespacePrefix ?? ''
+      value: aspect.value ?? '',
+      label: aspect.label ?? ''
     };
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -32,7 +32,6 @@ import { ContentApiService } from '@alfresco/aca-shared';
 import { NodeInfo } from '@alfresco/aca-shared/store';
 import { RuleCompositeCondition } from '../model/rule-composite-condition.model';
 import { RuleSimpleCondition } from '../model/rule-simple-condition.model';
-import { Aspect } from '../model/aspect.model';
 
 @Injectable({
   providedIn: 'root'
@@ -71,8 +70,6 @@ export class FolderRulesService {
   loading$ = this.loadingSource.asObservable();
   private deletedRuleIdSource = new BehaviorSubject<string>(null);
   deletedRuleId$: Observable<string> = this.deletedRuleIdSource.asObservable();
-  private aspectsSource = new BehaviorSubject<Aspect[]>([]);
-  aspects$: Observable<Aspect[]> = this.aspectsSource.asObservable();
 
   constructor(private apiService: AlfrescoApiService, private contentApi: ContentApiService) {}
 
@@ -173,18 +170,6 @@ export class FolderRulesService {
     ).subscribe({ error: (error) => console.error(error) });
   }
 
-  loadAspects(): void {
-    from(this.publicApiCall('/action-parameter-constraints/ac-aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']]))
-      .pipe(map((res) => res.entry.constraintValues.map((entry) => this.formatAspect(entry))))
-      .subscribe((res) => {
-        this.aspectsSource.next(res);
-      });
-  }
-
-  private publicApiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {
-    return this.apiService.getInstance().contentClient.callApi(path, httpMethod, ...params);
-  }
-
   private apiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {
     // APIs used by this service are still private and not yet available for public use
     return this.apiService.getInstance().contentPrivateClient.callApi(path, httpMethod, ...params);
@@ -235,13 +220,6 @@ export class FolderRulesService {
       field: obj.field || 'cm:name',
       comparator: obj.comparator || 'equals',
       parameter: obj.parameter || ''
-    };
-  }
-
-  private formatAspect(aspect): Aspect {
-    return {
-      value: aspect.value ?? '',
-      label: aspect.label ?? ''
     };
   }
 }

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -174,11 +174,15 @@ export class FolderRulesService {
   }
 
   loadAspects(): void {
-    from(this.apiCall('/action-parameter-constraints/ac-aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']]))
+    from(this.publicApiCall('/action-parameter-constraints/ac-aspects', 'GET', [{}, {}, {}, {}, {}, ['application/json'], ['application/json']]))
       .pipe(map((res) => res.entry.constraintValues.map((entry) => this.formatAspect(entry))))
       .subscribe((res) => {
         this.aspectsSource.next(res);
       });
+  }
+
+  private publicApiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {
+    return this.apiService.getInstance().contentClient.callApi(path, httpMethod, ...params);
   }
 
   private apiCall(path: string, httpMethod: string, params?: any[]): Promise<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently there is a blank field for add/remove aspect actions 

<img width="741" alt="Screenshot 2022-10-14 at 12 18 05" src="https://user-images.githubusercontent.com/84377976/195823544-85d1086f-d206-4539-87d7-a673b2c1d219.png">


**What is the new behaviour?**

Now `CardViewSelectItemModel` is used to display a list of all aspects

<img width="1012" alt="Screenshot 2022-10-14 at 12 18 43" src="https://user-images.githubusercontent.com/84377976/195823664-495e2069-4671-4126-858c-05a66d0fbbf6.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
