### PR TITLE
[ACS-4251] Added keyboard navigation for toolbar menu items

### DIFF
--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
@@ -12,14 +12,19 @@
 </button>
 
 <mat-menu #menu="matMenu" [overlapTrigger]="false">
-  <ng-container *ngFor="let child of actionRef.children; trackBy: trackByActionId">
-    <ng-container [ngSwitch]="child.type">
+  <ng-container *ngFor="let child of actionRef.children; trackBy: trackByActionId" [ngSwitch]="child.type">
       <ng-container *ngSwitchCase="'custom'">
-        <adf-dynamic-component [id]="child.component" [data]="child.data"></adf-dynamic-component>
+        <button mat-menu-item style="padding: 0" (click)="onCustomItemContainerClick($event)">
+          <adf-dynamic-component [id]="child.component" [data]="child.data"></adf-dynamic-component>
+        </button>
       </ng-container>
-      <ng-container *ngSwitchDefault>
+      <ng-container *ngSwitchCase="'separator'">
         <app-toolbar-menu-item [actionRef]="child" [menuId]="actionRef.id"></app-toolbar-menu-item>
       </ng-container>
-    </ng-container>
+      <ng-container *ngSwitchDefault>
+        <button mat-menu-item style="padding: 0" (click)="onCustomItemContainerClick($event)">
+          <app-toolbar-menu-item [actionRef]="child" [menuId]="actionRef.id"></app-toolbar-menu-item>
+        </button>
+      </ng-container>
   </ng-container>
 </mat-menu>

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.html
@@ -12,9 +12,10 @@
 </button>
 
 <mat-menu #menu="matMenu" [overlapTrigger]="false">
-  <ng-container *ngFor="let child of actionRef.children; trackBy: trackByActionId" [ngSwitch]="child.type">
+  <ng-container *ngFor="let child of actionRef.children; trackBy: trackByActionId">
+    <ng-container [ngSwitch]="child.type">
       <ng-container *ngSwitchCase="'custom'">
-        <button mat-menu-item style="padding: 0" (click)="onCustomItemContainerClick($event)">
+        <button mat-menu-item class="aca-mat-menu-item-container" (click)="onCustomItemContainerClick($event)">
           <adf-dynamic-component [id]="child.component" [data]="child.data"></adf-dynamic-component>
         </button>
       </ng-container>
@@ -22,9 +23,10 @@
         <app-toolbar-menu-item [actionRef]="child" [menuId]="actionRef.id"></app-toolbar-menu-item>
       </ng-container>
       <ng-container *ngSwitchDefault>
-        <button mat-menu-item style="padding: 0" (click)="onCustomItemContainerClick($event)">
+        <button mat-menu-item class="aca-mat-menu-item-container" (click)="onCustomItemContainerClick($event)">
           <app-toolbar-menu-item [actionRef]="child" [menuId]="actionRef.id"></app-toolbar-menu-item>
         </button>
       </ng-container>
+    </ng-container>
   </ng-container>
 </mat-menu>

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
@@ -23,9 +23,9 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList, AfterViewInit } from '@angular/core';
+import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList } from '@angular/core';
 import { ContentActionRef } from '@alfresco/adf-extensions';
-import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
 import { ThemePalette } from '@angular/material/core';
 import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item.component';
 
@@ -35,7 +35,7 @@ import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-toolbar-menu' }
 })
