### PR TITLE
[ACS-3823] ACA: Folder rule conditions - wrong values passed as comparators

### DIFF
--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
@@ -47,47 +47,47 @@ export const ruleConditionComparators: RuleConditionComparator[] = [
     }
   },
   {
-    name: 'startsWith',
+    name: 'starts_with',
     labels: {
       string: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.STARTS_WITH'
     }
   },
   {
-    name: 'endsWith',
+    name: 'ends_with',
     labels: {
       string: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.ENDS_WITH'
     }
   },
   {
-    name: 'greaterThan',
+    name: 'greater_than',
     labels: {
       number: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.GREATER_THAN',
       date: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.AFTER'
     }
   },
   {
-    name: 'lessThan',
+    name: 'less_than',
     labels: {
       number: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.LESS_THAN',
       date: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.BEFORE'
     }
   },
   {
-    name: 'greaterThanOrEqual',
+    name: 'greater_than_or_equal',
     labels: {
       number: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.GREATER_THAN_OR_EQUAL',
       date: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.ON_OR_AFTER'
     }
   },
   {
-    name: 'lessThanOrEqual',
+    name: 'less_than_or_equal',
     labels: {
       number: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.LESS_THAN_OR_EQUAL',
       date: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.ON_OR_BEFORE'
     }
   },
   {
-    name: 'instanceOf',
+    name: 'instance_of',
     labels: {
       type: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.INSTANCE_OF'
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When creating or updating rule and adding condition for Size ‘Greater than' (or any other multi-word comparator, e.g., ‘Less than’, 'Greater than or equal’) condition, then the value that is passed to the HTTP request is 'greaterthan' instead of 'greater_than'.
Unfortunately, this rule is persisted and no error is returned from the server but when the rule is executed, then error shows up.

**What is the new behaviour?**

Comparators were refactored from camelCase to snake_case style.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
