### PR TITLE
[ACS-4146] Folder Rules bug fix: An empty list for a child folder is displayed instead of an empty content template

### DIFF
--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.html
@@ -57,7 +57,7 @@
           </adf-toolbar>
           <mat-divider></mat-divider>
 
-          <div class="aca-manage-rules__container" *ngIf="(mainRuleSet$ | async) || (inheritedRuleSets$ | async).length > 0; else emptyContent">
+          <div class="aca-manage-rules__container" *ngIf="(mainRuleSet$ | async) || isInheritedRuleSetsNotEmpty(inheritedRuleSets$ | async); else emptyContent">
             <aca-rule-list
               [mainRuleSet]="mainRuleSet$ | async"
               [folderId]="nodeId"

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.spec.ts
@@ -30,7 +30,7 @@ import { CoreTestingModule } from '@alfresco/adf-core';
 import { FolderRulesService } from '../services/folder-rules.service';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
-import { inheritedRuleSetMock, ownedRuleSetMock, ruleSetWithLinkMock } from '../mock/rule-sets.mock';
+import { inheritedRuleSetMock, ownedRuleSetMock, ruleSetsWithEmptyRulesMock, ruleSetWithLinkMock } from '../mock/rule-sets.mock';
 import { By } from '@angular/platform-browser';
 import { owningFolderIdMock, owningFolderMock } from '../mock/node.mock';
 import { MatDialog } from '@angular/material/dialog';
@@ -100,7 +100,7 @@ describe('ManageRulesSmartComponent', () => {
   it('should only show adf-empty-content if node has no rules defined yet', () => {
     folderRuleSetsService.folderInfo$ = of(owningFolderMock);
     folderRuleSetsService.mainRuleSet$ = of(null);
-    folderRuleSetsService.inheritedRuleSets$ = of([]);
+    folderRuleSetsService.inheritedRuleSets$ = of(ruleSetsWithEmptyRulesMock);
     folderRuleSetsService.isLoading$ = of(false);
     actionsService.loading$ = of(false);
 

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -243,6 +243,7 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
   }
 
   isInheritedRuleSetsNotEmpty(inheritedRuleSets: RuleSet[]): boolean {
+    console.log(inheritedRuleSets);
     return inheritedRuleSets.filter((ruleSet) => ruleSet.rules.length > 0).length > 0;
   }
 }

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -243,7 +243,6 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
   }
 
   isInheritedRuleSetsNotEmpty(inheritedRuleSets: RuleSet[]): boolean {
-    console.log(inheritedRuleSets);
     return inheritedRuleSets.filter((ruleSet) => ruleSet.rules.length > 0).length > 0;
   }
 }

--- a/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-folder-rules/src/lib/manage-rules/manage-rules.smart-component.ts
@@ -241,4 +241,8 @@ export class ManageRulesSmartComponent implements OnInit, OnDestroy {
         }
       });
   }
+
+  isInheritedRuleSetsNotEmpty(inheritedRuleSets: RuleSet[]): boolean {
+    return inheritedRuleSets.filter((ruleSet) => ruleSet.rules.length > 0).length > 0;
+  }
 }

--- a/projects/aca-folder-rules/src/lib/mock/rule-sets.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/rule-sets.mock.ts
@@ -115,4 +115,16 @@ export const inheritedRuleSetMock: RuleSet = {
   loadingRules: false
 };
 
+export const inheritedRuleSetWithEmptyRulesMock: RuleSet = {
+  id: 'inherited-rule-set',
+  isLinkedTo: false,
+  owningFolder: otherFolderMock,
+  linkedToBy: [],
+  rules: [],
+  hasMoreRules: false,
+  loadingRules: false
+};
+
 export const ruleSetsMock: RuleSet[] = [inheritedRuleSetMock, ownedRuleSetMock, ruleSetWithLinkMock];
+
+export const ruleSetsWithEmptyRulesMock: RuleSet[] = [inheritedRuleSetWithEmptyRulesMock];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

In case if parent folder have non-inheritable rule, and child folder has no own or linked rules - empty rules list is shown instead of empty content template.
https://alfresco.atlassian.net/browse/ACS-4146
![image](https://user-images.githubusercontent.com/84377976/205915645-f19a8c90-d8ba-462d-9372-eb386f34efec.png)

**What is the new behaviour?**

In case if parent folder have non-inheritable rule, and child folder has no own or linked rules - empty content template will be displayed for child folder's Manage Rules screen.
<img width="1044" alt="Screenshot 2022-12-06 at 13 43 07" src="https://user-images.githubusercontent.com/84377976/205915848-8bcc636d-bbb7-4b91-855e-3856d88ce246.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