-export class ToolbarMenuComponent implements AfterViewInit {
+export class ToolbarMenuComponent {
   @Input()
   actionRef: ContentActionRef;
 
@@ -56,20 +56,14 @@ export class ToolbarMenuComponent implements AfterViewInit {
     this.matTrigger.closeMenu();
   }
 
-  ngAfterViewInit(): void {
-    const menuItems: MatMenuItem[] = [];
-    this.toolbarMenuItems.forEach((toolbarMenuItem: ToolbarMenuItemComponent) => {
-      if (toolbarMenuItem.menuItem !== undefined) {
-        menuItems.push(toolbarMenuItem.menuItem);
-      }
-    });
-    const menuItemsQueryList: QueryList<MatMenuItem> = new QueryList<MatMenuItem>();
-    menuItemsQueryList.reset(menuItems);
-    this.menu._allItems = menuItemsQueryList;
-    this.menu.ngAfterContentInit();
-  }
-
   trackByActionId(_: number, obj: ContentActionRef): string {
     return obj.id;
+  }
+
+  onCustomItemContainerClick(event) {
+    console.log(event);
+    const el: HTMLElement = event.target;
+    const ev = new MouseEvent('click');
+    el.firstElementChild?.firstElementChild?.dispatchEvent(ev);
   }
 }

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
@@ -63,7 +63,17 @@ export class ToolbarMenuComponent {
   onCustomItemContainerClick(event) {
     console.log(event);
     const el: HTMLElement = event.target;
-    const ev = new MouseEvent('click');
-    el.firstElementChild?.firstElementChild?.dispatchEvent(ev);
+    const x = window.scrollX + el.getBoundingClientRect().left + 5;
+    const y = window.scrollY + el.getBoundingClientRect().top + 5;
+
+    const opts = {
+      bubbles: false,
+      screenX: x,
+      screenY: y
+    };
+
+    const ev = new MouseEvent('click', opts);
+    document.elementFromPoint(x, y).dispatchEvent(ev);
+    event.stopPropagation();
   }
 }

--- a/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/tool-bar/toolbar-menu/toolbar-menu.component.ts
@@ -23,17 +23,23 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, ViewEncapsulation, HostListener, ViewChild, ViewChildren, QueryList } from '@angular/core';
+import { Component, Input, ViewEncapsulation, HostListener, ViewChild } from '@angular/core';
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
 import { ThemePalette } from '@angular/material/core';
-import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item.component';
 
 @Component({
   selector: 'app-toolbar-menu',
   templateUrl: './toolbar-menu.component.html',
   encapsulation: ViewEncapsulation.None,
-  host: { class: 'app-toolbar-menu' }
+  host: { class: 'app-toolbar-menu' },
+  styles: [
+    `
+      .aca-mat-menu-item-container {
+        padding: 0;
+      }
+    `
+  ]
 })
 export class ToolbarMenuComponent {
   @Input()
@@ -48,9 +54,6 @@ export class ToolbarMenuComponent {
   @ViewChild(MatMenu)
   menu: MatMenu;
 
-  @ViewChildren(ToolbarMenuItemComponent)
-  toolbarMenuItems: QueryList<ToolbarMenuItemComponent>;
-
   @HostListener('document:keydown.Escape')
   handleKeydownEscape() {
     this.matTrigger.closeMenu();
@@ -61,19 +64,8 @@ export class ToolbarMenuComponent {
   }
 
   onCustomItemContainerClick(event) {
-    console.log(event);
-    const el: HTMLElement = event.target;
-    const x = window.scrollX + el.getBoundingClientRect().left + 5;
-    const y = window.scrollY + el.getBoundingClientRect().top + 5;
-
-    const opts = {
-      bubbles: false,
-      screenX: x,
-      screenY: y
-    };
-
-    const ev = new MouseEvent('click', opts);
-    document.elementFromPoint(x, y).dispatchEvent(ev);
+    const ev = new MouseEvent('click');
+    event.target.querySelector('.mat-menu-item').dispatchEvent(ev);
     event.stopPropagation();
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Not all toolbar menu items could be navigated to using keyboard shortcuts. Only items wrapped with `<adf-toolbar-menu-item>` could be navigated. Those wrapped with `<adf-dynamic-component>` could not be navigated.


**What is the new behaviour?**
Implemented workaround where all  menubar items can be navigated to. This was done by wrapping the items with a button with the mat-menu-item directive, and then manually calling the click event on them when the button was clicked. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
