### PR TITLE
[ACS-4091] Folder rules: "Add simple workflow" action clears out parameters when trying to set destination folder

### DIFF
--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -196,7 +196,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
               icon: 'folder',
               default: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
               clickable: true,
-              clickCallBack: this.openSelectorDialog.bind(this),
+              clickCallBack: this.openSelectorDialog.bind(this, paramDef.name),
               value: this.parameters[paramDef.name]
             });
           }
@@ -218,7 +218,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     });
   }
 
-  private openSelectorDialog() {
+  private openSelectorDialog(pramName) {
     const data: ContentNodeSelectorComponentData = {
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
@@ -238,7 +238,8 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
           this.writeValue({
             actionDefinitionId: this.selectedActionDefinitionId,
             params: {
-              'destination-folder': selections[0].id
+              ...this.parameters,
+              [pramName]: selections[0].id
             }
           });
           this.onChange({

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -218,7 +218,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
     });
   }
 
-  private openSelectorDialog(pramName) {
+  private openSelectorDialog(paramDefName) {
     const data: ContentNodeSelectorComponentData = {
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
@@ -239,7 +239,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             actionDefinitionId: this.selectedActionDefinitionId,
             params: {
               ...this.parameters,
-              [pramName]: selections[0].id
+              [paramDefName]: selections[0].id
             }
           });
           this.onChange({


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-4091

**What is the new behaviour?**

The parameters get filled out, the submit button is clickable and when clicked, the new rule is saved.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
