### PR TITLE
[ACA-4645] Fix for shareActions e2es

### DIFF
--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -1,16 +1,5 @@
 {
   "C589205": "https://alfresco.atlassian.net/browse/ACA-4353",
   "C261153": "https://alfresco.atlassian.net/browse/AAE-7517",
-  "C306959": "https://alfresco.atlassian.net/browse/ACA-4620",
-  "C286330": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C286332": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C286337": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C286333": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C286335": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C286345": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C306996": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C306997": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C306999": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C306998": "https://alfresco.atlassian.net/browse/ACA-4645",
-  "C307000": "https://alfresco.atlassian.net/browse/ACA-4645"
+  "C306959": "https://alfresco.atlassian.net/browse/ACA-4620"
 }

--- a/e2e/suites/actions/share/share-file.test.ts
+++ b/e2e/suites/actions/share/share-file.test.ts
@@ -211,7 +211,7 @@ describe('Share a file', () => {
 
       it('[C286337] Expire date is displayed correctly', async () => {
         await dataTable.selectItem(file6);
-        await BrowserActions.click(toolbar.shareEditButton);
+        await BrowserActions.click(toolbar.shareButton);
         await shareDialog.waitForDialogToOpen();
 
         const expireProperty = await apis.user.nodes.getSharedExpiryDate(file6Id);
@@ -222,7 +222,7 @@ describe('Share a file', () => {
 
       it('[C286333] Disable the share link expiration', async () => {
         await dataTable.selectItem(file7);
-        await BrowserActions.click(toolbar.shareEditButton);
+        await BrowserActions.click(toolbar.shareButton);
         await shareDialog.waitForDialogToOpen();
 
         expect(await shareDialog.isExpireToggleEnabled()).toBe(true, 'Expiration is not checked');
@@ -246,7 +246,7 @@ describe('Share a file', () => {
 
         await page.dataTable.clearSelection();
         await dataTable.selectItem(file8);
-        await BrowserActions.click(toolbar.shareEditButton);
+        await BrowserActions.click(toolbar.shareButton);
         await shareDialog.waitForDialogToOpen();
         const url2 = await shareDialog.getLinkUrl();
 

--- a/e2e/suites/actions/share/share-file.test.ts
+++ b/e2e/suites/actions/share/share-file.test.ts
@@ -90,7 +90,10 @@ describe('Share a file', () => {
   });
 
   describe('when logged in', () => {
-    const expiryDate: any = '2022-12-25T18:30:00.000+0000';
+    const expiryDateObj: Date = new Date();
+    expiryDateObj.setFullYear(expiryDateObj.getFullYear() + 1);
+    const expiryDate: any = expiryDateObj.toISOString().replace('Z', '+0000');
+    // const expiryDate: any = '2022-12-25T18:30:00.000+0000';
 
     const loginPage = new LoginPage();
     const shareDialog = new ShareDialog();

--- a/e2e/suites/actions/share/share-file.test.ts
+++ b/e2e/suites/actions/share/share-file.test.ts
@@ -93,7 +93,6 @@ describe('Share a file', () => {
     const expiryDateObj: Date = new Date();
     expiryDateObj.setFullYear(expiryDateObj.getFullYear() + 1);
     const expiryDate: any = expiryDateObj.toISOString().replace('Z', '+0000');
-    // const expiryDate: any = '2022-12-25T18:30:00.000+0000';
 
     const loginPage = new LoginPage();
     const shareDialog = new ShareDialog();

--- a/e2e/suites/actions/share/unshare-file-search-results.test.ts
+++ b/e2e/suites/actions/share/unshare-file-search-results.test.ts
@@ -130,7 +130,7 @@ describe('Unshare a file from Search Results', () => {
     await dataTable.waitForBody();
 
     await dataTable.selectItem(file1);
-    await BrowserActions.click(toolbar.shareEditButton);
+    await BrowserActions.click(toolbar.shareButton);
     await shareDialog.waitForDialogToOpen();
 
     expect(await shareDialog.isShareToggleChecked()).toBe(true, 'Share toggle not checked');
@@ -150,7 +150,7 @@ describe('Unshare a file from Search Results', () => {
     await dataTable.waitForBody();
 
     await dataTable.selectItem(file2);
-    await BrowserActions.click(toolbar.shareEditButton);
+    await BrowserActions.click(toolbar.shareButton);
     await shareDialog.waitForDialogToOpen();
     const url = await shareDialog.getLinkUrl();
     await BrowserActions.click(shareDialog.shareToggle);
@@ -176,7 +176,7 @@ describe('Unshare a file from Search Results', () => {
     await dataTable.waitForBody();
 
     await dataTable.selectItem(file3);
-    await BrowserActions.click(toolbar.shareEditButton);
+    await BrowserActions.click(toolbar.shareButton);
     await shareDialog.waitForDialogToOpen();
 
     const urlBefore = await shareDialog.getLinkUrl();
@@ -225,7 +225,7 @@ describe('Unshare a file from Search Results', () => {
     await searchInput.searchFor(fileSite1);
     await dataTable.waitForBody();
     await dataTable.selectItem(fileSite1);
-    await BrowserActions.click(toolbar.shareEditButton);
+    await BrowserActions.click(toolbar.shareButton);
     await shareDialog.waitForDialogToOpen();
 
     expect(await shareDialog.isShareToggleDisabled()).toBe(false, 'Share toggle disabled for consumer');
@@ -244,7 +244,7 @@ describe('Unshare a file from Search Results', () => {
     await searchInput.searchFor(fileSite2);
     await dataTable.waitForBody();
     await dataTable.selectItem(fileSite2);
-    await BrowserActions.click(toolbar.shareEditButton);
+    await BrowserActions.click(toolbar.shareButton);
     await shareDialog.waitForDialogToOpen();
 
     expect(await shareDialog.isShareToggleDisabled()).toBe(false, 'Share toggle disabled for consumer');

--- a/projects/aca-testing-shared/src/components/toolbar/toolbar.ts
+++ b/projects/aca-testing-shared/src/components/toolbar/toolbar.ts
@@ -33,8 +33,7 @@ export class Toolbar extends Component {
   menu = new Menu();
 
   buttons = this.allByCss('button');
-  shareButton = this.byCss(`.mat-icon-button[title='Share']`);
-  shareEditButton = this.byCss(`.mat-icon-button[title='Shared Link Settings']`);
+  shareButton = this.byId('share-action-button');
   viewButton = this.byCss(`.mat-icon-button[title='View']`);
   downloadButton = this.byCss(`.mat-icon-button[title='Download']`);
   editFolderButton = this.byId('app.toolbar.editFolder');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4645

**What is the new behaviour?**

Running the e2e tests on local using the acadev environment:
- An expiry date in the past was causing the tests of the `share-file.test.ts` to fail. (Tests C286330, C286332, C286337, C286333, C286335, C286345)
- All the tests in the `unshare-file-search-results.test.ts` appear to pass without any changes needed. (Tests C306996, C306997, C306999, C306998, C307000)
- Test C286329, which wasn't included in the Jira as one of the failing tests, was also previously failing, but only when run alongside other test cases. This is because a test that would run before it would press on the button to create a link on a file, then this test would attempt to press on the button to create a link also, which fails because the file already has a link and the button had changed to an edit link button. The button for creating and editing is actually the same but the css selector used to select was different, this has been changed to fix it. The reason this test case was not listed before was because the CI would rerun any failed test cases, and this one would get a chance to run by itself, meaning it would eventually pass and never actually block any builds.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
