### PR TITLE
[ACA-4633] Fix error script dropdown sometimes not having a label

### DIFF
--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.html
@@ -7,7 +7,11 @@
       {{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.IS_ASYNCHRONOUS' | translate }}
     </mat-checkbox>
 
-    <mat-form-field [ngClass]="{ 'hide-error-script-dropdown': hideErrorScriptDropdown }">
+    <mat-form-field
+      data-automation-id="rule-option-form-field-errorScript"
+      floatLabel="always"
+      [ngClass]="{ 'hide-error-script-dropdown': hideErrorScriptDropdown }">
+
       <mat-select
         formControlName="errorScript"
         placeholder="{{ 'ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.ERROR_SCRIPT' | translate}}"
@@ -23,6 +27,7 @@
         </ng-template>
 
       </mat-select>
+
     </mat-form-field>
   </div>
 

--- a/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/options/rule-options.ui-component.spec.ts
@@ -30,6 +30,7 @@ import { RuleOptionsUiComponent } from './rule-options.ui-component';
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { errorScriptConstraintMock } from '../../mock/actions.mock';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 describe('RuleOptionsUiComponent', () => {
   let fixture: ComponentFixture<RuleOptionsUiComponent>;
@@ -46,7 +47,8 @@ describe('RuleOptionsUiComponent', () => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [FormsModule, ReactiveFormsModule, CoreTestingModule],
-      declarations: [RuleOptionsUiComponent]
+      declarations: [RuleOptionsUiComponent],
+      providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { floatLabel: 'never' } }]
     });
 
     fixture = TestBed.createComponent(RuleOptionsUiComponent);
@@ -132,5 +134,21 @@ describe('RuleOptionsUiComponent', () => {
     expect((matOptions[0].nativeElement as HTMLElement).innerText.trim()).toBe('ACA_FOLDER_RULES.RULE_DETAILS.OPTIONS.NO_SCRIPT');
     expect((matOptions[1].nativeElement as HTMLElement).innerText.trim()).toBe('Script 1');
     expect((matOptions[2].nativeElement as HTMLElement).innerText.trim()).toBe('Script 2');
+  });
+
+  it('should always show a label for the error script dropdown even when MAT_FORM_FIELD_DEFAULT_OPTIONS sets floatLabel to never', () => {
+    component.writeValue({
+      isEnabled: true,
+      isInheritable: false,
+      isAsynchronous: true,
+      errorScript: ''
+    });
+    component.errorScriptConstraint = errorScriptConstraintMock;
+    fixture.detectChanges();
+
+    const matFormField = fixture.debugElement.query(By.css(`[data-automation-id="rule-option-form-field-errorScript"] .mat-form-field-label`));
+    fixture.detectChanges();
+    expect(matFormField).not.toBeNull();
+    expect(matFormField.componentInstance['floatLabel']).toBe('always');
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4633

**What is the new behaviour?**

Label should always be visible regardless of the form field default option.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
