### PR TITLE
[ACS-4417] fix the shared link datetime picker defaults

### DIFF
--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -32,7 +32,7 @@
     "copyright": "APP.COPYRIGHT"
   },
   "viewer.maxRetries": 1,
-  "sharedLinkDateTimePickerType": "date",
+  "sharedLinkDateTimePickerType": "datetime",
   "headerColor": "#ffffff",
   "headerTextColor": "#000000",
   "customCssPath": "",

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -1,5 +1,6 @@
 {
   "C589205": "https://alfresco.atlassian.net/browse/ACA-4353",
   "C261153": "https://alfresco.atlassian.net/browse/AAE-7517",
-  "C306959": "https://alfresco.atlassian.net/browse/ACA-4620"
+  "C306959": "https://alfresco.atlassian.net/browse/ACA-4620",
+  "C286332": "https://alfresco.atlassian.net/browse/ACS-4425"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

time picker is not available

**What is the new behaviour?**

fix the regression: datetime mode for share link dialog

<img width="617" alt="Screenshot 2023-01-17 at 12 41 43" src="https://user-images.githubusercontent.com/503991/212972671-d56ec022-fa6e-4e8f-a017-d9713e273f96.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-4417