### PR TITLE
[ACA-4625] Add ADF linking to unit tests and e2es

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,29 +71,29 @@ jobs:
 
     - stage: Quality and Unit tests
       name: 'Unit tests: aos'
-      script: npm ci && ng test adf-office-services-ext
+      script: npm ci && ng test adf-office-services-ext $TEST_OPTS
       cache: false
 
     - stage: Quality and Unit tests
       name: 'Unit tests: aca-shared'
-      script: npm ci && ng test aca-shared
+      script: npm ci && ng test aca-shared $TEST_OPTS
       cache: false
 
     - stage: Quality and Unit tests
       name: 'Unit tests: aca-settings'
-      script: npm ci && ng test aca-settings
+      script: npm ci && ng test aca-settings $TEST_OPTS
       cache: false
 
     - stage: Quality and Unit tests
       name: 'Unit tests: aca-folder-rules'
-      script: npm ci && ng test aca-folder-rules
+      script: npm ci && ng test aca-folder-rules $TEST_OPTS
       cache: false
 
     - stage: Quality and Unit tests
       name: 'Unit tests: ACA'
       script:
         - npm ci
-        - ng test content-ce
+        - ng test content-ce $TEST_OPTS
       cache: false
 
     - stage: e2e

--- a/angular.json
+++ b/angular.json
@@ -307,6 +307,11 @@
                 "output": "/"
               }
             ]
