### PR TITLE
[ACS-3895] ACA - Folder Rules: inherit rule sets toggle

### DIFF
--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -95,7 +95,8 @@
           "CREATE_RULE": "Create rule",
           "LINK_RULES": "Link rules",
           "EDIT_RULE": "Edit",
-          "SEE_IN_FOLDER": "See in folder"
+          "SEE_IN_FOLDER": "See in folder",
+          "INHERIT_RULES": "Inherit rules"
         }
       },
       "EMPTY_RULES_LIST": {

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -35,7 +35,7 @@
               {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.INHERIT_RULES' | translate }}
             </mat-slide-toggle>
 
-            <mat-divider vertical [style]="{height:'50%', margin:'0 12px'}"></mat-divider>
+            <mat-divider vertical class="vertical-divider"></mat-divider>
 
             <div class="aca-manage-rules__actions-bar__buttons">
               <button

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -26,7 +26,13 @@
                               class="aca-manage-rules__actions-bar__title__breadcrumb"></adf-breadcrumb>
             </adf-toolbar-title>
 
-            <mat-slide-toggle disableRipple [labelPosition]="'before'" [aria-label]="'Inherit rules'">Inherit rules</mat-slide-toggle>
+            <mat-slide-toggle
+              [checked]="isInheritanceEnabled"
+              (change)="onToggleInheritanceClick($event)"
+              [disabled]="isInheritanceToggleDisabled"
+              [labelPosition]="'before'">
+              {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.INHERIT_RULES' | translate }}
+            </mat-slide-toggle>
 
             <mat-divider vertical [style]="{height:'50%', margin:'0 12px'}"></mat-divider>
 

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -26,6 +26,10 @@
                               class="aca-manage-rules__actions-bar__title__breadcrumb"></adf-breadcrumb>
             </adf-toolbar-title>
 
+            <mat-slide-toggle disableRipple [labelPosition]="'before'" [aria-label]="'Inherit rules'">Inherit rules</mat-slide-toggle>
+
+            <mat-divider vertical [style]="{height:'50%', margin:'0 12px'}"></mat-divider>
+
             <div class="aca-manage-rules__actions-bar__buttons">
               <button
                 *ngIf="!(mainRuleSet$ | async)"

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -27,8 +27,9 @@
             </adf-toolbar-title>
 
             <mat-slide-toggle
+              data-automation-id="manage-rules-inheritance-toggle-button"
               [checked]="isInheritanceEnabled"
-              (change)="onToggleInheritanceClick($event)"
+              (change)="onInheritanceToggleChange($event)"
               [disabled]="isInheritanceToggleDisabled"
               [labelPosition]="'before'">
               {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.INHERIT_RULES' | translate }}

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
@@ -17,7 +17,7 @@
     &__buttons {
       display: flex;
       align-items: stretch;
-      gap: 4px;
+      gap: 12px;
     }
 
     .mat-slide-toggle-label {

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
@@ -25,6 +25,11 @@
       font-size: 14px;
       color: var(--adf-breadcrumb-item-active-color);
     }
+
+    .vertical-divider {
+      height: 50%;
+      margin: 0 12px;
+    }
   }
 
   &__container {

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.scss
@@ -19,6 +19,12 @@
       align-items: stretch;
       gap: 4px;
     }
+
+    .mat-slide-toggle-label {
+      font-weight: 600;
+      font-size: 14px;
+      color: var(--adf-breadcrumb-item-active-color);
+    }
   }
 
   &__container {

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -36,7 +36,7 @@ import { owningFolderIdMock, owningFolderMock } from '../mock/node.mock';
 import { MatDialog } from '@angular/material/dialog';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
-import { ruleMock } from '../mock/rules.mock';
+import { ruleMock, ruleSettings } from '../mock/rules.mock';
 import { Store } from '@ngrx/store';
 
 describe('ManageRulesSmartComponent', () => {
@@ -227,6 +227,45 @@ describe('ManageRulesSmartComponent', () => {
 
       const createButton = debugElement.query(By.css(`[data-automation-id="manage-rules-create-button"]`));
       expect(createButton).toBeFalsy();
+    });
+  });
+
+  describe('Rule inheritance toggle  button', () => {
+    beforeEach(() => {
+      folderRuleSetsService.folderInfo$ = of(owningFolderMock);
+      folderRuleSetsService.inheritedRuleSets$ = of([]);
+      folderRuleSetsService.isLoading$ = of(false);
+      actionsService.loading$ = of(false);
+    });
+
+    it('should show inherit rules toggle button, and disable it when isInheritanceToggleDisabled = true', () => {
+      fixture.detectChanges();
+
+      const createButton = debugElement.query(By.css(`[data-automation-id="manage-rules-inheritance-toggle-button"]`));
+      expect(createButton).toBeTruthy();
+
+      component.isInheritanceToggleDisabled = true;
+      fixture.detectChanges();
+
+      expect(createButton.nativeNode.classList).toContain('mat-disabled');
+    });
+
+    it('should call onInheritanceToggleChange() on change', () => {
+      const onInheritanceToggleChangeSpy = spyOn(component, 'onInheritanceToggleChange').and.callThrough();
+      const updateRuleSettingsSpy = spyOn(folderRulesService, 'updateRuleSettings').and.returnValue(Promise.resolve(ruleSettings));
+      const loadRuleSetsSpy = spyOn(folderRuleSetsService, 'loadRuleSets').and.callThrough();
+
+      fixture.detectChanges();
+
+      const inheritanceToggleBtn = fixture.debugElement.query(By.css(`[data-automation-id="manage-rules-inheritance-toggle-button"]`));
+
+      inheritanceToggleBtn.nativeElement.dispatchEvent(new Event('change'));
+
+      fixture.detectChanges();
+
+      expect(onInheritanceToggleChangeSpy).toHaveBeenCalled();
+      expect(updateRuleSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(loadRuleSetsSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -36,7 +36,7 @@ import { owningFolderIdMock, owningFolderMock } from '../mock/node.mock';
 import { MatDialog } from '@angular/material/dialog';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
-import { ruleMock, ruleSettings } from '../mock/rules.mock';
+import { ruleMock, ruleSettingsMock } from '../mock/rules.mock';
 import { Store } from '@ngrx/store';
 
 describe('ManageRulesSmartComponent', () => {
@@ -252,7 +252,7 @@ describe('ManageRulesSmartComponent', () => {
 
     it('should call onInheritanceToggleChange() on change', () => {
       const onInheritanceToggleChangeSpy = spyOn(component, 'onInheritanceToggleChange').and.callThrough();
-      const updateRuleSettingsSpy = spyOn(folderRulesService, 'updateRuleSettings').and.returnValue(Promise.resolve(ruleSettings));
+      const updateRuleSettingsSpy = spyOn(folderRulesService, 'updateRuleSettings').and.returnValue(Promise.resolve(ruleSettingsMock));
       const loadRuleSetsSpy = spyOn(folderRuleSetsService, 'loadRuleSets').and.callThrough();
 
       fixture.detectChanges();

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -61,7 +61,6 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
   hasMoreRuleSets$: Observable<boolean>;
   ruleSetsLoading$: Observable<boolean>;
   folderInfo$: Observable<NodeInfo>;
-  isInheritanceEnabled$: Observable<boolean>;
 
   actionsLoading$: Observable<boolean>;
   actionDefinitions$: Observable<ActionDefinitionTransformed[]>;

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -162,7 +162,7 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
     await this.folderRulesService.updateRule(this.nodeId, rule.id, { ...rule, isEnabled });
   }
 
-  async onToggleInheritanceClick(event: MatSlideToggleChange) {
+  async onInheritanceToggleChange(event: MatSlideToggleChange) {
     this.isInheritanceToggleDisabled = true;
     const ruleSettings = await this.folderRulesService.updateRuleSettings(this.nodeId, '-isInheritanceEnabled-', { value: event.checked });
     this.isInheritanceEnabled = ruleSettings.value;

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -86,7 +86,6 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
     this.hasMoreRuleSets$ = this.folderRuleSetsService.hasMoreRuleSets$;
     this.ruleSetsLoading$ = this.folderRuleSetsService.isLoading$;
     this.folderInfo$ = this.folderRuleSetsService.folderInfo$;
-    // this.isInheritanceEnabled$ = this.folderRulesService.isInheritanceEnabled$;
 
     this.actionsLoading$ = this.actionsService.loading$.pipe(delay(0));
     this.actionDefinitions$ = this.actionsService.actionDefinitionsListing$;

--- a/projects/aca-folder-rules/src/lib/mock/rules.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/rules.mock.ts
@@ -171,7 +171,7 @@ export const ruleListGroupingItemsMock: RuleGroupingItem[] = [
   }
 ];
 
-export const ruleSettings: RuleSettings = {
+export const ruleSettingsMock: RuleSettings = {
   value: false,
   key: '-parameter-'
 };

--- a/projects/aca-folder-rules/src/lib/mock/rules.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/rules.mock.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Rule } from '../model/rule.model';
+import { Rule, RuleSettings } from '../model/rule.model';
 import { RuleGroupingItem } from '../model/rule-grouping-item.model';
 
 export const getRulesResponseMock = {
@@ -170,3 +170,8 @@ export const ruleListGroupingItemsMock: RuleGroupingItem[] = [
     rule: ruleMock('rule2')
   }
 ];
+
+export const ruleSettings: RuleSettings = {
+  value: false,
+  key: '-parameter-'
+};

--- a/projects/aca-folder-rules/src/lib/model/rule.model.ts
+++ b/projects/aca-folder-rules/src/lib/model/rule.model.ts
@@ -58,3 +58,8 @@ export interface RuleForForm {
   actions: RuleAction[];
   options: RuleOptions;
 }
+
+export interface RuleSettings {
+  value: boolean;
+  key?: string;
+}

--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
@@ -68,7 +68,7 @@ export class FolderRuleSetsService {
   inheritedRuleSets$: Observable<RuleSet[]> = this.inheritedRuleSetsSource.asObservable();
   hasMoreRuleSets$: Observable<boolean> = this.hasMoreRuleSetsSource.asObservable();
   folderInfo$: Observable<NodeInfo> = this.folderInfoSource.asObservable();
-  isLoading$ = this.isLoadingSource.asObservable();
+  isLoading$: Observable<boolean> = this.isLoadingSource.asObservable();
 
   selectedRuleSet$ = this.folderRulesService.selectedRule$.pipe(
     map((rule: Rule) => {

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -27,7 +27,7 @@ import { TestBed } from '@angular/core/testing';
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { FolderRulesService } from './folder-rules.service';
-import { getMoreRulesResponseMock, getRulesResponseMock, manyRulesMock, moreRulesMock, ruleMock, rulesMock } from '../mock/rules.mock';
+import { getMoreRulesResponseMock, getRulesResponseMock, manyRulesMock, moreRulesMock, ruleMock, ruleSettings, rulesMock } from '../mock/rules.mock';
 import { ruleSetMock } from '../mock/rule-sets.mock';
 import { expect } from '@angular/flex-layout/_private-utils/testing';
 import { owningFolderIdMock } from '../mock/node.mock';
@@ -44,6 +44,8 @@ describe('FolderRulesService', () => {
   const { id, ...mockedRuleWithoutId } = mockedRule;
   const mockedRuleEntry = { entry: mockedRule };
   const ruleId = mockedRule.id;
+  const mockedRuleSettingsEntry = { entry: ruleSettings };
+  const key = ruleSettings.key;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -137,5 +139,19 @@ describe('FolderRulesService', () => {
 
     const result = await folderRulesService.updateRule(nodeId, ruleId, mockedRule, ruleSetId);
     expect(result).toEqual(mockedRule);
+  });
+
+  it('should send correct GET request and return rule settings', async () => {
+    callApiSpy.withArgs(`/nodes/${nodeId}/rule-settings/${key}`, 'GET').and.returnValue(Promise.resolve(mockedRuleSettingsEntry));
+
+    const result = await folderRulesService.getRuleSettings(nodeId, key);
+    expect(result).toEqual(ruleSettings);
+  });
+
+  it('should send correct PUT request to update rule settings and return them', async () => {
+    callApiSpy.withArgs(`/nodes/${nodeId}/rule-settings/${key}`, 'PUT', ruleSettings).and.returnValue(Promise.resolve(mockedRuleSettingsEntry));
+
+    const result = await folderRulesService.updateRuleSettings(nodeId, key, ruleSettings);
+    expect(result).toEqual(ruleSettings);
   });
 });

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.spec.ts
@@ -27,7 +27,15 @@ import { TestBed } from '@angular/core/testing';
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { FolderRulesService } from './folder-rules.service';
-import { getMoreRulesResponseMock, getRulesResponseMock, manyRulesMock, moreRulesMock, ruleMock, ruleSettings, rulesMock } from '../mock/rules.mock';
+import {
+  getMoreRulesResponseMock,
+  getRulesResponseMock,
+  manyRulesMock,
+  moreRulesMock,
+  ruleMock,
+  ruleSettingsMock,
+  rulesMock
+} from '../mock/rules.mock';
 import { ruleSetMock } from '../mock/rule-sets.mock';
 import { expect } from '@angular/flex-layout/_private-utils/testing';
 import { owningFolderIdMock } from '../mock/node.mock';
@@ -44,8 +52,8 @@ describe('FolderRulesService', () => {
   const { id, ...mockedRuleWithoutId } = mockedRule;
   const mockedRuleEntry = { entry: mockedRule };
   const ruleId = mockedRule.id;
-  const mockedRuleSettingsEntry = { entry: ruleSettings };
-  const key = ruleSettings.key;
+  const mockedRuleSettingsEntry = { entry: ruleSettingsMock };
+  const key = ruleSettingsMock.key;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -145,13 +153,13 @@ describe('FolderRulesService', () => {
     callApiSpy.withArgs(`/nodes/${nodeId}/rule-settings/${key}`, 'GET').and.returnValue(Promise.resolve(mockedRuleSettingsEntry));
 
     const result = await folderRulesService.getRuleSettings(nodeId, key);
-    expect(result).toEqual(ruleSettings);
+    expect(result).toEqual(ruleSettingsMock);
   });
 
   it('should send correct PUT request to update rule settings and return them', async () => {
-    callApiSpy.withArgs(`/nodes/${nodeId}/rule-settings/${key}`, 'PUT', ruleSettings).and.returnValue(Promise.resolve(mockedRuleSettingsEntry));
+    callApiSpy.withArgs(`/nodes/${nodeId}/rule-settings/${key}`, 'PUT', ruleSettingsMock).and.returnValue(Promise.resolve(mockedRuleSettingsEntry));
 
-    const result = await folderRulesService.updateRuleSettings(nodeId, key, ruleSettings);
-    expect(result).toEqual(ruleSettings);
+    const result = await folderRulesService.updateRuleSettings(nodeId, key, ruleSettingsMock);
+    expect(result).toEqual(ruleSettingsMock);
   });
 });

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -152,13 +152,13 @@ export class FolderRulesService {
     );
   }
 
-  async getRuleSettings(nodeId: string, parameter: string = '-isInheritanceEnabled-'): Promise<RuleSettings> {
-    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${parameter}`, 'GET');
+  async getRuleSettings(nodeId: string, key: string = '-isInheritanceEnabled-'): Promise<RuleSettings> {
+    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${key}`, 'GET');
     return response.entry;
   }
 
-  async updateRuleSettings(nodeId: string, parameter: string, body: RuleSettings): Promise<RuleSettings> {
-    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${parameter}`, 'PUT', { ...body });
+  async updateRuleSettings(nodeId: string, key: string, body: RuleSettings): Promise<RuleSettings> {
+    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${key}`, 'PUT', { ...body });
     return response.entry;
   }
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rules.service.ts
@@ -27,7 +27,7 @@ import { Injectable } from '@angular/core';
 import { AlfrescoApiService } from '@alfresco/adf-core';
 import { BehaviorSubject, from, Observable } from 'rxjs';
 import { finalize, map } from 'rxjs/operators';
-import { Rule, RuleForForm, RuleOptions } from '../model/rule.model';
+import { Rule, RuleForForm, RuleOptions, RuleSettings } from '../model/rule.model';
 import { RuleCompositeCondition } from '../model/rule-composite-condition.model';
 import { RuleSimpleCondition } from '../model/rule-simple-condition.model';
 import { RuleSet } from '../model/rule-set.model';
@@ -150,6 +150,16 @@ export class FolderRulesService {
         this.deletedRuleIdSource.next(error);
       }
     );
+  }
+
+  async getRuleSettings(nodeId: string, parameter: string = '-isInheritanceEnabled-'): Promise<RuleSettings> {
+    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${parameter}`, 'GET');
+    return response.entry;
+  }
+
+  async updateRuleSettings(nodeId: string, parameter: string, body: RuleSettings): Promise<RuleSettings> {
+    const response = await this.callApi(`/nodes/${nodeId}/rule-settings/${parameter}`, 'PUT', { ...body });
+    return response.entry;
   }
 
   private formatRules(res): Rule[] {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently in ACA, the user does not have the ability to choose whether a folder should inherit folder rule sets from parent folders or not.

**What is the new behaviour?**

Each folder has a button to toggle whether it should inherit folder rule sets from its parent folders.
<img width="1466" alt="Screenshot 2022-11-23 at 17 53 08" src="https://user-images.githubusercontent.com/84377976/203604301-36774571-eaca-4a6a-87a5-fa010d9ea213.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
