### PR TITLE
[ACA-4624] - Add placeholder for input field in rules conditions

### DIFF
--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -21,7 +21,8 @@
       "PLACEHOLDER": {
         "NAME": "Enter rule name",
         "DESCRIPTION": "Enter rule description",
-        "NO_DESCRIPTION": "No description"
+        "NO_DESCRIPTION": "No description",
+        "VALUE": "Value"
       },
       "ERROR": {
         "REQUIRED": "This field is required",

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
@@ -22,6 +22,6 @@
   </mat-form-field>
 
   <mat-form-field class="aca-rule-simple-condition__form__parameter-input">
-    <input matInput type="text" formControlName="parameter" data-automation-id="value-input">
+    <input matInput placeholder="{{ 'ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.VALUE' | translate }}" type="text" formControlName="parameter" data-automation-id="value-input">
   </mat-form-field>
 </form>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

As @KikoUK mentioned - "although it might seem logical what the last input field is for, users might find that confusing.
I think it should have a default description of “expected value” or just “value'"
![image](https://user-images.githubusercontent.com/84377976/201939319-c5278bc1-e875-469f-b304-d4b5116b301b.png)

**What is the new behaviour?**

Placeholder 'Value" was added for input fields
<img width="1563" alt="Screenshot 2022-11-15 at 14 53 27" src="https://user-images.githubusercontent.com/84377976/201939645-1b7b4828-1fd7-484d-9912-dc79f1203591.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