+          },
+          "configurations": {
+            "adfprod": {
+              "tsConfig": "app/tsconfig.spec.adf.json"
+            }
           }
         },
         "lint": {
@@ -387,6 +392,11 @@
             "main": "projects/adf-office-services-ext/src/test.ts",
             "tsConfig": "projects/adf-office-services-ext/tsconfig.spec.json",
             "karmaConfig": "projects/adf-office-services-ext/karma.conf.js"
+          },
+          "configurations": {
+            "adfprod": {
+              "tsConfig": "projects/adf-office-services-ext/tsconfig.spec.adf.json"
+            }
           }
         },
         "lint": {
@@ -427,6 +437,11 @@
             "main": "projects/aca-shared/test.ts",
             "tsConfig": "projects/aca-shared/tsconfig.spec.json",
             "karmaConfig": "projects/aca-shared/karma.conf.js"
+          },
+          "configurations": {
+            "adfprod": {
+              "tsConfig": "projects/aca-shared/tsconfig.spec.adf.json"
+            }
           }
         },
         "lint": {
@@ -513,6 +528,11 @@
             "main": "projects/aca-settings/src/test.ts",
             "tsConfig": "projects/aca-settings/tsconfig.spec.json",
             "karmaConfig": "projects/aca-settings/karma.conf.js"
+          },
+          "configurations": {
+            "adfprod": {
+              "tsConfig": "projects/aca-settings/tsconfig.spec.adf.json"
+            }
           }
         },
         "lint": {
@@ -553,6 +573,11 @@
             "main": "projects/aca-folder-rules/src/test.ts",
             "tsConfig": "projects/aca-folder-rules/tsconfig.spec.json",
             "karmaConfig": "projects/aca-folder-rules/karma.conf.js"
+          },
+          "configurations": {
+            "adfprod": {
+              "tsConfig": "projects/aca-folder-rules/tsconfig.spec.adf.json"
+            }
           }
         },
         "lint": {

--- a/app/tsconfig.spec.adf.json
+++ b/app/tsconfig.spec.adf.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.adf.json",
+  "extends": "../tsconfig.adf.json",
   "compilerOptions": {
       "outDir": "../out-tsc/spec",
       "module": "commonjs"

--- a/e2e/tsconfig.e2e.adf.json
+++ b/e2e/tsconfig.e2e.adf.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.adf.json",
+  "compilerOptions": {
+    "outDir": "../out-tsc/e2e",
+    "baseUrl": "./",
+    "module": "commonjs",
+    "target": "es2017",
+    "types": ["jasmine", "jasminewd2", "node"],
+    "skipLibCheck": true,
+    "paths": {
+      "@alfresco/aca-testing-shared": ["../projects/aca-testing-shared"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/projects/aca-folder-rules/tsconfig.spec.adf.json
+++ b/projects/aca-folder-rules/tsconfig.spec.adf.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.adf.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/projects/aca-settings/tsconfig.spec.adf.json
+++ b/projects/aca-settings/tsconfig.spec.adf.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.adf.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/projects/aca-shared/tsconfig.spec.adf.json
+++ b/projects/aca-shared/tsconfig.spec.adf.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.adf.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/projects/adf-office-services-ext/tsconfig.spec.adf.json
+++ b/projects/adf-office-services-ext/tsconfig.spec.adf.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.adf.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -22,6 +22,8 @@ const SAVE_SCREENSHOT = process.env.SAVE_SCREENSHOT === 'true';
 const APP_CONFIG_ECM_HOST = process.env.APP_CONFIG_ECM_HOST || 'http://localhost:8080';
 const MAXINSTANCES = process.env.MAXINSTANCES || 1;
 const E2E_LOG_LEVEL = process.env.E2E_LOG_LEVEL || 'ERROR';
+const E2E_TS_CONFIG_FOR_ADF = 'tsconfig.e2e.adf.json';
+const LOCAL_ADF_OPTION = '--with-local-adf';
 
 
 const appConfig = {
@@ -170,7 +172,8 @@ exports.config = {
       smartRunnerFactory.getInstance().onPrepare();
     }
 
-    const tsConfigPath = path.resolve(e2eFolder, 'tsconfig.e2e.json');
+    const withLocalAdf = process.argv.indexOf(LOCAL_ADF_OPTION) !== -1;
+    const tsConfigPath = path.resolve(e2eFolder, withLocalAdf ? E2E_TS_CONFIG_FOR_ADF : 'tsconfig.e2e.json');
     const tsConfig = require(tsConfigPath);
 
     require('ts-node').register({

--- a/scripts/ci/job_hooks/before_install.sh
+++ b/scripts/ci/job_hooks/before_install.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-# Build options -----------------------------------------------------------------------
+# Build and test options -----------------------------------------------------------------------
 export BUILD_OPTS="--configuration=production,e2e"
+export TEST_OPTS=""
+export E2E_PROTRACTOR_OPTS=""
+export E2E_TSCONFIG="tsconfig.e2e.json"
 
 # Commit settings for ADF linking -----------------------------------------------------
 export HEAD_COMMIT_HASH=${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}

--- a/scripts/ci/jobs/affected-project-with.sh
+++ b/scripts/ci/jobs/affected-project-with.sh
@@ -29,6 +29,6 @@ done
 echo "Run alfresco-content-e2e protractor with options $OPTIONS"
 echo "./node_modules/.bin/protractor \"./protractor.conf.js\" $OPTIONS || exit 1"
 
-./node_modules/.bin/tsc -p "./e2e/tsconfig.e2e.json" || exit 1;
+./node_modules/.bin/tsc -p "./e2e/$E2E_TSCONFIG" || exit 1;
 ./node_modules/.bin/http-server -c-1 $CONTENT_CE_DIST_PATH -p 4200 > /dev/null &\
-./node_modules/.bin/protractor "./protractor.conf.js" $OPTIONS || exit 1
+./node_modules/.bin/protractor "./protractor.conf.js" $OPTIONS $E2E_PROTRACTOR_OPTS || exit 1

--- a/scripts/ci/partials/_adf-linking.sh
+++ b/scripts/ci/partials/_adf-linking.sh
@@ -6,6 +6,9 @@
 # ---------------------------------------------------------------
 if [[ $COMMIT_MESSAGE == *"[link-adf:"* ]]; then
     export BUILD_OPTS="--configuration=adfprod,e2e"
+    export TEST_OPTS="--configuration=adfprod"
+    export E2E_PROTRACTOR_OPTS="--with-local-adf"
+    export E2E_TSCONFIG="tsconfig.e2e.adf.json"
     BRANCH=`echo $COMMIT_MESSAGE | grep -o "\[link-adf\:[^]]*\]" | sed -e 's#\[link-adf:##g' | sed -e 's#\]##g'`
     echo "Checking out ADF's branch: ${BRANCH}" && \
     git clone https://github.com/Alfresco/alfresco-ng2-components.git --depth=1 --branch ${BRANCH} ../alfresco-ng2-components


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

ADF linking in ACA is running only with build. https://alfresco.atlassian.net/browse/ACA-4625


**What is the new behaviour?**

Added options to link ADF to unit tests and e2es as well.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
