### PR TITLE
[ACS-3700] Pass mat menu items from external components to mat menu

### DIFF
--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -23,9 +23,10 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { AppExtensionService } from '../../../services/app.extension.service';
+import { MatMenuItem } from '@angular/material/menu';
 
 @Component({
   selector: 'app-toolbar-menu-item',
@@ -43,6 +44,9 @@ import { AppExtensionService } from '../../../services/app.extension.service';
 export class ToolbarMenuItemComponent {
   @Input()
   actionRef: ContentActionRef;
+
+  @ViewChild(MatMenuItem)
+  menuItem: MatMenuItem;
 
   constructor(private extensions: AppExtensionService) {}
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList } from '@angular/core';
+import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList, AfterViewInit } from '@angular/core';
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { ThemePalette } from '@angular/material/core';
@@ -35,7 +35,7 @@ import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-toolbar-menu' }
 })
-export class ToolbarMenuComponent {
+export class ToolbarMenuComponent implements AfterViewInit {
   @Input()
   actionRef: ContentActionRef;
 
@@ -57,13 +57,13 @@ export class ToolbarMenuComponent {
   }
 
   ngAfterViewInit(): void {
-    let menuItems: MatMenuItem[] = [];
+    const menuItems: MatMenuItem[] = [];
     this.toolbarMenuItems.forEach((toolbarMenuItem: ToolbarMenuItemComponent) => {
       if (toolbarMenuItem.menuItem !== undefined) {
         menuItems.push(toolbarMenuItem.menuItem);
       }
     });
-    let menuItemsQueryList: QueryList<MatMenuItem> = new QueryList<MatMenuItem>();
+    const menuItemsQueryList: QueryList<MatMenuItem> = new QueryList<MatMenuItem>();
     menuItemsQueryList.reset(menuItems);
     this.menu._allItems = menuItemsQueryList;
     this.menu.ngAfterContentInit();

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
@@ -23,10 +23,11 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, ViewEncapsulation, HostListener, ViewChild } from '@angular/core';
+import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList } from '@angular/core';
 import { ContentActionRef } from '@alfresco/adf-extensions';
-import { MatMenuTrigger } from '@angular/material/menu';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { ThemePalette } from '@angular/material/core';
+import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item.component';
 
 @Component({
   selector: 'app-toolbar-menu',
@@ -44,9 +45,28 @@ export class ToolbarMenuComponent {
   @ViewChild('matTrigger')
   matTrigger: MatMenuTrigger;
 
+  @ViewChild(MatMenu)
+  menu: MatMenu;
+
+  @ViewChildren(ToolbarMenuItemComponent)
+  toolbarMenuItems: QueryList<ToolbarMenuItemComponent>;
+
   @HostListener('document:keydown.Escape')
   handleKeydownEscape() {
     this.matTrigger.closeMenu();
+  }
+
+  ngAfterViewInit(): void {
+    let menuItems: MatMenuItem[] = [];
+    this.toolbarMenuItems.forEach((toolbarMenuItem: ToolbarMenuItemComponent) => {
+      if (toolbarMenuItem.menuItem !== undefined) {
+        menuItems.push(toolbarMenuItem.menuItem);
+      }
+    });
+    let menuItemsQueryList: QueryList<MatMenuItem> = new QueryList<MatMenuItem>();
+    menuItemsQueryList.reset(menuItems);
+    this.menu._allItems = menuItemsQueryList;
+    this.menu.ngAfterContentInit();
   }
 
   trackByActionId(_: number, obj: ContentActionRef): string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Context menu items can't be accessed via keyboard.

**What is the new behaviour?**

Context menu items (except ones placed with ADF DynamicExtensionComponent ) are correctly passed to the material menu which results in them being properly focused and accessible via keyboard.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
