### PR TITLE
[ACA-4627] Folder Rules - clicking on Manage Rules button does not fire the correct requests to the backend for inherited rules

### DIFF
--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
@@ -40,6 +40,7 @@ describe('FolderRuleSetsService', () => {
   let contentApiService: ContentApiService;
 
   let callApiSpy: jasmine.Spy;
+  let getRulesSpy: jasmine.Spy;
   let getNodeSpy: jasmine.Spy;
 
   beforeEach(() => {
@@ -57,7 +58,7 @@ describe('FolderRuleSetsService', () => {
       .and.returnValue(of(getDefaultRuleSetResponseMock))
       .withArgs(`/nodes/${owningFolderIdMock}/rule-sets?include=isLinkedTo,owningFolder,linkedToBy&skipCount=0&maxItems=100`, 'GET')
       .and.returnValue(of(getRuleSetsResponseMock));
-    spyOn<any>(folderRulesService, 'getRules')
+    getRulesSpy = spyOn<any>(folderRulesService, 'getRules')
       .withArgs(jasmine.anything(), 'rule-set-no-links')
       .and.returnValue(of({ rules: ownedRulesMock, hasMoreRules: false }))
       .withArgs(jasmine.anything(), 'rule-set-with-link')
@@ -108,6 +109,7 @@ describe('FolderRuleSetsService', () => {
       'GET'
     );
     expect(ruleSets).toEqual([inheritedRuleSetMock]);
+    expect(getRulesSpy).toHaveBeenCalledWith(owningFolderIdMock, jasmine.anything());
     expect(hasMoreRuleSets).toEqual(false);
   });
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
@@ -186,7 +186,7 @@ export class FolderRuleSetsService {
     }
     return combineLatest(
       this.currentFolder?.id === entry.owningFolder ? of(this.currentFolder) : this.getNodeInfo(entry.owningFolder || ''),
-      this.folderRulesService.getRules(entry.owningFolder || '', entry.id)
+      this.folderRulesService.getRules(this.currentFolder.id || '', entry.id)
     ).pipe(
       map(([owningFolderNodeInfo, getRulesRes]) => ({
         id: entry.id,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4627

**What is the new behaviour?**

GET Rules request for inherited rules is sent to the Child folder instead of the Parent folder.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
