### PR TITLE
[ACS-3860] Folder rules - Node picker for action parameters of type "d:noderef"

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -65,7 +65,8 @@
     "dateitem",
     "versionable",
     "erroredSpy",
-    "errored"
+    "errored",
+    "noderef"
   ],
   "dictionaries": ["html", "en-gb", "en_US"]
 }

--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -22,7 +22,8 @@
         "NAME": "Enter rule name",
         "DESCRIPTION": "Enter rule description",
         "NO_DESCRIPTION": "No description",
-        "VALUE": "Value"
+        "VALUE": "Value",
+        "CHOOSE_FOLDER": "Choose destination folder"
       },
       "ERROR": {
         "REQUIRED": "This field is required",

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -86,7 +86,8 @@
                   [actionDefinitions]="actionDefinitions$ | async"
                   [readOnly]="true"
                   [preview]="true"
-                  [value]="selectedRule">
+                  [value]="selectedRule"
+                  [nodeId]="nodeId">
                 </aca-rule-details>
               </div>
             </div>

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -48,7 +48,7 @@ import { RuleSet } from '../model/rule-set.model';
   host: { class: 'aca-manage-rules' }
 })
 export class ManageRulesSmartComponent implements OnInit, OnDestroy {
-  nodeId: string = '';
+  nodeId = '';
 
   mainRuleSet$: Observable<RuleSet>;
   inheritedRuleSets$: Observable<RuleSet[]>;

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -48,7 +48,7 @@ import { RuleSet } from '../model/rule-set.model';
   host: { class: 'aca-manage-rules' }
 })
 export class ManageRulesSmartComponent implements OnInit, OnDestroy {
-  nodeId: string = null;
+  nodeId: string = '';
 
   mainRuleSet$: Observable<RuleSet>;
   inheritedRuleSets$: Observable<RuleSet[]>;
@@ -115,7 +115,8 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
       width: '90%',
       panelClass: 'aca-edit-rule-dialog-container',
       data: {
-        model
+        model,
+        nodeId: this.nodeId
       }
     });
 

--- a/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
@@ -62,14 +62,14 @@ export const actionDefListMock = {
             name: 'mock-action-parameter-noderef',
             type: 'd:noderef',
             multiValued: false,
-            mandatory: false,
+            mandatory: false
           },
           {
             name: 'aspect-name',
             type: 'd:noderef',
             multiValued: false,
-            mandatory: false,
-          },
+            mandatory: false
+          }
         ],
         name: 'mock-action-1-definition',
         trackStatus: false,
@@ -139,7 +139,13 @@ const action1TransformedMock: ActionDefinitionTransformed = {
   title: 'Action 1 title',
   applicableTypes: [],
   trackStatus: false,
-  parameterDefinitions: [actionParam1TransformedMock, actionParam2TransformedMock, actionParam3TransformedMock, actionParam4TransformedMock, actionParam5TransformedMock]
+  parameterDefinitions: [
+    actionParam1TransformedMock,
+    actionParam2TransformedMock,
+    actionParam3TransformedMock,
+    actionParam4TransformedMock,
+    actionParam5TransformedMock
+  ]
 };
 
 const action2TransformedMock: ActionDefinitionTransformed = {

--- a/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
@@ -57,7 +57,19 @@ export const actionDefListMock = {
             multiValued: false,
             mandatory: false,
             parameterConstraintName: 'ac-aspects'
-          }
+          },
+          {
+            name: 'mock-action-parameter-noderef',
+            type: 'd:noderef',
+            multiValued: false,
+            mandatory: false,
+          },
+          {
+            name: 'aspect-name',
+            type: 'd:noderef',
+            multiValued: false,
+            mandatory: false,
+          },
         ],
         name: 'mock-action-1-definition',
         trackStatus: false,
@@ -102,6 +114,24 @@ const actionParam3TransformedMock: ActionParameterDefinitionTransformed = {
   parameterConstraintName: 'ac-aspects'
 };
 
