### PR TITLE
[ACS-3757] returning focus to element from which they were opened

### DIFF
--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.html
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="selection$ | async as selection">
   <ng-container *ngIf="!data.iconButton">
-    <button mat-menu-item data-automation-id="share-action-button" (click)="editSharedNode(selection)">
+    <button mat-menu-item data-automation-id="share-action-button" (click)="editSharedNode(selection, '.adf-context-menu-source')">
       <mat-icon>link</mat-icon>
       <ng-container *ngIf="isShared(selection); else not_shared">
         <span>{{ 'APP.ACTIONS.SHARE_EDIT' | translate }}</span>
@@ -12,7 +12,7 @@
     <button
       mat-icon-button
       data-automation-id="share-action-button"
-      (click)="editSharedNode(selection)"
+      (click)="editSharedNode(selection, '#share-action-button')"
       [attr.aria-label]="getLabel(selection) | translate"
       [attr.title]="getLabel(selection) | translate"
       id="share-action-button"

--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.html
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.html
@@ -15,6 +15,7 @@
       (click)="editSharedNode(selection)"
       [attr.aria-label]="getLabel(selection) | translate"
       [attr.title]="getLabel(selection) | translate"
+      id="share-action-button"
     >
       <mat-icon>link</mat-icon>
     </button>

