### PR TITLE
[ACA-4632] [ACA-4633] Fix error script dropdown not having any options + hide dropdown when isAsynchronous unchecked

### DIFF
--- a/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/actions.mock.ts
@@ -24,6 +24,7 @@
  */
 
 import { ActionDefinitionTransformed, ActionParameterDefinitionTransformed, RuleAction } from '../model/rule-action.model';
+import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
 
 export const actionDefListMock = {
   list: {
@@ -187,3 +188,17 @@ export const validActionsMock: RuleAction[] = [
     params: {}
   }
 ];
+
+export const errorScriptConstraintMock: ActionParameterConstraint = {
+  name: 'script-ref',
+  constraints: [
+    {
+      value: 'script-1-value',
+      label: 'Script 1'
+    },
+    {
+      value: 'script-2-value',
+      label: 'Script 2'
+    }
+  ]
+};

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
@@ -7,12 +7,21 @@
       {{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.IS_ASYNCHRONOUS' | translate }}
     </mat-checkbox>
 
-    <mat-form-field>
+    <mat-form-field [ngClass]="{ 'hide-error-script-dropdown': hideErrorScriptDropdown }">
       <mat-select
         formControlName="errorScript"
         placeholder="{{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.ERROR_SCRIPT' | translate}}"
         data-automation-id="rule-option-select-errorScript">
+
         <mat-option value="">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.NO_SCRIPT' | translate }}</mat-option>
+
+        <ng-template ngFor [ngForOf]="errorScriptOptions" let-option>
+          <mat-option
+            [value]="option.value">
+            {{ option.label }}
+          </mat-option>
+        </ng-template>
+
       </mat-select>
     </mat-form-field>
   </div>

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.scss
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.scss
@@ -11,4 +11,8 @@
   &.read-only .mat-checkbox-inner-container {
     display: none;
   }
+
+  .hide-error-script-dropdown {
+    opacity: 0;
+  }
 }

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.spec.ts
@@ -29,6 +29,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RuleOptionsUiComponent } from './rule-options.ui-component';
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
+import { errorScriptConstraintMock } from '../../mock/actions.mock';
 
 describe('RuleOptionsUiComponent', () => {
   let fixture: ComponentFixture<RuleOptionsUiComponent>;
@@ -111,5 +112,25 @@ describe('RuleOptionsUiComponent', () => {
     expect(getByDataAutomationId('rule-option-checkbox-inheritable')).toBeTruthy();
     expect(getByDataAutomationId('rule-option-checkbox-enabled')).toBeFalsy();
     expect(getByDataAutomationId('rule-option-select-errorScript')).toBeTruthy();
+  });
+
+  it('should populate the error script dropdown with scripts', () => {
+    component.writeValue({
+      isEnabled: true,
+      isInheritable: false,
+      isAsynchronous: true,
+      errorScript: ''
+    });
+    component.errorScriptConstraint = errorScriptConstraintMock;
+    fixture.detectChanges();
+
+    (getByDataAutomationId('rule-option-select-errorScript').nativeElement as HTMLElement).click();
+    fixture.detectChanges();
+
+    const matOptions = fixture.debugElement.queryAll(By.css(`.mat-option`));
+    expect(matOptions.length).toBe(3);
+    expect((matOptions[0].nativeElement as HTMLElement).innerText.trim()).toBe('ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.NO_SCRIPT');
+    expect((matOptions[1].nativeElement as HTMLElement).innerText.trim()).toBe('Script 1');
+    expect((matOptions[2].nativeElement as HTMLElement).innerText.trim()).toBe('Script 2');
   });
 });

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.ts
@@ -23,10 +23,11 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, forwardRef, HostBinding, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, forwardRef, HostBinding, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { RuleOptions } from '../../model/rule.model';
+import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
 
 @Component({
   selector: 'aca-rule-options',
@@ -60,6 +61,11 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnDestroy {
     this.onTouch();
   });
 
+  hideErrorScriptDropdown = true;
+
+  @Input()
+  errorScriptConstraint: ActionParameterConstraint;
+
   @HostBinding('class.read-only')
   readOnly = false;
 
@@ -73,6 +79,10 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnDestroy {
     return this.form.get('isInheritable').value;
   }
 
+  get errorScriptOptions(): ConstraintValue[] {
+    return this.errorScriptConstraint?.constraints ?? [];
+  }
+
   writeValue(options: RuleOptions) {
     const isAsynchronousFormControl = this.form.get('isAsynchronous');
     const errorScriptFormControl = this.form.get('errorScript');
@@ -81,8 +91,10 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnDestroy {
     this.form.get('isAsynchronous').setValue(options.isAsynchronous);
     errorScriptFormControl.setValue(options.errorScript ?? '');
     if (isAsynchronousFormControl.value) {
+      this.hideErrorScriptDropdown = false;
       errorScriptFormControl.enable();
     } else {
+      this.hideErrorScriptDropdown = true;
       errorScriptFormControl.disable();
     }
   }
@@ -112,8 +124,10 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnDestroy {
   toggleErrorScriptDropdown(value: MatCheckboxChange) {
     const formControl: AbstractControl = this.form.get('errorScript');
     if (value.checked) {
+      this.hideErrorScriptDropdown = false;
       formControl.enable();
     } else {
+      this.hideErrorScriptDropdown = true;
       formControl.disable();
     }
   }

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.html
@@ -54,7 +54,11 @@
 
   <div class="aca-rule-details__form__row" *ngIf="showOptionsSection">
     <div class="label">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LABEL.OPTIONS' | translate }}</div>
-    <aca-rule-options formControlName="options" data-automation-id="rule-details-options-component"></aca-rule-options>
+    <aca-rule-options
+      formControlName="options"
+      data-automation-id="rule-details-options-component"
+      [errorScriptConstraint]="errorScriptConstraint">
+    </aca-rule-options>
   </div>
 
 </form>

--- a/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/rule-details.ui-component.ts
@@ -125,6 +125,10 @@ export class RuleDetailsUiComponent implements OnInit, OnDestroy {
     return !this.readOnly || this.value.isAsynchronous || this.value.isInheritable;
   }
 
+  get errorScriptConstraint(): ActionParameterConstraint {
+    return this.parameterConstraints.find((parameterConstraint: ActionParameterConstraint) => parameterConstraint.name === 'script-ref');
+  }
+
   ngOnInit() {
     this.form = new UntypedFormGroup({
       id: new UntypedFormControl(this.value.id),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4632
https://alfresco.atlassian.net/browse/ACA-4633

**What is the new behaviour?**

The "execute script" dropdown is now populated with scripts.
The dropdown is only visible when "Run rule in background" checked.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
