### PR TITLE
[ACS-4630] Fix no different rule is selected when rule is deleted

### DIFF
--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
@@ -124,8 +124,8 @@ describe('FolderRuleSetsService', () => {
 
   it('should select a different rule when removing a rule', () => {
     const selectRuleSpy = spyOn(folderRulesService, 'selectRule');
-    folderRuleSetsService['mainRuleSet'] = ownedRuleSetMock;
-    folderRuleSetsService['inheritedRuleSets'] = [inheritedRuleSetMock];
+    folderRuleSetsService['mainRuleSet'] = JSON.parse(JSON.stringify(ownedRuleSetMock));
+    folderRuleSetsService['inheritedRuleSets'] = JSON.parse(JSON.stringify([inheritedRuleSetMock]));
 
     folderRuleSetsService.removeRuleFromMainRuleSet('owned-rule-1-id');
 

--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.spec.ts
@@ -121,4 +121,19 @@ describe('FolderRuleSetsService', () => {
 
     expect(selectRuleSpy).toHaveBeenCalledWith(ruleMock('owned-rule-1'));
   });
+
+  it('should select a different rule when removing a rule', () => {
+    const selectRuleSpy = spyOn(folderRulesService, 'selectRule');
+    folderRuleSetsService['mainRuleSet'] = ownedRuleSetMock;
+    folderRuleSetsService['inheritedRuleSets'] = [inheritedRuleSetMock];
+
+    folderRuleSetsService.removeRuleFromMainRuleSet('owned-rule-1-id');
+
+    expect(selectRuleSpy).toHaveBeenCalledWith(ruleMock('owned-rule-2'));
+
+    selectRuleSpy.calls.reset();
+    folderRuleSetsService.removeRuleFromMainRuleSet('owned-rule-2-id');
+
+    expect(selectRuleSpy).toHaveBeenCalledWith(ruleMock('inherited-rule-1'));
+  });
 });

--- a/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
+++ b/projects/aca-folder-rules/src/lib/services/folder-rule-sets.service.ts
@@ -210,6 +210,7 @@ export class FolderRuleSetsService {
           this.mainRuleSet = null;
           this.mainRuleSetSource.next(this.mainRuleSet);
         }
+        this.folderRulesService.selectRule(this.mainRuleSet?.rules[0] ?? this.inheritedRuleSets[0]?.rules[0] ?? null);
       }
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4630

**What is the new behaviour?**

New rule is selected after the deletion.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