--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
@@ -37,7 +37,7 @@ export class ToggleSharedComponent implements OnInit {
   @Input()
   data: {
     iconButton?: string;
-    focusedElementOnCloseSelector?: string;
+    autoFocusedTriggerAfterModalClose?: boolean;
   };
 
   selection$: Observable<SelectionState>;
@@ -57,11 +57,11 @@ export class ToggleSharedComponent implements OnInit {
     return selection.first && selection.first.entry && selection.first.entry.properties && !!selection.first.entry.properties['qshare:sharedId'];
   }
 
-  editSharedNode(selection: SelectionState) {
+  editSharedNode(selection: SelectionState, focusedElementOnCloseSelector: string) {
     this.store.dispatch(
       new ShareNodeAction({
         ...selection.first,
-        focusedElementOnCloseSelector: this.data?.focusedElementOnCloseSelector
+        focusedElementOnCloseSelector: this.data?.autoFocusedTriggerAfterModalClose ? focusedElementOnCloseSelector : undefined
       })
     );
   }

--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
@@ -37,7 +37,6 @@ export class ToggleSharedComponent implements OnInit {
   @Input()
   data: {
     iconButton?: string;
-    autoFocusedTriggerAfterModalClose?: boolean;
   };
 
   selection$: Observable<SelectionState>;
@@ -61,7 +60,7 @@ export class ToggleSharedComponent implements OnInit {
     this.store.dispatch(
       new ShareNodeAction({
         ...selection.first,
-        focusedElementOnCloseSelector: this.data?.autoFocusedTriggerAfterModalClose ? focusedElementOnCloseSelector : undefined
+        focusedElementOnCloseSelector
       })
     );
   }

--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
@@ -34,7 +34,11 @@ import { AppStore, ShareNodeAction, getAppSelection } from '@alfresco/aca-shared
   templateUrl: './toggle-shared.component.html'
 })
 export class ToggleSharedComponent implements OnInit {
-  @Input() data: { iconButton?: string };
+  @Input()
+  data: {
+    iconButton?: string;
+    focusedElementOnCloseSelector?: string;
+  };
 
   selection$: Observable<SelectionState>;
 
@@ -54,7 +58,12 @@ export class ToggleSharedComponent implements OnInit {
   }
 
   editSharedNode(selection: SelectionState) {
-    this.store.dispatch(new ShareNodeAction(selection.first));
+    this.store.dispatch(
+      new ShareNodeAction({
+        ...selection.first,
+        focusedElementOnCloseSelector: this.data.focusedElementOnCloseSelector
+      })
+    );
   }
 
   getLabel(selection: SelectionState): string {

--- a/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
+++ b/app/src/app/content-plugin/components/common/toggle-shared/toggle-shared.component.ts
@@ -61,7 +61,7 @@ export class ToggleSharedComponent implements OnInit {
     this.store.dispatch(
       new ShareNodeAction({
         ...selection.first,
-        focusedElementOnCloseSelector: this.data.focusedElementOnCloseSelector
+        focusedElementOnCloseSelector: this.data?.focusedElementOnCloseSelector
       })
     );
   }

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.html
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.html
@@ -4,7 +4,7 @@
   <mat-menu #rootMenu="matMenu" class="aca-context-menu" hasBackdrop="false" acaContextMenuOutsideEvent (clickOutside)="onClickOutsideEvent()">
     <ng-container *ngFor="let entry of actions; trackBy: trackByActionId" [ngSwitch]="entry.type">
       <ng-container *ngSwitchDefault>
-        <button mat-menu-item [id]="entry.id" (click)="runAction(entry.actions.click)">
+        <button mat-menu-item [id]="entry.id" (click)="runAction(entry)">
           <adf-icon [value]="entry.icon"></adf-icon>
           <span>{{ entry.title | translate }}</span>
         </button>

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.spec.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.spec.ts
@@ -99,8 +99,8 @@ describe('ContextMenuComponent', () => {
   it('should run action with provided action id', () => {
     spyOn(extensionsService, 'runActionById');
 
-    component.runAction(contextItem.actions.click);
+    component.runAction(contextItem);
 
-    expect(extensionsService.runActionById).toHaveBeenCalledWith(contextItem.actions.click);
+    expect(extensionsService.runActionById).toHaveBeenCalledWith(contextItem.actions.click, undefined);
   });
 });

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.spec.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.spec.ts
@@ -96,11 +96,13 @@ describe('ContextMenuComponent', () => {
     expect(contextMenuElements[0].querySelector('span').innerText).toBe(contextItem.title);
   });
 
-  it('should run action with provided action id', () => {
+  it('should run action with provided action id and correct payload', () => {
     spyOn(extensionsService, 'runActionById');
 
     component.runAction(contextItem);
 
-    expect(extensionsService.runActionById).toHaveBeenCalledWith(contextItem.actions.click, undefined);
+    expect(extensionsService.runActionById).toHaveBeenCalledWith(contextItem.actions.click, {
+      focusedElementOnCloseSelector: '.adf-context-menu-source'
+    });
   });
 });

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
@@ -70,14 +70,9 @@ export class ContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   runAction(contentActionRef: ContentActionRef) {
-    this.extensions.runActionById(
-      contentActionRef.actions.click,
-      contentActionRef.data?.autoFocusedTriggerAfterModalClose
-        ? {
-            focusedElementOnCloseSelector: '.adf-context-menu-source'
-          }
-        : undefined
-    );
+    this.extensions.runActionById(contentActionRef.actions.click, {
+      focusedElementOnCloseSelector: '.adf-context-menu-source'
+    });
   }
 
   ngOnDestroy() {

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
@@ -69,8 +69,8 @@ export class ContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  runAction(actionId: string) {
-    this.extensions.runActionById(actionId);
+  runAction(contentActionRef: ContentActionRef) {
+    this.extensions.runAction(contentActionRef);
   }
 
   ngOnDestroy() {

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
@@ -70,8 +70,14 @@ export class ContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   runAction(contentActionRef: ContentActionRef) {
-    const { click, ...payload } = contentActionRef.actions;
-    this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
+    this.extensions.runActionById(
+      contentActionRef.actions.click,
+      contentActionRef.data?.autoFocusedTriggerAfterModalClose
+        ? {
+            focusedElementOnCloseSelector: '.adf-context-menu-source'
+          }
+        : undefined
+    );
   }
 
   ngOnDestroy() {

--- a/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
+++ b/app/src/app/content-plugin/components/context-menu/context-menu.component.ts
@@ -70,7 +70,8 @@ export class ContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   runAction(contentActionRef: ContentActionRef) {
-    this.extensions.runAction(contentActionRef);
+    const { click, ...payload } = contentActionRef.actions;
+    this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
   }
 
   ngOnDestroy() {

--- a/app/src/app/content-plugin/services/content-management.service.spec.ts
+++ b/app/src/app/content-plugin/services/content-management.service.spec.ts
@@ -1410,25 +1410,37 @@ describe('ContentManagementService', () => {
     }));
 
     it('should update node selection after dialog is closed', fakeAsync(() => {
+      spyOn(document, 'querySelector').and.returnValue(document.createElement('button'));
       const node = { entry: { id: '1', name: 'name1' } } as NodeEntry;
       spyOn(store, 'dispatch').and.callThrough();
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: () => of(null)
       } as MatDialogRef<MatDialog>);
-
-      store.dispatch(new ShareNodeAction(node));
-
-      expect(store.dispatch['calls'].argsFor(1)[0]).toEqual(new SetSelectedNodesAction([node]));
+      const payload = {
+        ...node,
+        ...{
+          focusedElementOnCloseSelector: 'some-selector'
+        }
+      };
+      store.dispatch(new ShareNodeAction(payload));
+      expect(store.dispatch['calls'].argsFor(1)[0]).toEqual(new SetSelectedNodesAction([payload]));
     }));
 
     it('should emit event when node is un-shared', fakeAsync(() => {
+      spyOn(document, 'querySelector').and.returnValue(document.createElement('button'));
       const node = { entry: { id: '1', name: 'name1' } } as NodeEntry;
       spyOn(appHookService.linksUnshared, 'next').and.callThrough();
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: () => of(node)
       } as MatDialogRef<MatDialog>);
-
-      store.dispatch(new ShareNodeAction(node));
+      store.dispatch(
+        new ShareNodeAction({
+          ...node,
+          ...{
+            focusedElementOnCloseSelector: 'some-selector'
+          }
+        })
+      );
       tick();
       flush();
 
@@ -1638,7 +1650,7 @@ describe('ContentManagementService', () => {
 
       contentManagementService.manageAspects(fakeNode);
 
-      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('real-node-ghostbuster');
+      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('real-node-ghostbuster', undefined);
     });
 
     it('should open dialog for managing the aspects', () => {
@@ -1647,7 +1659,7 @@ describe('ContentManagementService', () => {
 
       contentManagementService.manageAspects(fakeNode);
 
-      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('fake-node-id');
+      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('fake-node-id', undefined);
     });
   });
 });

--- a/app/src/app/content-plugin/services/content-management.service.spec.ts
+++ b/app/src/app/content-plugin/services/content-management.service.spec.ts
@@ -24,7 +24,7 @@
  */
 
 import { TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
-import { of, throwError, Subject } from 'rxjs';
+import { of, throwError, Subject, BehaviorSubject, EMPTY } from 'rxjs';
 import { Actions, ofType, EffectsModule } from '@ngrx/effects';
 import {
   AppStore,
@@ -56,7 +56,7 @@ import { NodeActionsService } from './node-actions.service';
 import { TranslationService, AlfrescoApiService, FileModel, NotificationService } from '@alfresco/adf-core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
-import { NodeEntry, Node, VersionPaging } from '@alfresco/js-api';
+import { NodeEntry, Node, VersionPaging, MinimalNodeEntity } from '@alfresco/js-api';
 import { NewVersionUploaderDataAction, NewVersionUploaderService, NodeAspectService, ViewVersion } from '@alfresco/adf-content-services';
 
 describe('ContentManagementService', () => {
@@ -1446,6 +1446,43 @@ describe('ContentManagementService', () => {
 
       expect(appHookService.linksUnshared.next).toHaveBeenCalled();
     }));
+
+    it('should focus element indicated by passed selector after closing modal', () => {
+      const elementToFocusSelector = 'button';
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      const elementToFocus = document.createElement(elementToFocusSelector);
+      spyOn(elementToFocus, 'focus');
+      spyOn(document, 'querySelector').withArgs(elementToFocusSelector).and.returnValue(elementToFocus);
+      spyOn(store, 'select').and.returnValue(new BehaviorSubject(''));
+      contentManagementService.shareNode(
+        {
+          entry: {}
+        },
+        elementToFocusSelector
+      );
+      afterClosed$.next();
+      expect(elementToFocus.focus).toHaveBeenCalled();
+    });
+
+    it('should not looking for element to focus if passed selector is empty string', () => {
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      spyOn(document, 'querySelector');
+      spyOn(store, 'select').and.returnValue(new BehaviorSubject(''));
+      contentManagementService.shareNode(
+        {
+          entry: {}
+        },
+        ''
+      );
+      afterClosed$.next();
+      expect(document.querySelector).not.toHaveBeenCalled();
+    });
   });
 
   describe('Unlock Node', () => {
@@ -1556,8 +1593,10 @@ describe('ContentManagementService', () => {
         showVersionsOnly: true,
         title: 'VERSION.DIALOG.TITLE'
       };
-      contentManagementService.manageVersions(fakeNodeIsFile);
+      const elementToFocusSelector = 'some-selector';
+      contentManagementService.manageVersions(fakeNodeIsFile, elementToFocusSelector);
       expect(spyOnOpenUploadNewVersionDialog['calls'].argsFor(0)[0]).toEqual(expectedArgument);
+      expect(spyOnOpenUploadNewVersionDialog['calls'].argsFor(0)[2]).toEqual(elementToFocusSelector);
     });
 
     it('should dispatch ReloadDocumentListAction if dialog emit refresh action', () => {
@@ -1627,6 +1666,37 @@ describe('ContentManagementService', () => {
 
       expect(alfrescoApiService.nodeUpdated.next).toHaveBeenCalledWith(newNode);
     }));
+
+    it('should focus element indicated by passed selector after closing modal', () => {
+      const elementToFocusSelector = 'button';
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable(),
+        componentInstance: {
+          error: EMPTY
+        }
+      } as MatDialogRef<any>);
+      const elementToFocus = document.createElement(elementToFocusSelector);
+      spyOn(elementToFocus, 'focus');
+      spyOn(document, 'querySelector').withArgs(elementToFocusSelector).and.returnValue(elementToFocus);
+      contentManagementService.editFolder({} as MinimalNodeEntity, elementToFocusSelector);
+      afterClosed$.next();
+      expect(elementToFocus.focus).toHaveBeenCalled();
+    });
+
+    it('should not looking for element to focus if passed selector is empty string', () => {
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable(),
+        componentInstance: {
+          error: EMPTY
+        }
+      } as MatDialogRef<any>);
+      spyOn(document, 'querySelector');
+      contentManagementService.editFolder({} as MinimalNodeEntity, '');
+      afterClosed$.next();
+      expect(document.querySelector).not.toHaveBeenCalled();
+    });
   });
 
   describe('aspect list dialog', () => {
@@ -1645,21 +1715,50 @@ describe('ContentManagementService', () => {
         createdAt: null,
         createdByUser: null
       };
+      const elementToFocusSelector = 'some-selector';
 
       spyOn(contentApi, 'getNodeInfo').and.returnValue(of(responseNode));
 
-      contentManagementService.manageAspects(fakeNode);
+      contentManagementService.manageAspects(fakeNode, elementToFocusSelector);
 
-      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('real-node-ghostbuster', undefined);
+      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('real-node-ghostbuster', elementToFocusSelector);
     });
 
     it('should open dialog for managing the aspects', () => {
       spyOn(nodeAspectService, 'updateNodeAspects').and.stub();
       const fakeNode = { entry: { id: 'fake-node-id' } };
+      const elementToFocusSelector = 'some-selector';
 
-      contentManagementService.manageAspects(fakeNode);
+      contentManagementService.manageAspects(fakeNode, elementToFocusSelector);
 
-      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('fake-node-id', undefined);
+      expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('fake-node-id', elementToFocusSelector);
+    });
+  });
+
+  describe('leaveLibrary', () => {
+    it('should focus element indicated by passed selector after closing modal', () => {
+      const elementToFocusSelector = 'button';
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      const elementToFocus = document.createElement(elementToFocusSelector);
+      spyOn(elementToFocus, 'focus');
+      spyOn(document, 'querySelector').withArgs(elementToFocusSelector).and.returnValue(elementToFocus);
+      contentManagementService.leaveLibrary('', elementToFocusSelector);
+      afterClosed$.next();
+      expect(elementToFocus.focus).toHaveBeenCalled();
+    });
+
+    it('should not looking for element to focus if passed selector is empty string', () => {
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      spyOn(document, 'querySelector');
+      contentManagementService.leaveLibrary('', '');
+      afterClosed$.next();
+      expect(document.querySelector).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/src/app/content-plugin/services/content-management.service.ts
+++ b/app/src/app/content-plugin/services/content-management.service.ts
@@ -85,6 +85,8 @@ interface RestoredNode {
   providedIn: 'root'
 })
 export class ContentManagementService {
+  private static MORE_ACTIONS_BUTTON_SELECTOR = '#app\\.toolbar\\.more';
+
   constructor(
     private alfrescoApiService: AlfrescoApiService,
     private store: Store<AppStore>,
@@ -261,6 +263,7 @@ export class ContentManagementService {
       if (node) {
         this.alfrescoApiService.nodeUpdated.next(node);
       }
+      ContentManagementService.focusMoreActionsButton();
     });
   }
 
@@ -578,9 +581,8 @@ export class ContentManagementService {
         showVersionsOnly: true,
         title: 'VERSION.DIALOG.TITLE'
       };
-      this.newVersionUploaderService
-        .openUploadNewVersionDialog(newVersionUploaderDialogData, { width: '630px', role: 'dialog' })
-        .subscribe((newVersionUploaderData: NewVersionUploaderData) => {
+      this.newVersionUploaderService.openUploadNewVersionDialog(newVersionUploaderDialogData, { width: '630px', role: 'dialog' }).subscribe({
+        next: (newVersionUploaderData: NewVersionUploaderData) => {
           switch (newVersionUploaderData.action) {
             case NewVersionUploaderDataAction.refresh:
               this.store.dispatch(new ReloadDocumentListAction());
@@ -595,7 +597,9 @@ export class ContentManagementService {
             default:
               break;
           }
-        });
+        },
+        complete: ContentManagementService.focusMoreActionsButton
+      });
     } else {
       this.store.dispatch(new SnackbarErrorAction('APP.MESSAGES.ERRORS.PERMISSION'));
     }
@@ -604,7 +608,7 @@ export class ContentManagementService {
   private openAspectListDialog(node: any) {
     // workaround Shared
     if (node.isFile || node.id) {
-      this.nodeAspectService.updateNodeAspects(node.id);
+      this.nodeAspectService.updateNodeAspects(node.id, ContentManagementService.MORE_ACTIONS_BUTTON_SELECTOR);
     } else {
       this.store.dispatch(new SnackbarErrorAction('APP.MESSAGES.ERRORS.PERMISSION'));
     }
@@ -1082,5 +1086,9 @@ export class ContentManagementService {
 
   private static focusCreateMenuButton(): void {
     document.querySelector<HTMLElement>('app-create-menu button').focus();
+  }
+
+  private static focusMoreActionsButton(): void {
+    document.querySelector<HTMLElement>(ContentManagementService.MORE_ACTIONS_BUTTON_SELECTOR).focus();
   }
 }

--- a/app/src/app/content-plugin/services/content-management.service.ts
+++ b/app/src/app/content-plugin/services/content-management.service.ts
@@ -303,7 +303,7 @@ export class ContentManagementService {
     );
   }
 
-  leaveLibrary(siteId: string): void {
+  leaveLibrary(siteId: string, focusedElementOnCloseSelector?: string): void {
     const dialogRef = this.dialogRef.open(ConfirmDialogComponent, {
       data: {
         title: 'APP.DIALOGS.CONFIRM_LEAVE.TITLE',
@@ -326,6 +326,7 @@ export class ContentManagementService {
           }
         );
       }
+      ContentManagementService.focusAfterClose(focusedElementOnCloseSelector);
     });
   }
 
@@ -580,25 +581,26 @@ export class ContentManagementService {
         showVersionsOnly: true,
         title: 'VERSION.DIALOG.TITLE'
       };
-      this.newVersionUploaderService.openUploadNewVersionDialog(newVersionUploaderDialogData, { width: '630px', role: 'dialog' }).subscribe({
-        next: (newVersionUploaderData: NewVersionUploaderData) => {
-          switch (newVersionUploaderData.action) {
-            case NewVersionUploaderDataAction.refresh:
-              this.store.dispatch(new ReloadDocumentListAction());
-              break;
-            case NewVersionUploaderDataAction.view:
-              this.store.dispatch(
-                new ViewNodeVersionAction(node.id, newVersionUploaderData.versionId, {
-                  location: this.router.url
-                })
-              );
-              break;
-            default:
-              break;
+      this.newVersionUploaderService
+        .openUploadNewVersionDialog(newVersionUploaderDialogData, { width: '630px', role: 'dialog' }, focusedElementOnCloseSelector)
+        .subscribe({
+          next: (newVersionUploaderData: NewVersionUploaderData) => {
+            switch (newVersionUploaderData.action) {
+              case NewVersionUploaderDataAction.refresh:
+                this.store.dispatch(new ReloadDocumentListAction());
+                break;
+              case NewVersionUploaderDataAction.view:
+                this.store.dispatch(
+                  new ViewNodeVersionAction(node.id, newVersionUploaderData.versionId, {
+                    location: this.router.url
+                  })
+                );
+                break;
+              default:
+                break;
+            }
           }
-        },
-        complete: () => ContentManagementService.focusAfterClose(focusedElementOnCloseSelector)
-      });
+        });
     } else {
       this.store.dispatch(new SnackbarErrorAction('APP.MESSAGES.ERRORS.PERMISSION'));
     }

--- a/app/src/app/content-plugin/services/content-management.service.ts
+++ b/app/src/app/content-plugin/services/content-management.service.ts
@@ -85,6 +85,8 @@ interface RestoredNode {
   providedIn: 'root'
 })
 export class ContentManagementService {
+  private readonly createMenuButtonSelector = 'app-create-menu button';
+
   constructor(
     private alfrescoApiService: AlfrescoApiService,
     private store: Store<AppStore>,
@@ -214,7 +216,7 @@ export class ContentManagementService {
           .subscribe(() => {
             this.store.dispatch(new SetSelectedNodesAction([node]));
             this.appHookService.linksUnshared.next();
-            ContentManagementService.focusAfterClose(focusedElementOnCloseSelector);
+            this.focusAfterClose(focusedElementOnCloseSelector);
           });
       });
   }
@@ -238,7 +240,7 @@ export class ContentManagementService {
       if (node) {
         this.store.dispatch(new ReloadDocumentListAction());
       }
-      ContentManagementService.focusCreateMenuButton();
+      this.focusAfterClose(this.createMenuButtonSelector);
     });
   }
 
@@ -262,7 +264,7 @@ export class ContentManagementService {
       if (node) {
         this.alfrescoApiService.nodeUpdated.next(node);
       }
-      ContentManagementService.focusAfterClose(focusedElementOnCloseSelector);
+      this.focusAfterClose(focusedElementOnCloseSelector);
     });
   }
 