+const actionParam4TransformedMock: ActionParameterDefinitionTransformed = {
+  name: 'mock-action-parameter-noderef',
+  type: 'd:noderef',
+  multiValued: false,
+  mandatory: false,
+  displayLabel: 'mock-action-parameter-noderef',
+  parameterConstraintName: ''
+};
+
+const actionParam5TransformedMock: ActionParameterDefinitionTransformed = {
+  name: 'aspect-name',
+  type: 'd:noderef',
+  multiValued: false,
+  mandatory: false,
+  displayLabel: 'aspect-name',
+  parameterConstraintName: ''
+};
+
 const action1TransformedMock: ActionDefinitionTransformed = {
   id: 'mock-action-1-definition',
   name: 'mock-action-1-definition',
@@ -109,7 +139,7 @@ const action1TransformedMock: ActionDefinitionTransformed = {
   title: 'Action 1 title',
   applicableTypes: [],
   trackStatus: false,
-  parameterDefinitions: [actionParam1TransformedMock, actionParam2TransformedMock, actionParam3TransformedMock]
+  parameterDefinitions: [actionParam1TransformedMock, actionParam2TransformedMock, actionParam3TransformedMock, actionParam4TransformedMock, actionParam5TransformedMock]
 };
 
 const action2TransformedMock: ActionDefinitionTransformed = {

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.html
@@ -3,7 +3,8 @@
     [actionDefinitions]="actionDefinitions"
     [parameterConstraints]="parameterConstraints"
     [readOnly]="readOnly"
-    [formControl]="control">
+    [formControl]="control"
+    [nodeId]="nodeId">
   </aca-rule-action>
 
   <button

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
@@ -52,7 +52,7 @@ export class RuleActionListUiComponent implements ControlValueAccessor, OnDestro
   @Input()
   parameterConstraints: ActionParameterConstraint[] = [];
   @Input()
-  nodeId: string = '';
+  nodeId = '';
 
   formArray = new FormArray([]);
   private formArraySubscription: Subscription;

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action-list.ui-component.ts
@@ -51,6 +51,8 @@ export class RuleActionListUiComponent implements ControlValueAccessor, OnDestro
   readOnly = false;
   @Input()
   parameterConstraints: ActionParameterConstraint[] = [];
+  @Input()
+  nodeId: string = '';
 
   formArray = new FormArray([]);
   private formArraySubscription: Subscription;

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.spec.ts
@@ -79,10 +79,13 @@ describe('RuleActionUiComponent', () => {
     expect(cardView.properties.length).toBe(0);
 
     changeMatSelectValue('rule-action-select', 'mock-action-1-definition');
-    expect(cardView.properties.length).toBe(3);
+
+    expect(cardView.properties.length).toBe(5);
     expect(cardView.properties[0]).toBeInstanceOf(CardViewTextItemModel);
     expect(cardView.properties[1]).toBeInstanceOf(CardViewBoolItemModel);
     expect(cardView.properties[2]).toBeInstanceOf(CardViewSelectItemModel);
+    expect(cardView.properties[3]).toBeInstanceOf(CardViewTextItemModel);
+    expect(cardView.properties[4]).toBeInstanceOf(CardViewSelectItemModel);
 
     changeMatSelectValue('rule-action-select', 'mock-action-2-definition');
     expect(cardView.properties.length).toBe(0);

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -35,7 +35,7 @@ import {
   CardViewUpdateService,
   UpdateNotification
 } from '@alfresco/adf-core';
-import { ActionParameterDefinition } from '@alfresco/js-api';
+import { ActionParameterDefinition, Node } from '@alfresco/js-api';
 import { of, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
@@ -224,12 +224,12 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     });
   }
 
-  openSelectorDialog() {
+  private openSelectorDialog() {
     const data: ContentNodeSelectorComponentData = {
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
       currentFolderId: this._nodeId,
-      select: new Subject<any>()
+      select: new Subject<Node[]>()
     };
 
     this.dialog.open(ContentNodeSelectorComponent, {
@@ -239,7 +239,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     });
 
     data.select.subscribe(
-      (selections) => {
+      (selections: Node[]) => {
         if (selections[0].id) {
           this.writeValue({
             actionDefinitionId: this.selectedActionDefinitionId,

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -41,6 +41,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
 import { ContentNodeSelectorComponent, ContentNodeSelectorComponentData, NodeAction } from '@alfresco/adf-content-services';
 import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'aca-rule-action',
@@ -120,7 +121,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   onChange: (action: RuleAction) => void = () => undefined;
   onTouch: () => void = () => undefined;
 
-  constructor(private cardViewUpdateService: CardViewUpdateService, private dialog: MatDialog) {}
+  constructor(private cardViewUpdateService: CardViewUpdateService, private dialog: MatDialog, private translate: TranslateService) {}
 
   writeValue(action: RuleAction) {
     this.form.setValue({
@@ -200,7 +201,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             return new CardViewTextItemModel({
               ...cardViewPropertiesModel,
               icon: 'folder',
-              default: 'Choose destination folder',
+              default: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
               clickable: true,
               clickCallBack: this.openSelectorDialog.bind(this),
               value: this.parameters[paramDef.name]
@@ -226,7 +227,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
 
   openSelectorDialog() {
     const data = {
-      title: 'Choose an item',
+      title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
       currentFolderId: this._nodeId,
       select: new Subject<any>()

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -39,10 +39,7 @@ import { ActionParameterDefinition } from '@alfresco/js-api';
 import { of, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
-import {
-  ContentNodeSelectorComponent,
-  ContentNodeSelectorComponentData, NodeAction
-} from '@alfresco/adf-content-services';
+import { ContentNodeSelectorComponent, ContentNodeSelectorComponentData, NodeAction } from '@alfresco/adf-content-services';
 import { MatDialog } from '@angular/material/dialog';
 
 @Component({
@@ -63,11 +60,11 @@ import { MatDialog } from '@angular/material/dialog';
 export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDestroy {
   private _nodeId;
   @Input()
-  get nodeId(): string{
-    return this._nodeId
+  get nodeId(): string {
+    return this._nodeId;
   }
   set nodeId(value) {
-    this._nodeId = value
+    this._nodeId = value;
   }
 
   private _actionDefinitions: ActionDefinitionTransformed[];
@@ -117,7 +114,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   get cardViewStyle() {
-    return this.isFullWidth ? {width: '100%'} : {};
+    return this.isFullWidth ? { width: '100%' } : {};
   }
 
   onChange: (action: RuleAction) => void = () => undefined;
@@ -228,23 +225,21 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   openSelectorDialog() {
-    let data = {
+    const data = {
       title: 'Choose an item',
       actionName: NodeAction.CHOOSE,
       currentFolderId: this._nodeId,
       select: new Subject<any>()
     };
 
-    this.dialog.open(
-      ContentNodeSelectorComponent,
-      {
-        data,
-        panelClass: 'adf-content-node-selector-dialog',
-        width: '630px'
-      }
-    );
+    this.dialog.open(ContentNodeSelectorComponent, {
+      data,
+      panelClass: 'adf-content-node-selector-dialog',
+      width: '630px'
+    });
 
-    data.select.subscribe((selections) => {
+    data.select.subscribe(
+      (selections) => {
         if (selections[0].id) {
           this.writeValue({
             actionDefinitionId: this.selectedActionDefinitionId,
@@ -260,11 +255,12 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
         }
       },
       (error) => {
-      console.error(error)
+        console.error(error);
       },
       () => {
         this.dialog.closeAll();
-      });
+      }
+    );
   }
 
   setDefaultParameters() {

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -98,7 +98,6 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   isFullWidth = false;
-  isNodeSelector = false;
   data: ContentNodeSelectorComponentData;
 
   form = new FormGroup({
@@ -118,12 +117,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   get cardViewStyle() {
-    let style = {}
-
-    this.isFullWidth ? style = {...style, width: '100%' } : style = {...style };
-    this.isNodeSelector ? style = {...style, cursor: 'pointer', input: {cursor: 'pointer !important'} } : style = {...style };
-
-    return style;
+    return this.isFullWidth ? {width: '100%'} : {};
   }
 
   onChange: (action: RuleAction) => void = () => undefined;
@@ -182,9 +176,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   setCardViewProperties() {
     this.cardViewItems = (this.selectedActionDefinition?.parameterDefinitions ?? []).map((paramDef) => {
       this.isFullWidth = false;
-      this.isNodeSelector = false;
       const constraintsForDropdownBox = this._parameterConstraints.find((obj) => obj.name === paramDef.name);
-
       const cardViewPropertiesModel = {
         label: paramDef.displayLabel + (paramDef.mandatory ? ' *' : ''),
         key: paramDef.name,
@@ -207,7 +199,6 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             value: this.parameters[paramDef.name] ?? false
           });
         case 'd:noderef':
-          this.isNodeSelector = true;
           if (!constraintsForDropdownBox && !this.readOnly) {
             return new CardViewTextItemModel({
               ...cardViewPropertiesModel,
@@ -254,14 +245,19 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     );
 
     data.select.subscribe((selections) => {
-      // console.log(selections[0].name)
-        this.writeValue({
-          actionDefinitionId: this.selectedActionDefinitionId,
-          params: {
-            'destination-folder': selections[0].id //,
-            // 'folder-name': selections[0].name
-          }
-        });
+        if (selections[0].id) {
+          this.writeValue({
+            actionDefinitionId: this.selectedActionDefinitionId,
+            params: {
+              'destination-folder': selections[0].id
+            }
+          });
+          this.onChange({
+            actionDefinitionId: this.selectedActionDefinitionId,
+            params: this.parameters
+          });
+          this.onTouch();
+        }
       },
       (error) => {
       console.error(error)

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -59,7 +59,7 @@ import { TranslateService } from '@ngx-translate/core';
   ]
 })
 export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  private _nodeId;
+  private _nodeId = '';
   @Input()
   get nodeId(): string {
     return this._nodeId;
@@ -96,7 +96,6 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   isFullWidth = false;
-  data: ContentNodeSelectorComponentData;
 
   form = new FormGroup({
     actionDefinitionId: new FormControl('', Validators.required)
@@ -226,7 +225,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
   }
 
   openSelectorDialog() {
-    const data = {
+    const data: ContentNodeSelectorComponentData = {
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
       currentFolderId: this._nodeId,

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -59,14 +59,8 @@ import { TranslateService } from '@ngx-translate/core';
   ]
 })
 export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  private _nodeId = '';
   @Input()
-  get nodeId(): string {
-    return this._nodeId;
-  }
-  set nodeId(value) {
-    this._nodeId = value;
-  }
+  nodeId = '';
 
   private _actionDefinitions: ActionDefinitionTransformed[];
   @Input()
@@ -228,7 +222,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     const data: ContentNodeSelectorComponentData = {
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
-      currentFolderId: this._nodeId,
+      currentFolderId: this.nodeId,
       select: new Subject<Node[]>()
     };
 

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.html
@@ -20,6 +20,7 @@
       [actionDefinitions]="actionDefinitions$ | async"
       [parameterConstraints]="parameterConstraints$ | async"
       [value]="model"
+      [nodeId]="nodeId"
       (formValueChanged)="formValue = $event"
       (formValidationChanged)="onFormValidChange($event)">
     </aca-rule-details>

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -43,7 +43,7 @@ export interface EditRuleDialogOptions {
 export class EditRuleDialogSmartComponent implements OnInit, OnDestroy {
   formValid = false;
   model: Partial<Rule>;
-  nodeId: string = '';
+  nodeId = '';
   formValue: Partial<Rule>;
   @Output() submitted = new EventEmitter<Partial<Rule>>();
   actionDefinitions$ = this.actionsService.actionDefinitionsListing$;
@@ -53,7 +53,7 @@ export class EditRuleDialogSmartComponent implements OnInit, OnDestroy {
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions, private actionsService: ActionsService) {
     this.model = this.data?.model || {};
-    this.nodeId = this.data?.nodeId
+    this.nodeId = this.data?.nodeId;
   }
 
   get isUpdateMode(): boolean {

--- a/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/edit-rule-dialog.smart-component.ts
@@ -30,6 +30,7 @@ import { ActionsService } from '../services/actions.service';
 
 export interface EditRuleDialogOptions {
   model?: Partial<Rule>;
+  nodeId?: string;
 }
 
 @Component({
@@ -42,6 +43,7 @@ export interface EditRuleDialogOptions {
 export class EditRuleDialogSmartComponent implements OnInit, OnDestroy {
   formValid = false;
   model: Partial<Rule>;
+  nodeId: string = '';
   formValue: Partial<Rule>;
   @Output() submitted = new EventEmitter<Partial<Rule>>();
   actionDefinitions$ = this.actionsService.actionDefinitionsListing$;
@@ -51,6 +53,7 @@ export class EditRuleDialogSmartComponent implements OnInit, OnDestroy {
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: EditRuleDialogOptions, private actionsService: ActionsService) {
     this.model = this.data?.model || {};
+    this.nodeId = this.data?.nodeId
   }
 
   get isUpdateMode(): boolean {

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
@@ -47,7 +47,8 @@
       formControlName="actions"
       [actionDefinitions]="actionDefinitions"
       [parameterConstraints]="parameterConstraints"
-      [readOnly]="readOnly">
+      [readOnly]="readOnly"
+      [nodeId]="nodeId">
     </aca-rule-action-list>
   </div>
 

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
@@ -23,7 +23,15 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewEncapsulation
+} from '@angular/core';
 import { AbstractControl, UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
@@ -97,6 +105,8 @@ export class RuleDetailsUiComponent implements OnInit, OnDestroy {
   actionDefinitions: ActionDefinitionTransformed[] = [];
   @Input()
   parameterConstraints: ActionParameterConstraint[] = [];
+  @Input()
+  nodeId: string = '';
 
   @Output()
   formValidationChanged = new EventEmitter<boolean>();

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
@@ -23,15 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
@@ -106,7 +98,7 @@ export class RuleDetailsUiComponent implements OnInit, OnDestroy {
   @Input()
   parameterConstraints: ActionParameterConstraint[] = [];
   @Input()
-  nodeId: string = '';
+  nodeId = '';
 
   @Output()
   formValidationChanged = new EventEmitter<boolean>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently for action parameters of type "d:noderef" there is text input, where user should manually enter folder id.

**What is the new behaviour?**

Now for action parameters of type "d:noderef" node selection dialog opens to select a node rather than a simple text box.

<img width="609" alt="Screenshot 2022-11-22 at 08 44 35" src="https://user-images.githubusercontent.com/84377976/203255400-53cb541d-a348-46af-9639-5498a808d42b.png">
<img width="644" alt="Screenshot 2022-11-22 at 08 46 15" src="https://user-images.githubusercontent.com/84377976/203255412-a3b2c9b2-7ebf-498c-b3a0-f091cdd7b250.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
