### PR TITLE
[ACS-3758] 880526 modal is closed focus is not returned to trigger in the create new menu

### DIFF
--- a/app/src/app/content-plugin/services/content-management.service.ts
+++ b/app/src/app/content-plugin/services/content-management.service.ts
@@ -237,6 +237,7 @@ export class ContentManagementService {
       if (node) {
         this.store.dispatch(new ReloadDocumentListAction());
       }
+      ContentManagementService.focusCreateMenuButton();
     });
   }
 
@@ -277,6 +278,7 @@ export class ContentManagementService {
         if (node) {
           this.appHookService.libraryCreated.next(node);
         }
+        ContentManagementService.focusCreateMenuButton();
       }),
       map((node: SiteEntry) => {
         if (node && node.entry && node.entry.guid) {
@@ -1076,5 +1078,9 @@ export class ContentManagementService {
       )
       .onAction()
       .subscribe(() => this.undoMoveNodes(moveResponse, initialParentId));
+  }
+
+  private static focusCreateMenuButton(): void {
+    document.querySelector<HTMLElement>('app-create-menu button').focus();
   }
 }

--- a/app/src/app/content-plugin/services/node-template.service.spec.ts
+++ b/app/src/app/content-plugin/services/node-template.service.spec.ts
@@ -55,6 +55,7 @@ describe('NodeTemplateService', () => {
     store = TestBed.inject(Store);
     dialog = TestBed.inject(MatDialog);
     nodeTemplateService = TestBed.inject(NodeTemplateService);
+    spyOn(document, 'querySelector').and.returnValue(document.createElement('button'));
   });
 
   it('should open dialog with parent node `id` as data property', fakeAsync(() => {

--- a/app/src/app/content-plugin/services/node-template.service.ts
+++ b/app/src/app/content-plugin/services/node-template.service.ts
@@ -116,11 +116,13 @@ export class NodeTemplateService {
   }
 
   createTemplateDialog(node: Node): MatDialogRef<CreateFromTemplateDialogComponent> {
-    return this.dialog.open(CreateFromTemplateDialogComponent, {
+    const dialog = this.dialog.open(CreateFromTemplateDialogComponent, {
       data: node,
       panelClass: 'aca-create-from-template-dialog',
       width: '630px'
     });
+    dialog.afterClosed().subscribe(() => NodeTemplateService.focusCreateMenuButton());
+    return dialog;
   }
 
   private transformNode(node: MinimalNode): MinimalNode {
@@ -144,6 +146,7 @@ export class NodeTemplateService {
 
   private close() {
     this.dialog.closeAll();
+    NodeTemplateService.focusCreateMenuButton();
   }
 
   private title(selectionType: string) {
@@ -161,5 +164,9 @@ export class NodeTemplateService {
 
   private getPathElements(node: Node): PathElement[] {
     return node.path.elements.filter((pathElement) => !this.rootNode.path.elements.some((rootPathElement) => pathElement.id === rootPathElement.id));
+  }
+
+  private static focusCreateMenuButton(): void {
+    document.querySelector<HTMLElement>('app-create-menu button').focus();
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-3758


**What is the new behaviour?**
After closing dialogs for folder/library creation or for creation file/folder from template, the New button has been auto focused. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ADF PR: https://github.com/Alfresco/alfresco-ng2-components/pull/8006
APPS PR: https://github.com/Alfresco/alfresco-apps/pull/4570