@@ -280,7 +282,7 @@ export class ContentManagementService {
         if (node) {
           this.appHookService.libraryCreated.next(node);
         }
-        ContentManagementService.focusCreateMenuButton();
+        this.focusAfterClose(this.createMenuButtonSelector);
       }),
       map((node: SiteEntry) => {
         if (node && node.entry && node.entry.guid) {
@@ -326,7 +328,7 @@ export class ContentManagementService {
           }
         );
       }
-      ContentManagementService.focusAfterClose(focusedElementOnCloseSelector);
+      this.focusAfterClose(focusedElementOnCloseSelector);
     });
   }
 
@@ -1085,11 +1087,7 @@ export class ContentManagementService {
       .subscribe(() => this.undoMoveNodes(moveResponse, initialParentId));
   }
 
-  private static focusCreateMenuButton(): void {
-    document.querySelector<HTMLElement>('app-create-menu button').focus();
-  }
-
-  private static focusAfterClose(focusedElementSelector: string): void {
+  private focusAfterClose(focusedElementSelector: string): void {
     if (focusedElementSelector) {
       document.querySelector<HTMLElement>(focusedElementSelector).focus();
     }

--- a/app/src/app/content-plugin/services/node-actions.service.spec.ts
+++ b/app/src/app/content-plugin/services/node-actions.service.spec.ts
@@ -115,7 +115,9 @@ describe('NodeActionsService', () => {
 
   describe('ContentNodeSelector configuration', () => {
     it('should validate selection when allowableOperation has `create`', () => {
-      spyOn(dialog, 'open');
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as MatDialogRef<any>);
       const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
@@ -131,7 +133,9 @@ describe('NodeActionsService', () => {
     });
 
     it('should invalidate selection when allowableOperation does not have `create`', () => {
-      spyOn(dialog, 'open');
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as MatDialogRef<any>);
       const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
@@ -147,7 +151,9 @@ describe('NodeActionsService', () => {
     });
 
     it('should invalidate selection if isSite', () => {
-      spyOn(dialog, 'open');
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as MatDialogRef<any>);
       const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
@@ -164,7 +170,9 @@ describe('NodeActionsService', () => {
     });
 
     it('should validate selection if not a Site', () => {
-      spyOn(dialog, 'open');
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as MatDialogRef<any>);
       const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
@@ -280,7 +288,7 @@ describe('NodeActionsService', () => {
 
       spyOn(dialog, 'open').and.callFake((_contentNodeSelectorComponent: any, data: any) => {
         dialogData = data;
-        return { componentInstance: {} } as MatDialogRef<any>;
+        return { componentInstance: {}, afterClosed: of } as MatDialogRef<any>;
       });
 
       service.copyNodes([fileToCopy, folderToCopy]);
@@ -335,7 +343,7 @@ describe('NodeActionsService', () => {
       subject.next([destinationFolder.entry]);
 
       expect(spyOnBatchOperation.calls.count()).toEqual(1);
-      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.COPY, [fileToCopy, folderToCopy], undefined);
+      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.COPY, [fileToCopy, folderToCopy], undefined, undefined);
     });
 
     it('should use the custom data object with custom rowFilter & imageResolver & title with destination picker', () => {
@@ -346,12 +354,12 @@ describe('NodeActionsService', () => {
       let dialogData = null;
       const spyOnDialog = spyOn(dialog, 'open').and.callFake((_contentNodeSelectorComponent: any, data: any) => {
         dialogData = data;
-        return { componentInstance: {} } as MatDialogRef<any>;
+        return { componentInstance: {}, afterClosed: of } as MatDialogRef<any>;
       });
 
       service.copyNodes([fileToCopy, folderToCopy]);
 
-      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.COPY, [fileToCopy, folderToCopy], undefined);
+      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.COPY, [fileToCopy, folderToCopy], undefined, undefined);
       expect(spyOnDestinationPicker.calls.count()).toEqual(1);
       expect(spyOnDialog.calls.count()).toEqual(1);
 
@@ -388,7 +396,7 @@ describe('NodeActionsService', () => {
       let dialogData: any;
       spyOn(dialog, 'open').and.callFake((_contentNodeSelectorComponent: any, data: any) => {
         dialogData = data;
-        return { componentInstance: {} } as MatDialogRef<any>;
+        return { componentInstance: {}, afterClosed: of } as MatDialogRef<any>;
       });
 
       service.copyNodes([{ entry: { id: 'entry-id', name: 'entry-name' } }]);
@@ -410,7 +418,7 @@ describe('NodeActionsService', () => {
       let dialogData = null;
       spyOn(dialog, 'open').and.callFake((_contentNodeSelectorComponent: any, data: any) => {
         dialogData = data;
-        return { componentInstance: {} } as MatDialogRef<any>;
+        return { componentInstance: {}, afterClosed: of } as MatDialogRef<any>;
       });
 
       service.copyNodes([{ entry: { id: 'entry-id' } }]);
@@ -736,7 +744,7 @@ describe('NodeActionsService', () => {
       service.moveNodes([fileToMove, folderToMove], permissionToMove);
       subject.next([destinationFolder.entry]);
 
-      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.MOVE, [fileToMove, folderToMove], permissionToMove);
+      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.MOVE, [fileToMove, folderToMove], permissionToMove, undefined);
       expect(spyOnDestinationPicker).toHaveBeenCalled();
     });
 
@@ -749,7 +757,7 @@ describe('NodeActionsService', () => {
       service.moveNodes([fileToMove, folderToMove], permissionToMove);
       subject.next([destinationFolder.entry]);
 
-      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.MOVE, [fileToMove, folderToMove], permissionToMove);
+      expect(spyOnBatchOperation).toHaveBeenCalledWith(NodeAction.MOVE, [fileToMove, folderToMove], permissionToMove, undefined);
       expect(spyOnDestinationPicker).not.toHaveBeenCalled();
     });
 

--- a/app/src/app/content-plugin/services/node-actions.service.ts
+++ b/app/src/app/content-plugin/services/node-actions.service.ts
@@ -140,7 +140,7 @@ export class NodeActionsService {
           } else if (action === NodeAction.MOVE) {
             this.contentMoved.next(processedData);
           }
-        });
+        }, observable.error.bind(observable));
       });
     } else {
       observable.error(new Error(JSON.stringify({ error: { statusCode: 403 } })));

--- a/app/src/app/content-plugin/services/node-actions.service.ts
+++ b/app/src/app/content-plugin/services/node-actions.service.ts
@@ -226,7 +226,7 @@ export class NodeActionsService {
         role: 'dialog'
       })
       .afterClosed()
-      .subscribe(() => NodeActionsService.focusAfterClose(focusedElementOnCloseSelector));
+      .subscribe(() => this.focusAfterClose(focusedElementOnCloseSelector));
 
     data.select.subscribe({
       complete: this.close.bind(this)
@@ -698,7 +698,7 @@ export class NodeActionsService {
     }
   }
 
-  private static focusAfterClose(focusedElementSelector: string): void {
+  private focusAfterClose(focusedElementSelector: string): void {
     if (focusedElementSelector) {
       document.querySelector<HTMLElement>(focusedElementSelector).focus();
     }

--- a/app/src/app/content-plugin/services/node-actions.service.ts
+++ b/app/src/app/content-plugin/services/node-actions.service.ts
@@ -211,12 +211,15 @@ export class NodeActionsService {
       excludeSiteContent: ContentNodeDialogService.nonDocumentSiteContent
     };
 
-    this.dialog.open(ContentNodeSelectorComponent, {
-      data,
-      panelClass: 'adf-content-node-selector-dialog',
-      width: '630px',
-      role: 'dialog'
-    });
+    this.dialog
+      .open(ContentNodeSelectorComponent, {
+        data,
+        panelClass: 'adf-content-node-selector-dialog',
+        width: '630px',
+        role: 'dialog'
+      })
+      .afterClosed()
+      .subscribe(() => NodeActionsService.focusMoreActionsButton());
 
     data.select.subscribe({
       complete: this.close.bind(this)
@@ -686,5 +689,9 @@ export class NodeActionsService {
 
       return moveStatus;
     }
+  }
+
+  private static focusMoreActionsButton(): void {
+    document.querySelector<HTMLElement>('#app\\.toolbar\\.more').focus();
   }
 }

--- a/app/src/app/content-plugin/services/node-actions.service.ts
+++ b/app/src/app/content-plugin/services/node-actions.service.ts
@@ -78,6 +78,7 @@ export class NodeActionsService {
    *
    * @param contentEntities nodes to copy
    * @param permission permission which is needed to apply the action
+   * @param focusedElementOnCloseSelector element's selector which should be autofocused after closing modal
    */
   copyNodes(contentEntities: any[], permission?: string, focusedElementOnCloseSelector?: string): Subject<string> {
     return this.doBatchOperation(NodeAction.COPY, contentEntities, permission, focusedElementOnCloseSelector);
@@ -88,6 +89,7 @@ export class NodeActionsService {
    *
    * @param contentEntities nodes to move
    * @param permission permission which is needed to apply the action
+   * @param focusedElementOnCloseSelector element's selector which should be autofocused after closing modal
    */
   moveNodes(contentEntities: any[], permission?: string, focusedElementOnCloseSelector?: string): Subject<string> {
     return this.doBatchOperation(NodeAction.MOVE, contentEntities, permission, focusedElementOnCloseSelector);
@@ -99,6 +101,7 @@ export class NodeActionsService {
    * @param action the action to perform (copy|move)
    * @param contentEntities the contentEntities which have to have the action performed on
    * @param permission permission which is needed to apply the action
+   * @param focusedElementOnCloseSelector element's selector which should be autofocused after closing modal
    */
   doBatchOperation(action: BatchOperationType, contentEntities: any[], permission?: string, focusedElementOnCloseSelector?: string): Subject<string> {
     const observable: Subject<string> = new Subject<string>();

--- a/app/src/app/content-plugin/store/effects/download.effects.spec.ts
+++ b/app/src/app/content-plugin/store/effects/download.effects.spec.ts
@@ -1,0 +1,115 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { AppTestingModule } from '../../testing/app-testing.module';
+import { EffectsModule } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { DownloadNodesAction } from '@alfresco/aca-shared/store';
+import { SelectionState } from '@alfresco/adf-extensions';
+import { VersionEntry } from '@alfresco/js-api';
+import { DownloadEffects } from './download.effects';
+
+describe('DownloadEffects', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule, EffectsModule.forRoot([DownloadEffects])]
+    });
+    store = TestBed.inject(Store);
+  });
+
+  describe('downloadNode$', () => {
+    let dialog: MatDialog;
+
+    beforeEach(() => {
+      dialog = TestBed.inject(MatDialog);
+    });
+
+    it('should focus element indicated by passed selector after closing modal', () => {
+      const elementToFocusSelector = 'button';
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      const elementToFocus = document.createElement(elementToFocusSelector);
+      spyOn(elementToFocus, 'focus');
+      spyOn(document, 'querySelector').withArgs(elementToFocusSelector).and.returnValue(elementToFocus);
+      spyOn(store, 'select').and.returnValues(
+        new BehaviorSubject({
+          isEmpty: false,
+          nodes: [
+            {
+              entry: {
+                id: 'someId',
+                isFolder: true
+              }
+            }
+          ]
+        } as SelectionState),
+        new BehaviorSubject<VersionEntry>(null)
+      );
+      store.dispatch(
+        new DownloadNodesAction({
+          focusedElementOnCloseSelector: elementToFocusSelector
+        })
+      );
+      afterClosed$.next();
+      expect(elementToFocus.focus).toHaveBeenCalled();
+    });
+
+    it('should not looking for element to focus if passed selector is empty string', () => {
+      const afterClosed$ = new Subject<void>();
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => afterClosed$.asObservable()
+      } as MatDialogRef<any>);
+      spyOn(document, 'querySelector');
+      spyOn(store, 'select').and.returnValues(
+        new BehaviorSubject({
+          isEmpty: false,
+          nodes: [
+            {
+              entry: {
+                id: 'someId',
+                isFolder: true
+              }
+            }
+          ]
+        } as SelectionState),
+        new BehaviorSubject<VersionEntry>(null)
+      );
+      store.dispatch(
+        new DownloadNodesAction({
+          focusedElementOnCloseSelector: ''
+        })
+      );
+      afterClosed$.next();
+      expect(document.querySelector).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/src/app/content-plugin/store/effects/download.effects.ts
+++ b/app/src/app/content-plugin/store/effects/download.effects.ts
@@ -31,7 +31,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Actions, ofType, createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { map, take } from 'rxjs/operators';
-import { ContentApiService } from '@alfresco/aca-shared';
+import { ContentApiService, ModalConfiguration } from '@alfresco/aca-shared';
 import { ContentUrlService } from '../../services/content-url.service';
 
 @Injectable()
@@ -64,10 +64,7 @@ export class DownloadEffects {
                       if (version) {
                         this.downloadFileVersion(selection.nodes[0].entry, version.entry);
                       } else {
-                        this.downloadNodes(
-                          selection.nodes,
-                          (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
-                        );
+                        this.downloadNodes(selection.nodes, (action.payload as ModalConfiguration)?.focusedElementOnCloseSelector);
                       }
                     });
                 }

--- a/app/src/app/content-plugin/store/effects/library.effects.ts
+++ b/app/src/app/content-plugin/store/effects/library.effects.ts
@@ -39,7 +39,7 @@ import { Injectable } from '@angular/core';
 import { Actions, ofType, createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { map, mergeMap, take } from 'rxjs/operators';
-import { ContentApiService } from '@alfresco/aca-shared';
+import { ContentApiService, ModalConfiguration } from '@alfresco/aca-shared';
 import { ContentManagementService } from '../../services/content-management.service';
 
 @Injectable()
@@ -86,10 +86,7 @@ export class LibraryEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.library) {
-                  this.content.leaveLibrary(
-                    selection.library.entry.id,
-                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
-                  );
+                  this.content.leaveLibrary(selection.library.entry.id, (action.payload as ModalConfiguration)?.focusedElementOnCloseSelector);
                 }
               });
           }

--- a/app/src/app/content-plugin/store/effects/library.effects.ts
+++ b/app/src/app/content-plugin/store/effects/library.effects.ts
@@ -56,7 +56,8 @@ export class LibraryEffects {
       this.actions$.pipe(
         ofType<DeleteLibraryAction>(LibraryActionTypes.Delete),
         map((action) => {
-          if (action.payload) {
+          console.log(action);
+          if (typeof action?.payload === 'string') {
             this.content.deleteLibrary(action.payload);
           } else {
             this.store

--- a/app/src/app/content-plugin/store/effects/library.effects.ts
+++ b/app/src/app/content-plugin/store/effects/library.effects.ts
@@ -78,7 +78,7 @@ export class LibraryEffects {
       this.actions$.pipe(
         ofType<LeaveLibraryAction>(LibraryActionTypes.Leave),
         map((action) => {
-          if (action.payload) {
+          if (typeof action.payload === 'string') {
             this.content.leaveLibrary(action.payload);
           } else {
             this.store
@@ -86,7 +86,10 @@ export class LibraryEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.library) {
-                  this.content.leaveLibrary(selection.library.entry.id);
+                  this.content.leaveLibrary(
+                    selection.library.entry.id,
+                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }

--- a/app/src/app/content-plugin/store/effects/library.effects.ts
+++ b/app/src/app/content-plugin/store/effects/library.effects.ts
@@ -56,7 +56,6 @@ export class LibraryEffects {
       this.actions$.pipe(
         ofType<DeleteLibraryAction>(LibraryActionTypes.Delete),
         map((action) => {
-          console.log(action);
           if (typeof action?.payload === 'string') {
             this.content.deleteLibrary(action.payload);
           } else {

--- a/app/src/app/content-plugin/store/effects/node.effects.spec.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.spec.ts
@@ -79,10 +79,12 @@ describe('NodeEffects', () => {
     it('should share node from payload', () => {
       spyOn(contentService, 'shareNode').and.stub();
 
-      const node: any = {};
+      const node: any = {
+        entry: {}
+      };
       store.dispatch(new ShareNodeAction(node));
 
-      expect(contentService.shareNode).toHaveBeenCalledWith(node);
+      expect(contentService.shareNode).toHaveBeenCalledWith(node, undefined);
     });
 
     it('should share node from active selection', fakeAsync(() => {
@@ -94,7 +96,7 @@ describe('NodeEffects', () => {
       tick(100);
 
       store.dispatch(new ShareNodeAction(null));
-      expect(contentService.shareNode).toHaveBeenCalledWith(node);
+      expect(contentService.shareNode).toHaveBeenCalledWith(node, undefined);
     }));
 
     it('should do nothing if invoking share with no data', () => {
@@ -300,7 +302,7 @@ describe('NodeEffects', () => {
       tick(100);
 
       store.dispatch(new EditFolderAction(null));
-      expect(contentService.editFolder).toHaveBeenCalledWith(currentFolder);
+      expect(contentService.editFolder).toHaveBeenCalledWith(currentFolder, undefined);
     }));
 
     it('should do nothing if editing folder with no selection and payload', () => {
@@ -332,7 +334,7 @@ describe('NodeEffects', () => {
 
       store.dispatch(new CopyNodesAction(null));
 
-      expect(contentService.copyNodes).toHaveBeenCalledWith([node]);
+      expect(contentService.copyNodes).toHaveBeenCalledWith([node], undefined);
     }));
 
     it('should do nothing if invoking copy with no data', () => {
@@ -364,7 +366,7 @@ describe('NodeEffects', () => {
 
       store.dispatch(new MoveNodesAction(null));
 
-      expect(contentService.moveNodes).toHaveBeenCalledWith([node]);
+      expect(contentService.moveNodes).toHaveBeenCalledWith([node], undefined);
     }));
 
     it('should do nothing if invoking move with no data', () => {
@@ -488,7 +490,7 @@ describe('NodeEffects', () => {
 
       store.dispatch(new ManageAspectsAction(null));
 
-      expect(contentService.manageAspects).toHaveBeenCalledWith({ entry: { isFile: true, id: 'file-node-id' } });
+      expect(contentService.manageAspects).toHaveBeenCalledWith({ entry: { isFile: true, id: 'file-node-id' } }, undefined);
     }));
 
     it('should call aspect dialog from the active folder selection', fakeAsync(() => {
@@ -501,7 +503,7 @@ describe('NodeEffects', () => {
 
       store.dispatch(new ManageAspectsAction(null));
 
-      expect(contentService.manageAspects).toHaveBeenCalledWith({ entry: { isFile: false, id: 'folder-node-id' } });
+      expect(contentService.manageAspects).toHaveBeenCalledWith({ entry: { isFile: false, id: 'folder-node-id' } }, undefined);
     }));
   });
 });

--- a/app/src/app/content-plugin/store/effects/node.effects.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.ts
@@ -54,6 +54,7 @@ import {
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { ViewUtilService } from '@alfresco/adf-core';
+import { ModalConfiguration } from '@alfresco/aca-shared';
 
 @Injectable()
 export class NodeEffects {
@@ -245,10 +246,7 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.copyNodes(
-                    selection.nodes,
-                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
-                  );
+                  this.contentService.copyNodes(selection.nodes, (action.payload as ModalConfiguration)?.focusedElementOnCloseSelector);
                 }
               });
           }
@@ -270,10 +268,7 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.moveNodes(
-                    selection.nodes,
-                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
-                  );
+                  this.contentService.moveNodes(selection.nodes, (action.payload as ModalConfiguration)?.focusedElementOnCloseSelector);
                 }
               });
           }

--- a/app/src/app/content-plugin/store/effects/node.effects.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.ts
@@ -54,6 +54,7 @@ import {
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { ViewUtilService } from '@alfresco/adf-core';
+import { MinimalNodeEntity } from '@alfresco/js-api';
 
 @Injectable()
 export class NodeEffects {
@@ -69,15 +70,15 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ShareNodeAction>(NodeActionTypes.Share),
         map((action) => {
-          if (action.payload) {
-            this.contentService.shareNode(action.payload);
+          if (action.payload?.entry) {
+            this.contentService.shareNode(action.payload, action.payload?.focusedElementOnCloseSelector);
           } else {
             this.store
               .select(getAppSelection)
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.file) {
-                  this.contentService.shareNode(selection.file);
+                  this.contentService.shareNode(selection.file, action.payload?.focusedElementOnCloseSelector);
                 }
               });
           }
@@ -215,7 +216,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<EditFolderAction>(NodeActionTypes.EditFolder),
         map((action) => {
-          if (action.payload) {
+          if (action.payload instanceof MinimalNodeEntity) {
             this.contentService.editFolder(action.payload);
           } else {
             this.store
@@ -223,7 +224,10 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.folder) {
-                  this.contentService.editFolder(selection.folder);
+                  this.contentService.editFolder(
+                    selection.folder,
+                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }
@@ -237,7 +241,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<CopyNodesAction>(NodeActionTypes.Copy),
         map((action) => {
-          if (action.payload && action.payload.length > 0) {
+          if (Array.isArray(action.payload) && action.payload?.length > 0) {
             this.contentService.copyNodes(action.payload);
           } else {
             this.store
@@ -245,7 +249,10 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.copyNodes(selection.nodes);
+                  this.contentService.copyNodes(
+                    selection.nodes,
+                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }
@@ -259,7 +266,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<MoveNodesAction>(NodeActionTypes.Move),
         map((action) => {
-          if (action.payload && action.payload.length > 0) {
+          if (Array.isArray(action.payload) && action.payload?.length > 0) {
             this.contentService.moveNodes(action.payload);
           } else {
             this.store
@@ -267,7 +274,10 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.moveNodes(selection.nodes);
+                  this.contentService.moveNodes(
+                    selection.nodes,
+                    (action.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }
@@ -329,7 +339,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManageVersionsAction>(NodeActionTypes.ManageVersions),
         map((action) => {
-          if (action && action.payload) {
+          if (action?.payload instanceof MinimalNodeEntity) {
             this.contentService.manageVersions(action.payload);
           } else {
             this.store
@@ -337,7 +347,10 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.file) {
-                  this.contentService.manageVersions(selection.file);
+                  this.contentService.manageVersions(
+                    selection.file,
+                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }
@@ -395,7 +408,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManageAspectsAction>(NodeActionTypes.ChangeAspects),
         map((action) => {
-          if (action && action.payload) {
+          if (action?.payload instanceof MinimalNodeEntity) {
             this.contentService.manageAspects(action.payload);
           } else {
             this.store
@@ -403,7 +416,10 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.manageAspects(selection.nodes[0]);
+                  this.contentService.manageAspects(
+                    selection.nodes[0],
+                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
+                  );
                 }
               });
           }

--- a/app/src/app/content-plugin/store/effects/node.effects.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.ts
@@ -54,7 +54,6 @@ import {
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { ViewUtilService } from '@alfresco/adf-core';
-import { MinimalNodeEntity } from '@alfresco/js-api';
 
 @Injectable()
 export class NodeEffects {
@@ -216,7 +215,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<EditFolderAction>(NodeActionTypes.EditFolder),
         map((action) => {
-          if (action.payload instanceof MinimalNodeEntity) {
+          if (action.payload?.entry) {
             this.contentService.editFolder(action.payload);
           } else {
             this.store
@@ -224,10 +223,7 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.folder) {
-                  this.contentService.editFolder(
-                    selection.folder,
-                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
-                  );
+                  this.contentService.editFolder(selection.folder, action.payload?.focusedElementOnCloseSelector);
                 }
               });
           }
@@ -339,7 +335,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManageVersionsAction>(NodeActionTypes.ManageVersions),
         map((action) => {
-          if (action?.payload instanceof MinimalNodeEntity) {
+          if (action?.payload?.entry) {
             this.contentService.manageVersions(action.payload);
           } else {
             this.store
@@ -347,10 +343,7 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && selection.file) {
-                  this.contentService.manageVersions(
-                    selection.file,
-                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
-                  );
+                  this.contentService.manageVersions(selection.file, action.payload?.focusedElementOnCloseSelector);
                 }
               });
           }
@@ -408,7 +401,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManageAspectsAction>(NodeActionTypes.ChangeAspects),
         map((action) => {
-          if (action?.payload instanceof MinimalNodeEntity) {
+          if (action?.payload?.entry) {
             this.contentService.manageAspects(action.payload);
           } else {
             this.store
@@ -416,10 +409,7 @@ export class NodeEffects {
               .pipe(take(1))
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
-                  this.contentService.manageAspects(
-                    selection.nodes[0],
-                    action.payload instanceof MinimalNodeEntity ? '' : action.payload?.focusedElementOnCloseSelector
-                  );
+                  this.contentService.manageAspects(selection.nodes[0], action.payload?.focusedElementOnCloseSelector);
                 }
               });
           }

--- a/app/src/app/content-plugin/store/effects/node.effects.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.ts
@@ -306,7 +306,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ExpandInfoDrawerAction>(NodeActionTypes.ExpandInfoDrawer),
         map((action) => {
-          if (action && action.payload) {
+          if (action?.payload?.entry) {
             const route = 'personal-files/details';
             this.store.dispatch(new NavigateRouteAction([route, action.payload.entry.id]));
           } else {

--- a/app/src/app/content-plugin/store/effects/node.effects.ts
+++ b/app/src/app/content-plugin/store/effects/node.effects.ts
@@ -287,7 +287,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManagePermissionsAction>(NodeActionTypes.ManagePermissions),
         map((action) => {
-          if (action && action.payload) {
+          if (action?.payload?.entry) {
             const route = 'personal-files/details';
             this.store.dispatch(new NavigateRouteAction([route, action.payload.entry.id, 'permissions']));
           } else {
@@ -435,7 +435,7 @@ export class NodeEffects {
       this.actions$.pipe(
         ofType<ManageRulesAction>(NodeActionTypes.ManageRules),
         map((action) => {
-          if (action && action.payload) {
+          if (action?.payload?.entry) {
             this.store.dispatch(new NavigateRouteAction(['nodes', action.payload.entry.id, 'rules']));
           } else {
             this.store

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -47,6 +47,7 @@ export class UploadEffects {
   private fileInput: HTMLInputElement;
   private folderInput: HTMLInputElement;
   private fileVersionInput: HTMLInputElement;
+  private readonly createMenuButtonSelector = 'app-create-menu button';
 
   constructor(
     private store: Store<AppStore>,
@@ -90,7 +91,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFilesAction>(UploadActionTypes.UploadFiles),
         map(() => {
-          this.registerFocusingCreateMenuButton(this.fileInput);
+          this.registerFocusingElementAfterModalClose(this.fileInput, this.createMenuButtonSelector);
           this.fileInput.click();
         })
       ),
@@ -102,7 +103,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFolderAction>(UploadActionTypes.UploadFolder),
         map(() => {
-          this.registerFocusingCreateMenuButton(this.folderInput);
+          this.registerFocusingElementAfterModalClose(this.folderInput, this.createMenuButtonSelector);
           this.folderInput.click();
         })
       ),
@@ -119,7 +120,7 @@ export class UploadEffects {
             const file: any = action?.payload?.detail?.files[0]?.file;
             this.contentService.versionUpdateDialog(node, file);
           } else if (!action?.payload || !(action.payload instanceof CustomEvent)) {
-            this.registerFocusingCreateMenuButton(
+            this.registerFocusingElementAfterModalClose(
               this.fileVersionInput,
               (action?.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
             );
@@ -203,7 +204,7 @@ export class UploadEffects {
     });
   }
 
-  private registerFocusingCreateMenuButton(input: HTMLInputElement, focusedElementSelector: string): void {
+  private registerFocusingElementAfterModalClose(input: HTMLInputElement, focusedElementSelector: string): void {
     input.addEventListener(
       'click',
       () => {

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -114,11 +114,15 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFileVersionAction>(UploadActionTypes.UploadFileVersion),
         map((action) => {
-          if (action?.payload) {
+          if (action?.payload instanceof CustomEvent) {
             const node = action?.payload?.detail?.data?.node?.entry;
             const file: any = action?.payload?.detail?.files[0]?.file;
             this.contentService.versionUpdateDialog(node, file);
-          } else if (!action?.payload) {
+          } else if (!action?.payload || !(action.payload instanceof CustomEvent)) {
+            this.registerFocusingCreateMenuButton(
+              this.fileVersionInput,
+              (action?.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
+            );
             this.fileVersionInput.click();
           }
         })
@@ -199,18 +203,18 @@ export class UploadEffects {
     });
   }
 
-  private registerFocusingCreateMenuButton(input: HTMLInputElement): void {
+  private registerFocusingCreateMenuButton(input: HTMLInputElement, focusedElementSelector: string): void {
     input.addEventListener(
       'click',
       () => {
         window.addEventListener(
           'focus',
           () => {
-            const createMenuButton = document.querySelector<HTMLElement>('app-create-menu button');
-            createMenuButton.addEventListener('focus', () => createMenuButton.classList.add('cdk-program-focused'), {
+            const elementToFocus = document.querySelector<HTMLElement>(focusedElementSelector);
+            elementToFocus.addEventListener('focus', () => elementToFocus.classList.add('cdk-program-focused'), {
               once: true
             });
-            createMenuButton.focus();
+            elementToFocus.focus();
           },
           {
             once: true

--- a/app/src/app/content-plugin/store/effects/upload.effects.ts
+++ b/app/src/app/content-plugin/store/effects/upload.effects.ts
@@ -41,6 +41,7 @@ import { of } from 'rxjs';
 import { catchError, map, take } from 'rxjs/operators';
 import { ContentManagementService } from '../../services/content-management.service';
 import { MinimalNodeEntryEntity } from '@alfresco/js-api';
+import { ModalConfiguration } from '@alfresco/aca-shared';
 
 @Injectable()
 export class UploadEffects {
@@ -122,7 +123,7 @@ export class UploadEffects {
           } else if (!action?.payload || !(action.payload instanceof CustomEvent)) {
             this.registerFocusingElementAfterModalClose(
               this.fileVersionInput,
-              (action?.payload as { focusedElementOnCloseSelector: string })?.focusedElementOnCloseSelector
+              (action?.payload as ModalConfiguration)?.focusedElementOnCloseSelector
             );
             this.fileVersionInput.click();
           }

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -402,7 +402,8 @@
         "title": "APP.ACTIONS.LEAVE",
         "icon": "exit_to_app",
         "actions": {
-          "click": "LEAVE_LIBRARY"
+          "click": "LEAVE_LIBRARY",
+          "focusedElementOnCloseSelector": "#app\\.toolbar\\.leaveLibrary"
         },
         "rules": {
           "visible": "canLeaveLibrary"
@@ -637,7 +638,7 @@
         "order": 100,
         "data": {
           "iconButton": false,
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -690,7 +691,7 @@
         "icon": "create",
         "actions": {
           "click": "EDIT_FOLDER",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "canEditFolder"
@@ -703,7 +704,7 @@
         "icon": "playlist_add",
         "actions": {
           "click": "UPLOAD_FILE_VERSION",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "app.selection.file.canUploadVersion"
@@ -765,7 +766,7 @@
         "icon": "adf:move_file",
         "actions": {
           "click": "MOVE_NODES",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "app.selection.canDelete"
@@ -778,7 +779,7 @@
         "icon": "content_copy",
         "actions": {
           "click": "COPY_NODES",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "canCopyNode"
@@ -808,7 +809,7 @@
         "icon": "history",
         "actions": {
           "click": "MANAGE_VERSIONS",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "canManageFileVersions"
@@ -821,7 +822,7 @@
         "icon": "toc",
         "actions": {
           "click": "ASPECT_LIST",
-          "focusedElementOnCloseSelector": ".adf-is-selected"
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "canEditAspects"
@@ -866,7 +867,8 @@
         "title": "APP.ACTIONS.LEAVE",
         "icon": "exit_to_app",
         "actions": {
-          "click": "LEAVE_LIBRARY"
+          "click": "LEAVE_LIBRARY",
+          "focusedElementOnCloseSelector": ".adf-context-menu-source"
         },
         "rules": {
           "visible": "canLeaveLibrary"

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -331,7 +331,7 @@
         "order": 100,
         "data": {
           "iconButton": true,
-          "focusedElementOnCloseSelector": "#share-action-button"
+          "autoFocusedTriggerAfterModalClose": true
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -402,8 +402,10 @@
         "title": "APP.ACTIONS.LEAVE",
         "icon": "exit_to_app",
         "actions": {
-          "click": "LEAVE_LIBRARY",
-          "focusedElementOnCloseSelector": "#app\\.toolbar\\.leaveLibrary"
+          "click": "LEAVE_LIBRARY"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canLeaveLibrary"
@@ -454,8 +456,10 @@
             "title": "APP.ACTIONS.UPLOAD_VERSION",
             "icon": "playlist_add",
             "actions": {
-              "click": "UPLOAD_FILE_VERSION",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "UPLOAD_FILE_VERSION"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "app.selection.file.canUploadVersion"
@@ -467,8 +471,10 @@
             "title": "APP.ACTIONS.EDIT",
             "icon": "create",
             "actions": {
-              "click": "EDIT_FOLDER",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "EDIT_FOLDER"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canEditFolder"
@@ -529,8 +535,10 @@
             "title": "APP.ACTIONS.MOVE",
             "icon": "adf:move_file",
             "actions": {
-              "click": "MOVE_NODES",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "MOVE_NODES"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "app.selection.canDelete"
@@ -542,8 +550,10 @@
             "title": "APP.ACTIONS.COPY",
             "icon": "content_copy",
             "actions": {
-              "click": "COPY_NODES",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "COPY_NODES"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canCopyNode"
@@ -572,8 +582,10 @@
             "title": "APP.ACTIONS.VERSIONS",
             "icon": "history",
             "actions": {
-              "click": "MANAGE_VERSIONS",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "MANAGE_VERSIONS"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canManageFileVersions"
@@ -585,8 +597,10 @@
             "title": "APP.ACTIONS.CHANGE_ASPECT",
             "icon": "toc",
             "actions": {
-              "click": "ASPECT_LIST",
-              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
+              "click": "ASPECT_LIST"
+            },
+            "data": {
+              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canEditAspects"
@@ -638,7 +652,7 @@
         "order": 100,
         "data": {
           "iconButton": false,
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "autoFocusedTriggerAfterModalClose": true
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -690,8 +704,10 @@
         "title": "APP.ACTIONS.EDIT",
         "icon": "create",
         "actions": {
-          "click": "EDIT_FOLDER",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "EDIT_FOLDER"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canEditFolder"
@@ -703,8 +719,10 @@
         "order": 700,
         "icon": "playlist_add",
         "actions": {
-          "click": "UPLOAD_FILE_VERSION",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "UPLOAD_FILE_VERSION"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "app.selection.file.canUploadVersion"
@@ -765,8 +783,10 @@
         "order": 1000,
         "icon": "adf:move_file",
         "actions": {
-          "click": "MOVE_NODES",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "MOVE_NODES"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "app.selection.canDelete"
@@ -778,8 +798,10 @@
         "order": 1100,
         "icon": "content_copy",
         "actions": {
-          "click": "COPY_NODES",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "COPY_NODES"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canCopyNode"
@@ -808,8 +830,10 @@
         "order": 1400,
         "icon": "history",
         "actions": {
-          "click": "MANAGE_VERSIONS",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "MANAGE_VERSIONS"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canManageFileVersions"
@@ -821,8 +845,10 @@
         "title": "APP.ACTIONS.CHANGE_ASPECT",
         "icon": "toc",
         "actions": {
-          "click": "ASPECT_LIST",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "ASPECT_LIST"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canEditAspects"
@@ -867,8 +893,10 @@
         "title": "APP.ACTIONS.LEAVE",
         "icon": "exit_to_app",
         "actions": {
-          "click": "LEAVE_LIBRARY",
-          "focusedElementOnCloseSelector": ".adf-context-menu-source"
+          "click": "LEAVE_LIBRARY"
+        },
+        "data": {
+          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canLeaveLibrary"

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -330,8 +330,7 @@
         "type": "custom",
         "order": 100,
         "data": {
-          "iconButton": true,
-          "autoFocusedTriggerAfterModalClose": true
+          "iconButton": true
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -404,9 +403,6 @@
         "actions": {
           "click": "LEAVE_LIBRARY"
         },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
-        },
         "rules": {
           "visible": "canLeaveLibrary"
         }
@@ -458,9 +454,6 @@
             "actions": {
               "click": "UPLOAD_FILE_VERSION"
             },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
-            },
             "rules": {
               "visible": "app.selection.file.canUploadVersion"
             }
@@ -472,9 +465,6 @@
             "icon": "create",
             "actions": {
               "click": "EDIT_FOLDER"
-            },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canEditFolder"
@@ -537,9 +527,6 @@
             "actions": {
               "click": "MOVE_NODES"
             },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
-            },
             "rules": {
               "visible": "app.selection.canDelete"
             }
@@ -551,9 +538,6 @@
             "icon": "content_copy",
             "actions": {
               "click": "COPY_NODES"
-            },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canCopyNode"
@@ -584,9 +568,6 @@
             "actions": {
               "click": "MANAGE_VERSIONS"
             },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
-            },
             "rules": {
               "visible": "canManageFileVersions"
             }
@@ -598,9 +579,6 @@
             "icon": "toc",
             "actions": {
               "click": "ASPECT_LIST"
-            },
-            "data": {
-              "autoFocusedTriggerAfterModalClose": true
             },
             "rules": {
               "visible": "canEditAspects"
@@ -651,8 +629,7 @@
         "type": "custom",
         "order": 100,
         "data": {
-          "iconButton": false,
-          "autoFocusedTriggerAfterModalClose": true
+          "iconButton": false
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -706,9 +683,6 @@
         "actions": {
           "click": "EDIT_FOLDER"
         },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
-        },
         "rules": {
           "visible": "canEditFolder"
         }
@@ -720,9 +694,6 @@
         "icon": "playlist_add",
         "actions": {
           "click": "UPLOAD_FILE_VERSION"
-        },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "app.selection.file.canUploadVersion"
@@ -785,9 +756,6 @@
         "actions": {
           "click": "MOVE_NODES"
         },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
-        },
         "rules": {
           "visible": "app.selection.canDelete"
         }
@@ -799,9 +767,6 @@
         "icon": "content_copy",
         "actions": {
           "click": "COPY_NODES"
-        },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canCopyNode"
@@ -832,9 +797,6 @@
         "actions": {
           "click": "MANAGE_VERSIONS"
         },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
-        },
         "rules": {
           "visible": "canManageFileVersions"
         }
@@ -846,9 +808,6 @@
         "icon": "toc",
         "actions": {
           "click": "ASPECT_LIST"
-        },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canEditAspects"
@@ -894,9 +853,6 @@
         "icon": "exit_to_app",
         "actions": {
           "click": "LEAVE_LIBRARY"
-        },
-        "data": {
-          "autoFocusedTriggerAfterModalClose": true
         },
         "rules": {
           "visible": "canLeaveLibrary"

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -330,7 +330,8 @@
         "type": "custom",
         "order": 100,
         "data": {
-          "iconButton": true
+          "iconButton": true,
+          "focusedElementOnCloseSelector": "#share-action-button"
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -464,7 +465,8 @@
             "title": "APP.ACTIONS.EDIT",
             "icon": "create",
             "actions": {
-              "click": "EDIT_FOLDER"
+              "click": "EDIT_FOLDER",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "canEditFolder"
@@ -525,7 +527,8 @@
             "title": "APP.ACTIONS.MOVE",
             "icon": "adf:move_file",
             "actions": {
-              "click": "MOVE_NODES"
+              "click": "MOVE_NODES",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "app.selection.canDelete"
@@ -537,7 +540,8 @@
             "title": "APP.ACTIONS.COPY",
             "icon": "content_copy",
             "actions": {
-              "click": "COPY_NODES"
+              "click": "COPY_NODES",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "canCopyNode"
@@ -566,7 +570,8 @@
             "title": "APP.ACTIONS.VERSIONS",
             "icon": "history",
             "actions": {
-              "click": "MANAGE_VERSIONS"
+              "click": "MANAGE_VERSIONS",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "canManageFileVersions"
@@ -578,7 +583,8 @@
             "title": "APP.ACTIONS.CHANGE_ASPECT",
             "icon": "toc",
             "actions": {
-              "click": "ASPECT_LIST"
+              "click": "ASPECT_LIST",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "canEditAspects"
@@ -629,7 +635,8 @@
         "type": "custom",
         "order": 100,
         "data": {
-          "iconButton": false
+          "iconButton": false,
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "component": "app.shared-link.toggleSharedLink",
         "rules": {
@@ -681,7 +688,8 @@
         "title": "APP.ACTIONS.EDIT",
         "icon": "create",
         "actions": {
-          "click": "EDIT_FOLDER"
+          "click": "EDIT_FOLDER",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "canEditFolder"
@@ -754,7 +762,8 @@
         "order": 1000,
         "icon": "adf:move_file",
         "actions": {
-          "click": "MOVE_NODES"
+          "click": "MOVE_NODES",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "app.selection.canDelete"
@@ -766,7 +775,8 @@
         "order": 1100,
         "icon": "content_copy",
         "actions": {
-          "click": "COPY_NODES"
+          "click": "COPY_NODES",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "canCopyNode"
@@ -795,7 +805,8 @@
         "order": 1400,
         "icon": "history",
         "actions": {
-          "click": "MANAGE_VERSIONS"
+          "click": "MANAGE_VERSIONS",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "canManageFileVersions"
@@ -807,7 +818,8 @@
         "title": "APP.ACTIONS.CHANGE_ASPECT",
         "icon": "toc",
         "actions": {
-          "click": "ASPECT_LIST"
+          "click": "ASPECT_LIST",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "canEditAspects"

--- a/app/src/assets/app.extensions.json
+++ b/app/src/assets/app.extensions.json
@@ -453,7 +453,8 @@
             "title": "APP.ACTIONS.UPLOAD_VERSION",
             "icon": "playlist_add",
             "actions": {
-              "click": "UPLOAD_FILE_VERSION"
+              "click": "UPLOAD_FILE_VERSION",
+              "focusedElementOnCloseSelector": "#app\\.toolbar\\.more"
             },
             "rules": {
               "visible": "app.selection.file.canUploadVersion"
@@ -701,7 +702,8 @@
         "order": 700,
         "icon": "playlist_add",
         "actions": {
-          "click": "UPLOAD_FILE_VERSION"
+          "click": "UPLOAD_FILE_VERSION",
+          "focusedElementOnCloseSelector": ".adf-is-selected"
         },
         "rules": {
           "visible": "app.selection.file.canUploadVersion"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@alfresco/adf-cli": {
-      "version": "6.0.0-A.1-37352",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-cli/-/adf-cli-6.0.0-A.1-37352.tgz",
-      "integrity": "sha512-lM//JUPyBmyO9PVDd628VFyumMJElBKNDvy6E0Yv/iKZmj2S/93pCFhkjnnbG/hOMNAIy5HePOvwOHQ9+vQAgg==",
+      "version": "6.0.0-A.1-37376",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-cli/-/adf-cli-6.0.0-A.1-37376.tgz",
+      "integrity": "sha512-sEKwZ9DS4CAzub6oKOmJGFoLzc4esMW4859GnbLVU9V8pBZ+KPIfRECY3AsCrRvbuK7dSM8EQgsrT8KDb9IZDg==",
       "dev": true,
       "requires": {
         "@alfresco/js-api": "5.2.0",
@@ -28,17 +28,17 @@
       }
     },
     "@alfresco/adf-content-services": {
-      "version": "6.0.0-A.1-37352",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-6.0.0-A.1-37352.tgz",
-      "integrity": "sha512-vKtVJDl7WE19WkbB9KHfeka5lnSBOUFAEwjBsSr/UGhNFkQn0zSS1I4CXhjY5h0o+X31JVuIzVLfPqAWiEOZkA==",
+      "version": "6.0.0-A.1-37376",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-6.0.0-A.1-37376.tgz",
+      "integrity": "sha512-QrwadBgJFG4n7iaUJfirhYPEWCO+BD1YiPBlo3+gK9LJvnaHiAiiAFbnXqaa2FY1RlFm6Td6NH0yoHJtwQH+sQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@alfresco/adf-core": {
-      "version": "6.0.0-A.1-37352",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-6.0.0-A.1-37352.tgz",
-      "integrity": "sha512-zGvZkpIYTaUgZLzyGWBK17MCA+HOQbEEefr3V3KisuLFgCXWwD2GyGn1xSba+kp6CDbabGjfTG/2pG0oDk8NeA==",
+      "version": "6.0.0-A.1-37376",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-6.0.0-A.1-37376.tgz",
+      "integrity": "sha512-NryzWdDie9eyrp0a7lC1P+6R0nXp7KzoHfIVrWO1rNhPWBhYgJlRHPP44KBO0/Ydgbio3jvnwZlX15+Kq0/Awg==",
       "requires": {
         "@editorjs/code": "2.7.0",
         "@editorjs/editorjs": "2.25.0",
@@ -56,20 +56,20 @@
       }
     },
     "@alfresco/adf-extensions": {
-      "version": "6.0.0-A.1-37352",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-6.0.0-A.1-37352.tgz",
-      "integrity": "sha512-OcalA6Jl9tr1ynFj9SPbH+i+h4faMpqdFzDza6ZjT2Hquq2Thk5ylzMz+LIHW1FB2wsfKssy9a/409sRHyy1Uw==",
+      "version": "6.0.0-A.1-37376",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-6.0.0-A.1-37376.tgz",
+      "integrity": "sha512-amPdYFRlctYGfKIf1IKt9+SSsVcXOhvOxMsccbN9jI6ShlXBvhBTK+jtItqoJp3GDfWWGU/7RJ0anbZbbQQxTw==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@alfresco/adf-testing": {
-      "version": "6.0.0-A.1-37352",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-testing/-/adf-testing-6.0.0-A.1-37352.tgz",
-      "integrity": "sha512-0T18iLgKq76YzCK+iJwpRie8xrJXmGBM/YZ/OqMwAmyHPt5nUY7Uzy+stBlh/TDC9bULCejf3aZByMP82lT7hg==",
+      "version": "6.0.0-A.1-37376",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-testing/-/adf-testing-6.0.0-A.1-37376.tgz",
+      "integrity": "sha512-WXbpfnKgRHCk7yb/OiWOkJuCvldxRa4vBlP4sRQ4ggoywS85V1yRtJqespoDV/MmYZQ0/ZNXZtVFW8GHzQPOcQ==",
       "dev": true,
       "requires": {
-        "@alfresco/js-api": "5.3.0-466",
+        "@alfresco/js-api": "5.3.0-475",
         "@angular/compiler": "14.1.3",
         "@angular/core": "14.1.3",
         "rxjs": "6.6.6",
@@ -78,9 +78,9 @@
       },
       "dependencies": {
         "@alfresco/js-api": {
-          "version": "5.3.0-466",
-          "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-5.3.0-466.tgz",
-          "integrity": "sha512-ArBqTqEDbzR/jD6YtJTrPQG3Wz69WXURjnzZE8Os+JWUacJS1n/xEqncJY+xDoILuT1EtaEjogOWNYZixUqXlg==",
+          "version": "5.3.0-475",
+          "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-5.3.0-475.tgz",
+          "integrity": "sha512-oNx3f6c7UlEhAry4pOSoXfZV5E53EM10dBXO2O2PrNS1hNJyT/XiWzeFT3szF8pMQWKyHc3fR5JRVThnTnR++A==",
           "dev": true,
           "requires": {
             "event-emitter": "^0.3.5",
@@ -7548,14 +7548,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -11343,16 +11335,6 @@
       "dev": true,
       "requires": {
         "minimatch": "^5.0.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        }
       }
     },
     "image-size": {
@@ -13770,14 +13752,6 @@
             "picomatch": "^2.0.4"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "cacache": {
           "version": "16.1.3",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -14277,14 +14251,6 @@
             "humanize-ms": "^1.2.1"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "cacache": {
           "version": "16.1.2",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.2.tgz",
@@ -14642,14 +14608,6 @@
         "npm-normalize-package-bin": "^1.0.1"
       },
       "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "glob": {
           "version": "8.0.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
@@ -15160,14 +15118,6 @@
             "debug": "^4.1.0",
             "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
           }
         },
         "builtins": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "private": true,
   "dependencies": {
-    "@alfresco/adf-content-services": "6.0.0-A.1-37352",
-    "@alfresco/adf-core": "6.0.0-A.1-37352",
-    "@alfresco/adf-extensions": "6.0.0-A.1-37352",
+    "@alfresco/adf-content-services": "6.0.0-A.1-37376",
+    "@alfresco/adf-core": "6.0.0-A.1-37376",
+    "@alfresco/adf-extensions": "6.0.0-A.1-37376",
     "@alfresco/js-api": "5.2.0",
     "@angular/animations": "14.1.2",
     "@angular/cdk": "14.1.2",
@@ -58,8 +58,8 @@
     "zone.js": "0.11.8"
   },
   "devDependencies": {
-    "@alfresco/adf-cli": "6.0.0-A.1-37352",
-    "@alfresco/adf-testing": "6.0.0-A.1-37352",
+    "@alfresco/adf-cli": "6.0.0-A.1-37376",
+    "@alfresco/adf-testing": "6.0.0-A.1-37376",
     "@angular-custom-builders/lite-serve": "^0.2.3",
     "@angular-devkit/build-angular": "14.1.2",
     "@angular-eslint/builder": "^14.1.2",

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
@@ -52,9 +52,16 @@ export class ToolbarButtonComponent {
   constructor(private extensions: AppExtensionService) {}
 
   runAction() {
+    console.log(1234);
     if (this.hasClickAction(this.actionRef)) {
-      const { click, ...payload } = this.actionRef.actions;
-      this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
+      this.extensions.runActionById(
+        this.actionRef.actions.click,
+        this.actionRef.data?.autoFocusedTriggerAfterModalClose
+          ? {
+              focusedElementOnCloseSelector: `#${this.actionRef.id.replace(/\./g, '\\.')}`
+            }
+          : undefined
+      );
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
@@ -53,7 +53,7 @@ export class ToolbarButtonComponent {
 
   runAction() {
     if (this.hasClickAction(this.actionRef)) {
-      this.extensions.runActionById(this.actionRef.actions.click);
+      this.extensions.runAction(this.actionRef);
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
@@ -52,16 +52,10 @@ export class ToolbarButtonComponent {
   constructor(private extensions: AppExtensionService) {}
 
   runAction() {
-    console.log(1234);
     if (this.hasClickAction(this.actionRef)) {
-      this.extensions.runActionById(
-        this.actionRef.actions.click,
-        this.actionRef.data?.autoFocusedTriggerAfterModalClose
-          ? {
-              focusedElementOnCloseSelector: `#${this.actionRef.id.replace(/\./g, '\\.')}`
-            }
-          : undefined
-      );
+      this.extensions.runActionById(this.actionRef.actions.click, {
+        focusedElementOnCloseSelector: `#${this.actionRef.id.replace(/\./g, '\\.')}`
+      });
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-button/toolbar-button.component.ts
@@ -53,7 +53,8 @@ export class ToolbarButtonComponent {
 
   runAction() {
     if (this.hasClickAction(this.actionRef)) {
-      this.extensions.runAction(this.actionRef);
+      const { click, ...payload } = this.actionRef.actions;
+      this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -44,6 +44,8 @@ import { MatMenuItem } from '@angular/material/menu';
 export class ToolbarMenuItemComponent {
   @Input()
   actionRef: ContentActionRef;
+  @Input()
+  menuId?: string;
 
   @ViewChild(MatMenuItem)
   menuItem: MatMenuItem;
@@ -52,8 +54,14 @@ export class ToolbarMenuItemComponent {
 
   runAction() {
     if (this.hasClickAction(this.actionRef)) {
-      const { click, ...payload } = this.actionRef.actions;
-      this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
+      this.extensions.runActionById(
+        this.actionRef.actions.click,
+        this.actionRef.data?.autoFocusedTriggerAfterModalClose && this.menuId
+          ? {
+              focusedElementOnCloseSelector: `#${this.menuId.replace(/\./g, '\\.')}`
+            }
+          : undefined
+      );
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -56,7 +56,7 @@ export class ToolbarMenuItemComponent {
     if (this.hasClickAction(this.actionRef)) {
       this.extensions.runActionById(
         this.actionRef.actions.click,
-        this.actionRef.data?.autoFocusedTriggerAfterModalClose && this.menuId
+        this.menuId
           ? {
               focusedElementOnCloseSelector: `#${this.menuId.replace(/\./g, '\\.')}`
             }

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -52,7 +52,7 @@ export class ToolbarMenuItemComponent {
 
   runAction() {
     if (this.hasClickAction(this.actionRef)) {
-      this.extensions.runActionById(this.actionRef.actions.click);
+      this.extensions.runAction(this.actionRef);
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -52,7 +52,8 @@ export class ToolbarMenuItemComponent {
 
   runAction() {
     if (this.hasClickAction(this.actionRef)) {
-      this.extensions.runAction(this.actionRef);
+      const { click, ...payload } = this.actionRef.actions;
+      this.extensions.runActionById(click, Object.keys(payload).length ? payload : undefined);
     }
   }
 

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
@@ -18,7 +18,7 @@
         <adf-dynamic-component [id]="child.component" [data]="child.data"></adf-dynamic-component>
       </ng-container>
       <ng-container *ngSwitchDefault>
-        <app-toolbar-menu-item [actionRef]="child"></app-toolbar-menu-item>
+        <app-toolbar-menu-item [actionRef]="child" [menuId]="actionRef.id"></app-toolbar-menu-item>
       </ng-container>
     </ng-container>
   </ng-container>

--- a/projects/aca-shared/src/lib/models/modal-configuration.ts
+++ b/projects/aca-shared/src/lib/models/modal-configuration.ts
@@ -1,0 +1,3 @@
+export interface ModalConfiguration {
+  focusedElementOnCloseSelector?: string;
+}

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -500,6 +500,7 @@ export class AppExtensionService implements RuleContext {
 
   runActionById(id: string) {
     const action = this.extensions.getActionById(id);
+    console.log(action);
     if (action) {
       const { type, payload } = action;
       const context = {
@@ -517,7 +518,7 @@ export class AppExtensionService implements RuleContext {
     const { click, ...payload } = contentActionRef.actions;
     this.store.dispatch({
       type: click,
-      payload
+      payload: Object.keys(payload).length ? payload : undefined
     });
   }
 

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -513,6 +513,14 @@ export class AppExtensionService implements RuleContext {
     }
   }
 
+  runAction(contentActionRef: ContentActionRef) {
+    const { click, ...payload } = contentActionRef.actions;
+    this.store.dispatch({
+      type: click,
+      payload
+    });
+  }
+
   // todo: move to ADF/RuleService
   isRuleDefined(ruleId: string): boolean {
     return !!(ruleId && this.getEvaluator(ruleId));

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -498,9 +498,8 @@ export class AppExtensionService implements RuleContext {
     return false;
   }
 
-  runActionById(id: string) {
+  runActionById(id: string, additionalPayload?: { [key: string]: any }) {
     const action = this.extensions.getActionById(id);
-    console.log(action);
     if (action) {
       const { type, payload } = action;
       const context = {
@@ -508,18 +507,22 @@ export class AppExtensionService implements RuleContext {
       };
       const expression = this.extensions.runExpression(payload, context);
 
-      this.store.dispatch({ type, payload: expression });
+      this.store.dispatch({
+        type,
+        payload:
+          typeof expression === 'object'
+            ? {
+                ...expression,
+                ...additionalPayload
+              }
+            : expression
+      });
     } else {
-      this.store.dispatch({ type: id });
+      this.store.dispatch({
+        type: id,
+        payload: additionalPayload
+      });
     }
-  }
-
-  runAction(contentActionRef: ContentActionRef) {
-    const { click, ...payload } = contentActionRef.actions;
-    this.store.dispatch({
-      type: click,
-      payload: Object.keys(payload).length ? payload : undefined
-    });
   }
 
   // todo: move to ADF/RuleService

--- a/projects/aca-shared/src/public-api.ts
+++ b/projects/aca-shared/src/public-api.ts
@@ -48,6 +48,7 @@ export * from './lib/directives/shared.directives.module';
 
 export * from './lib/models/types';
 export * from './lib/models/viewer.rules';
+export * from './lib/models/modal-configuration';
 
 export * from './lib/routing/shared.guard';
 

--- a/projects/aca-shared/store/src/actions/library.actions.ts
+++ b/projects/aca-shared/store/src/actions/library.actions.ts
@@ -59,5 +59,5 @@ export class UpdateLibraryAction implements Action {
 export class LeaveLibraryAction implements Action {
   readonly type = LibraryActionTypes.Leave;
 
-  constructor(public payload?: string) {}
+  constructor(public payload?: string | { focusedElementOnCloseSelector: string }) {}
 }

--- a/projects/aca-shared/store/src/actions/library.actions.ts
+++ b/projects/aca-shared/store/src/actions/library.actions.ts
@@ -25,6 +25,7 @@
 
 import { Action } from '@ngrx/store';
 import { SiteBody } from '@alfresco/js-api';
+import { ModalConfiguration } from '@alfresco/aca-shared';
 
 export enum LibraryActionTypes {
   Delete = 'DELETE_LIBRARY',
@@ -59,5 +60,5 @@ export class UpdateLibraryAction implements Action {
 export class LeaveLibraryAction implements Action {
   readonly type = LibraryActionTypes.Leave;
 
-  constructor(public payload?: string | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload?: string | ModalConfiguration) {}
 }

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -25,6 +25,7 @@
 
 import { Action } from '@ngrx/store';
 import { MinimalNodeEntity } from '@alfresco/js-api';
+import { ModalConfiguration } from '@alfresco/aca-shared';
 
 export enum NodeActionTypes {
   SetSelection = 'SET_SELECTED_NODES',
@@ -84,7 +85,7 @@ export class PurgeDeletedNodesAction implements Action {
 export class DownloadNodesAction implements Action {
   readonly type = NodeActionTypes.Download;
 
-  constructor(public payload: MinimalNodeEntity[] | { focusedElementOnCloseSelector: string } = []) {}
+  constructor(public payload: MinimalNodeEntity[] | ModalConfiguration = []) {}
 }
 
 export class CreateFolderAction implements Action {
@@ -96,13 +97,13 @@ export class CreateFolderAction implements Action {
 export class EditFolderAction implements Action {
   readonly type = NodeActionTypes.EditFolder;
 
-  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & ModalConfiguration) {}
 }
 
 export class ShareNodeAction implements Action {
   readonly type = NodeActionTypes.Share;
 
-  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & ModalConfiguration) {}
 }
 
 export class UnshareNodesAction implements Action {
@@ -114,13 +115,13 @@ export class UnshareNodesAction implements Action {
 export class CopyNodesAction implements Action {
   readonly type = NodeActionTypes.Copy;
 
-  constructor(public payload: Array<MinimalNodeEntity> | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: Array<MinimalNodeEntity> | ModalConfiguration) {}
 }
 
 export class MoveNodesAction implements Action {
   readonly type = NodeActionTypes.Move;
 
-  constructor(public payload: Array<MinimalNodeEntity> | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: Array<MinimalNodeEntity> | ModalConfiguration) {}
 }
 
 export class ManagePermissionsAction implements Action {
@@ -143,7 +144,7 @@ export class PrintFileAction implements Action {
 export class ManageVersionsAction implements Action {
   readonly type = NodeActionTypes.ManageVersions;
 
-  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & ModalConfiguration) {}
 }
 
 export class EditOfflineAction implements Action {
@@ -172,7 +173,7 @@ export class RemoveFavoriteAction implements Action {
 export class ManageAspectsAction implements Action {
   readonly type = NodeActionTypes.ChangeAspects;
 
-  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & ModalConfiguration) {}
 }
 
 export class ManageRulesAction implements Action {

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -84,7 +84,7 @@ export class PurgeDeletedNodesAction implements Action {
 export class DownloadNodesAction implements Action {
   readonly type = NodeActionTypes.Download;
 
-  constructor(public payload: MinimalNodeEntity[] = []) {}
+  constructor(public payload: MinimalNodeEntity[] | { focusedElementOnCloseSelector: string } = []) {}
 }
 
 export class CreateFolderAction implements Action {

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -96,13 +96,13 @@ export class CreateFolderAction implements Action {
 export class EditFolderAction implements Action {
   readonly type = NodeActionTypes.EditFolder;
 
-  constructor(public payload: MinimalNodeEntity) {}
+  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
 }
 
 export class ShareNodeAction implements Action {
   readonly type = NodeActionTypes.Share;
 
-  constructor(public payload: MinimalNodeEntity) {}
+  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
 }
 
 export class UnshareNodesAction implements Action {
@@ -114,13 +114,13 @@ export class UnshareNodesAction implements Action {
 export class CopyNodesAction implements Action {
   readonly type = NodeActionTypes.Copy;
 
-  constructor(public payload: Array<MinimalNodeEntity>) {}
+  constructor(public payload: Array<MinimalNodeEntity> | { focusedElementOnCloseSelector: string }) {}
 }
 
 export class MoveNodesAction implements Action {
   readonly type = NodeActionTypes.Move;
 
-  constructor(public payload: Array<MinimalNodeEntity>) {}
+  constructor(public payload: Array<MinimalNodeEntity> | { focusedElementOnCloseSelector: string }) {}
 }
 
 export class ManagePermissionsAction implements Action {
@@ -143,7 +143,7 @@ export class PrintFileAction implements Action {
 export class ManageVersionsAction implements Action {
   readonly type = NodeActionTypes.ManageVersions;
 
-  constructor(public payload: MinimalNodeEntity) {}
+  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
 }
 
 export class EditOfflineAction implements Action {
@@ -172,7 +172,7 @@ export class RemoveFavoriteAction implements Action {
 export class ManageAspectsAction implements Action {
   readonly type = NodeActionTypes.ChangeAspects;
 
-  constructor(public payload: MinimalNodeEntity) {}
+  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
 }
 
 export class ManageRulesAction implements Action {

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -96,7 +96,7 @@ export class CreateFolderAction implements Action {
 export class EditFolderAction implements Action {
   readonly type = NodeActionTypes.EditFolder;
 
-  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
 }
 
 export class ShareNodeAction implements Action {
@@ -143,7 +143,7 @@ export class PrintFileAction implements Action {
 export class ManageVersionsAction implements Action {
   readonly type = NodeActionTypes.ManageVersions;
 
-  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
 }
 
 export class EditOfflineAction implements Action {
@@ -172,7 +172,7 @@ export class RemoveFavoriteAction implements Action {
 export class ManageAspectsAction implements Action {
   readonly type = NodeActionTypes.ChangeAspects;
 
-  constructor(public payload: MinimalNodeEntity | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: MinimalNodeEntity & { focusedElementOnCloseSelector: string }) {}
 }
 
 export class ManageRulesAction implements Action {

--- a/projects/aca-shared/store/src/actions/upload.actions.ts
+++ b/projects/aca-shared/store/src/actions/upload.actions.ts
@@ -24,6 +24,7 @@
  */
 
 import { Action } from '@ngrx/store';
+import { ModalConfiguration } from '@alfresco/aca-shared';
 
 export enum UploadActionTypes {
   UploadFiles = 'UPLOAD_FILES',
@@ -46,5 +47,5 @@ export class UploadFolderAction implements Action {
 export class UploadFileVersionAction implements Action {
   readonly type = UploadActionTypes.UploadFileVersion;
 
-  constructor(public payload: CustomEvent | { focusedElementOnCloseSelector: string }) {}
+  constructor(public payload: CustomEvent | ModalConfiguration) {}
 }

--- a/projects/aca-shared/store/src/actions/upload.actions.ts
+++ b/projects/aca-shared/store/src/actions/upload.actions.ts
@@ -46,5 +46,5 @@ export class UploadFolderAction implements Action {
 export class UploadFileVersionAction implements Action {
   readonly type = UploadActionTypes.UploadFileVersion;
 
-  constructor(public payload: CustomEvent) {}
+  constructor(public payload: CustomEvent | { focusedElementOnCloseSelector: string }) {}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Modals which were opened from personal files/libraries list or toolbar or more menu, after closing, were not returning focus to element from which they were opened. 


**What is the new behaviour?**
After closing modals opened from personal files/libraries or toolbar or more menu, focus is returned to correct element. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ADF PR: https://github.com/Alfresco/alfresco-ng2-components/pull/8034
APPS PR: https://github.com/Alfresco/alfresco-apps/pull/4630