### PR TITLE
[ACS-3872] Disable boolean mode dropdown due to lack of OR in ACS

### DIFF
--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-composite-condition.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-composite-condition.ui-component.html
@@ -20,7 +20,7 @@
     <mat-form-field *ngIf="i > 0">
       <mat-select
         [value]="booleanModeControl.value"
-        [disabled]="i > 1 || readOnly"
+        [disabled]="!isOrImplemented || i > 1 || readOnly"
         (selectionChange)="setBooleanMode($event.value)">
         <mat-option value="and">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LOGIC_OPERATORS.AND' | translate }}</mat-option>
         <mat-option value="or">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LOGIC_OPERATORS.OR' | translate }}</mat-option>

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-composite-condition.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-composite-condition.ui-component.ts
@@ -57,6 +57,8 @@ export class RuleCompositeConditionUiComponent implements ControlValueAccessor, 
     simpleConditions: new FormArray([])
   });
 
+  readonly isOrImplemented = false;
+
   private _readOnly = false;
   @Input()
   get readOnly(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-3872

**What is the new behaviour?**

The dropdown box is permanently disabled so long as the OR boolean mode hasn't yet been implemented in ACS.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
