### PR TITLE
[ACS-3758] 880526 fix for modals which close was not returning to new button

### DIFF
--- a/app/src/app/content-plugin/store/effects/upload.effects.spec.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.spec.ts
@@ -30,7 +30,7 @@ import { UploadEffects } from './upload.effects';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { NgZone } from '@angular/core';
 import { UploadService, FileUploadCompleteEvent, FileModel } from '@alfresco/adf-core';
-import { UnlockWriteAction, UploadFileVersionAction } from '@alfresco/aca-shared/store';
+import { UnlockWriteAction, UploadFilesAction, UploadFileVersionAction, UploadFolderAction } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 
 describe('UploadEffects', () => {
@@ -57,6 +57,80 @@ describe('UploadEffects', () => {
   beforeEach(() => {
     spyOn(effects['fileVersionInput'], 'click');
     spyOn(effects, 'uploadVersion').and.callThrough();
+  });
+
+  describe('uploadFiles$', () => {
+    let createMenuButton: HTMLButtonElement;
+    const focusedClass = 'cdk-program-focused';
+
+    beforeEach(() => {
+      createMenuButton = document.createElement('button');
+      document.body.appendChild(createMenuButton);
+      store.dispatch(new UploadFilesAction({}));
+      spyOn(document, 'querySelector').withArgs('app-create-menu button').and.returnValue(createMenuButton);
+    });
+
+    it('should call focus function on create menu button', () => {
+      spyOn(createMenuButton, 'focus');
+      window.dispatchEvent(new FocusEvent('focus'));
+      expect(createMenuButton.focus).toHaveBeenCalledWith();
+    });
+
+    it('should not call focus function on create menu button if handler for focus of window is not fired', () => {
+      spyOn(createMenuButton, 'focus');
+      expect(createMenuButton.focus).not.toHaveBeenCalled();
+    });
+
+    it('should add cdk-program-focused class to create menu button', () => {
+      window.dispatchEvent(new FocusEvent('focus'));
+      createMenuButton.dispatchEvent(new FocusEvent('focus'));
+      expect(createMenuButton).toHaveClass(focusedClass);
+    });
+
+    it('should not add cdk-program-focused class to create menu button if handler for focus of window is not fired', () => {
+      expect(createMenuButton).not.toHaveClass(focusedClass);
+    });
+
+    afterEach(() => {
+      createMenuButton.remove();
+    });
+  });
+
+  describe('uploadFolder$', () => {
+    let createMenuButton: HTMLButtonElement;
+    const focusedClass = 'cdk-program-focused';
+
+    beforeEach(() => {
+      createMenuButton = document.createElement('button');
+      document.body.appendChild(createMenuButton);
+      store.dispatch(new UploadFolderAction({}));
+      spyOn(document, 'querySelector').withArgs('app-create-menu button').and.returnValue(createMenuButton);
+    });
+
+    it('should call focus function on create menu button', () => {
+      spyOn(createMenuButton, 'focus');
+      window.dispatchEvent(new FocusEvent('focus'));
+      expect(createMenuButton.focus).toHaveBeenCalledWith();
+    });
+
+    it('should not call focus function on create menu button if handler for focus of window is not fired', () => {
+      spyOn(createMenuButton, 'focus');
+      expect(createMenuButton.focus).not.toHaveBeenCalled();
+    });
+
+    it('should add cdk-program-focused class to create menu button', () => {
+      window.dispatchEvent(new FocusEvent('focus'));
+      createMenuButton.dispatchEvent(new FocusEvent('focus'));
+      expect(createMenuButton).toHaveClass(focusedClass);
+    });
+
+    it('should not add cdk-program-focused class to create menu button if handler for focus of window is not fired', () => {
+      expect(createMenuButton).not.toHaveClass(focusedClass);
+    });
+
+    afterEach(() => {
+      createMenuButton.remove();
+    });
   });
 
   describe('uploadAndUnlock()', () => {

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -206,19 +206,7 @@ export class UploadEffects {
         window.addEventListener(
           'focus',
           () => {
-            const createMenuButton = document.querySelector<HTMLElement>('app-create-menu button');
-            const oldBackgroundColor = createMenuButton.style.backgroundColor;
-            createMenuButton.style.backgroundColor = 'rgb(221, 221, 221)';
-            createMenuButton.focus();
-            createMenuButton.addEventListener(
-              'blur',
-              () => {
-                createMenuButton.style.backgroundColor = oldBackgroundColor;
-              },
-              {
-                once: true
-              }
-            );
+            document.querySelector<HTMLElement>('app-create-menu button').focus();
           },
           {
             once: true

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -90,6 +90,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFilesAction>(UploadActionTypes.UploadFiles),
         map(() => {
+          this.registerFocusingCreateMenuButton(this.fileInput);
           this.fileInput.click();
         })
       ),
@@ -101,6 +102,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFolderAction>(UploadActionTypes.UploadFolder),
         map(() => {
+          this.registerFocusingCreateMenuButton(this.folderInput);
           this.folderInput.click();
         })
       ),
@@ -195,5 +197,25 @@ export class UploadEffects {
         subscription.unsubscribe();
       });
     });
+  }
+
+  private registerFocusingCreateMenuButton(input: HTMLInputElement): void {
+    input.addEventListener(
+      'click',
+      () => {
+        window.addEventListener(
+          'focus',
+          () => {
+            document.querySelector<HTMLElement>('app-create-menu button').focus();
+          },
+          {
+            once: true
+          }
+        );
+      },
+      {
+        once: true
+      }
+    );
   }
 }

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -206,7 +206,11 @@ export class UploadEffects {
         window.addEventListener(
           'focus',
           () => {
-            document.querySelector<HTMLElement>('app-create-menu button').focus();
+            const createMenuButton = document.querySelector<HTMLElement>('app-create-menu button');
+            createMenuButton.addEventListener('focus', () => createMenuButton.classList.add('cdk-program-focused'), {
+              once: true
+            });
+            createMenuButton.focus();
           },
           {
             once: true

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -206,7 +206,19 @@ export class UploadEffects {
         window.addEventListener(
           'focus',
           () => {
-            document.querySelector<HTMLElement>('app-create-menu button').focus();
+            const createMenuButton = document.querySelector<HTMLElement>('app-create-menu button');
+            const oldBackgroundColor = createMenuButton.style.backgroundColor;
+            createMenuButton.style.backgroundColor = 'rgb(221, 221, 221)';
+            createMenuButton.focus();
+            createMenuButton.addEventListener(
+              'blur',
+              () => {
+                createMenuButton.style.backgroundColor = oldBackgroundColor;
+              },
+              {
+                once: true
+              }
+            );
           },
           {
             once: true

--- a/app/src/app/content-plugin/ui/overrides/ay11.scss
+++ b/app/src/app/content-plugin/ui/overrides/ay11.scss
@@ -138,6 +138,10 @@
   }
 
   .mat-stroked-button, .mat-flat-button {
+    &.cdk-focused .mat-button-focus-overlay {
+      opacity: .12;
+    }
+
     &.cdk-keyboard-focused {
       .mat-button-ripple.mat-ripple {
         outline: 2px solid var(--theme-blue-button-color);

--- a/app/src/app/content-plugin/ui/overrides/ay11.scss
+++ b/app/src/app/content-plugin/ui/overrides/ay11.scss
@@ -138,10 +138,6 @@
   }
 
   .mat-stroked-button, .mat-flat-button {
-    &.cdk-focused .mat-button-focus-overlay {
-      opacity: .12;
-    }
-
     &.cdk-keyboard-focused {
       .mat-button-ripple.mat-ripple {
         outline: 2px solid var(--theme-blue-button-color);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After closing browser's modal for file input, focus was not returning to New button. 


**What is the new behaviour?**
When browser's modal for file input is closed then focus is returned to New button. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
APPS PR https://github.com/Alfresco/alfresco-apps/pull/4611