### PR TITLE
Revert "e2e cleanup"

### DIFF
--- a/e2e/suites/actions-available/files-folders/folders-actions.test.ts
+++ b/e2e/suites/actions-available/files-folders/folders-actions.test.ts
@@ -51,14 +51,14 @@ describe('Folders - available actions : ', () => {
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
 
-    parentId = await userApi.createFolder(parentName);
+    parentId = (await userApi.nodes.createFolder(parentName)).entry.id;
 
-    await userApi.createFile(testData.file.name, parentId);
-    fileFavId = await userApi.createFile(testData.fileFav.name, parentId);
+    await userApi.nodes.createFile(testData.file.name, parentId);
+    fileFavId = (await userApi.nodes.createFile(testData.fileFav.name, parentId)).entry.id;
 
-    await userApi.createFolder(testData.folder.name, parentId);
-    folderFavId = await userApi.createFolder(testData.folderFav.name, parentId);
-    folderFav2Id = await userApi.createFolder(testData.folderFav2.name, parentId);
+    await userApi.nodes.createFolder(testData.folder.name, parentId);
+    folderFavId = (await userApi.nodes.createFolder(testData.folderFav.name, parentId)).entry.id;
+    folderFav2Id = (await userApi.nodes.createFolder(testData.folderFav2.name, parentId)).entry.id;
 
     const initialFavoritesTotalItems = (await userApi.favorites.getFavoritesTotalItems()) || 0;
     await userApi.favorites.addFavoritesByIds('folder', [folderFavId, folderFav2Id]);

--- a/e2e/suites/actions-available/files-folders/locked-files-actions.test.ts
+++ b/e2e/suites/actions-available/files-folders/locked-files-actions.test.ts
@@ -51,14 +51,13 @@ describe('Locked Files - available actions : ', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    userActions.login(username, username);
 
-    parentId = await userApi.createFolder(parentName);
+    parentId = (await userApi.nodes.createFolder(parentName)).entry.id;
 
-    fileLockedId = await userApi.createFile(testData.fileLocked.name, parentId);
-    fileFavLockedId = await userApi.createFile(testData.fileFavLocked.name, parentId);
-    fileSharedLockedId = await userApi.createFile(testData.fileSharedLocked.name, parentId);
-    fileSharedFavLockedId = await userApi.createFile(testData.fileSharedFavLocked.name, parentId);
+    fileLockedId = (await userApi.nodes.createFile(testData.fileLocked.name, parentId)).entry.id;
+    fileFavLockedId = (await userApi.nodes.createFile(testData.fileFavLocked.name, parentId)).entry.id;
+    fileSharedLockedId = (await userApi.nodes.createFile(testData.fileSharedLocked.name, parentId)).entry.id;
+    fileSharedFavLockedId = (await userApi.nodes.createFile(testData.fileSharedFavLocked.name, parentId)).entry.id;
 
     const initialFavoritesTotalItems = (await userApi.favorites.getFavoritesTotalItems()) || 0;
     await userApi.favorites.addFavoritesByIds('file', [fileFavLockedId, fileSharedFavLockedId]);
@@ -66,7 +65,10 @@ describe('Locked Files - available actions : ', () => {
 
     await userApi.shared.shareFilesByIds([fileSharedLockedId, fileSharedFavLockedId]);
 
-    await userActions.lockNodes([fileLockedId, fileFavLockedId, fileSharedLockedId, fileSharedFavLockedId]);
+    await userApi.nodes.lockFile(fileLockedId);
+    await userApi.nodes.lockFile(fileFavLockedId);
+    await userApi.nodes.lockFile(fileSharedLockedId);
+    await userApi.nodes.lockFile(fileSharedFavLockedId);
 
     await userApi.shared.waitForFilesToBeShared([fileSharedLockedId, fileSharedFavLockedId]);
     await userApi.search.waitForApi(username, { expect: 4 });

--- a/e2e/suites/actions-available/files-folders/multiple-files-actions.test.ts
+++ b/e2e/suites/actions-available/files-folders/multiple-files-actions.test.ts
@@ -58,17 +58,18 @@ describe('Multiple Files - available actions : ', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    parentId = await userApi.createFolder(parentName);
+    parentId = (await userApi.nodes.createFolder(parentName)).entry.id;
 
-    file1Id = await userApi.createFile(file1, parentId);
-    file2Id = await userApi.createFile(file2, parentId);
-    file3LockedId = await userApi.createFile(file3Locked, parentId);
-    file1LockedFavId = await userApi.createFile(file1LockedFav, parentId);
-    file2LockedFavId = await userApi.createFile(file2LockedFav, parentId);
+    file1Id = (await userApi.nodes.createFile(file1, parentId)).entry.id;
+    file2Id = (await userApi.nodes.createFile(file2, parentId)).entry.id;
+    file3LockedId = (await userApi.nodes.createFile(file3Locked, parentId)).entry.id;
+    file1LockedFavId = (await userApi.nodes.createFile(file1LockedFav, parentId)).entry.id;
+    file2LockedFavId = (await userApi.nodes.createFile(file2LockedFav, parentId)).entry.id;
 
-    await userActions.lockNodes([file1LockedFavId, file2LockedFavId, file3LockedId]);
+    await userApi.nodes.lockFile(file1LockedFavId);
+    await userApi.nodes.lockFile(file2LockedFavId);
+    await userApi.nodes.lockFile(file3LockedId);
 
     const initialFavoritesTotalItems = (await userApi.favorites.getFavoritesTotalItems()) || 0;
     await userApi.favorites.addFavoritesByIds('file', [file1LockedFavId, file2LockedFavId]);

--- a/e2e/suites/actions-available/libraries/library-trash.test.ts
+++ b/e2e/suites/actions-available/libraries/library-trash.test.ts
@@ -23,13 +23,14 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { LoginPage, BrowsingPage, Utils, AdminActions, UserActions } from '@alfresco/aca-testing-shared';
+import { LoginPage, BrowsingPage, RepoClient, Utils, AdminActions, UserActions } from '@alfresco/aca-testing-shared';
 import * as testData from './test-data-libraries';
 import * as testUtil from '../test-util';
 
 describe('Library actions : ', () => {
   const username = `user-${Utils.random()}`;
 
+  const userApi = new RepoClient(username, username);
   const adminApiActions = new AdminActions();
   const userActions = new UserActions();
 
@@ -38,9 +39,11 @@ describe('Library actions : ', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    await userActions.createSites([testData.siteInTrash.name, testData.site2InTrash.name]);
+    await userApi.sites.createSite(testData.siteInTrash.name);
+    await userApi.sites.createSite(testData.site2InTrash.name);
+
+    await userActions.login(username, username);
     await userActions.deleteSites([testData.siteInTrash.name, testData.site2InTrash.name], false);
 
     await loginPage.loginWith(username);

--- a/e2e/suites/actions-available/libraries/library.test.ts
+++ b/e2e/suites/actions-available/libraries/library.test.ts
@@ -23,16 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  LoginPage,
-  BrowsingPage,
-  SearchResultsPage,
-  RepoClient,
-  Utils,
-  AdminActions,
-  UserActions,
-  SITE_VISIBILITY
-} from '@alfresco/aca-testing-shared';
+import { LoginPage, BrowsingPage, SearchResultsPage, RepoClient, Utils, AdminActions, UserActions } from '@alfresco/aca-testing-shared';
 import * as testData from './test-data-libraries';
 import * as testUtil from '../test-util';
 import { Logger } from '@alfresco/adf-testing';
@@ -54,23 +45,18 @@ describe('Library actions : ', () => {
       await adminApiActions.createUser({ username });
 
       await userApi.sites.createSite(testData.publicUserMemberFav.name);
-      await userApi.sites.createSite(testData.privateUserMemberFav.name, SITE_VISIBILITY.PRIVATE);
-      await userApi.sites.createSite(testData.moderatedUserMemberFav.name, SITE_VISIBILITY.MODERATED);
+      await userApi.sites.createSitePrivate(testData.privateUserMemberFav.name);
+      await userApi.sites.createSiteModerated(testData.moderatedUserMemberFav.name);
       const publicUserMemberNotFavId = (await userApi.sites.createSite(testData.publicUserMemberNotFav.name)).entry.guid;
-      const privateUserMemberNotFavId = (await userApi.sites.createSite(testData.privateUserMemberNotFav.name, SITE_VISIBILITY.PRIVATE)).entry.guid;
-      const moderatedUserMemberNotFavId = (await userApi.sites.createSite(testData.moderatedUserMemberNotFav.name, SITE_VISIBILITY.MODERATED)).entry
-        .guid;
+      const privateUserMemberNotFavId = (await userApi.sites.createSitePrivate(testData.privateUserMemberNotFav.name)).entry.guid;
+      const moderatedUserMemberNotFavId = (await userApi.sites.createSiteModerated(testData.moderatedUserMemberNotFav.name)).entry.guid;
 
-      await adminApiActions.sites.createSites([testData.publicNotMemberFav.name, testData.publicNotMemberNotFav.name]);
-      await adminApiActions.sites.createSites(
-        [
-          testData.moderatedNotMemberFav.name,
-          testData.moderatedNotMemberNotFav.name,
-          testData.moderatedRequestedJoinFav.name,
-          testData.moderatedRequestedJoinNotFav.name
-        ],
-        SITE_VISIBILITY.MODERATED
-      );
+      await adminApiActions.sites.createSite(testData.publicNotMemberFav.name);
+      await adminApiActions.sites.createSiteModerated(testData.moderatedNotMemberFav.name);
+      await adminApiActions.sites.createSite(testData.publicNotMemberNotFav.name);
+      await adminApiActions.sites.createSiteModerated(testData.moderatedNotMemberNotFav.name);
+      await adminApiActions.sites.createSiteModerated(testData.moderatedRequestedJoinFav.name);
+      await adminApiActions.sites.createSiteModerated(testData.moderatedRequestedJoinNotFav.name);
 
       await userApi.sites.requestToJoin(testData.moderatedRequestedJoinFav.name);
       await userApi.sites.requestToJoin(testData.moderatedRequestedJoinNotFav.name);

--- a/e2e/suites/actions-available/new-menu/new-menu.test.ts
+++ b/e2e/suites/actions-available/new-menu/new-menu.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, SITE_ROLES, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, SITE_ROLES, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('New menu', () => {
   const username = `user-${Utils.random()}`;
@@ -31,32 +31,30 @@ describe('New menu', () => {
   const siteUser = `site-user-${Utils.random()}`;
   const siteAdmin = `site-admin-${Utils.random()}`;
 
+  const apis = {
+    user: new RepoClient(username, username)
+  };
+
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
   const { dataTable, sidenav } = page;
   const { menu } = sidenav;
 
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
-
     await adminApiActions.sites.createSite(siteAdmin);
     await adminApiActions.sites.addSiteMember(siteAdmin, username, SITE_ROLES.SITE_CONSUMER.ROLE);
 
-    await userActions.createSites([siteUser]);
+    await apis.user.sites.createSite(siteUser);
 
     await loginPage.loginWith(username);
   });
 
   afterAll(async () => {
-    await userActions.login(username, username);
-    await userActions.deleteSites([siteUser]);
-
-    await adminApiActions.login();
-    await adminApiActions.deleteSites([siteAdmin]);
+    await apis.user.sites.deleteSite(siteUser);
+    await adminApiActions.sites.deleteSite(siteAdmin);
   });
 
   afterEach(async () => {

--- a/e2e/suites/actions-available/special-permissions/special-permissions-actions.test.ts
+++ b/e2e/suites/actions-available/special-permissions/special-permissions-actions.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { LoginPage, RepoClient, Utils, AdminActions, FILES, SITE_ROLES, SITE_VISIBILITY, UserActions } from '@alfresco/aca-testing-shared';
+import { LoginPage, RepoClient, Utils, AdminActions, FILES, SITE_ROLES } from '@alfresco/aca-testing-shared';
 import * as testData from './test-data-permissions';
 import { librariesTests } from './my-libraries';
 import { favoritesTests } from './favorites';
@@ -58,8 +58,6 @@ describe('Special permissions : ', () => {
   let folderFav2Id: string;
 
   const adminApiActions = new AdminActions();
-  const managerActions = new UserActions();
-  const demotedUserActions = new UserActions();
 
   const userManagerApi = new RepoClient(userManager, userManager);
   const userConsumerApi = new RepoClient(userConsumer, userConsumer);
@@ -74,14 +72,11 @@ describe('Special permissions : ', () => {
     await adminApiActions.createUser({ username: userCollaborator });
     await adminApiActions.createUser({ username: userDemoted });
 
-    await managerActions.login(userManager, userManager);
-    await demotedUserActions.login(userDemoted, userDemoted);
-
     const consumerFavoritesTotalItems = await userConsumerApi.favorites.getFavoritesTotalItems();
     const managerSearchTotalItems = await userManagerApi.search.getTotalItems(userManager);
     const collaboratorFavoritesTotalItems = await userCollaboratorApi.favorites.getFavoritesTotalItems();
 
-    await userManagerApi.sites.createSite(sitePrivate, SITE_VISIBILITY.PRIVATE);
+    await userManagerApi.sites.createSitePrivate(sitePrivate);
     const docLibId = await userManagerApi.sites.getDocLibId(sitePrivate);
     await userManagerApi.sites.addSiteConsumer(sitePrivate, userConsumer);
     await userManagerApi.sites.addSiteCollaborator(sitePrivate, userCollaborator);
@@ -89,27 +84,27 @@ describe('Special permissions : ', () => {
 
     await userManagerApi.upload.uploadFileWithRename(FILES.docxFile, docLibId, testData.fileDocx.name);
     fileDocxFavId = (await userManagerApi.upload.uploadFileWithRename(FILES.docxFile, docLibId, testData.fileDocxFav.name)).entry.id;
-    await userManagerApi.createFile(testData.file.name, docLibId);
-    fileFavId = await userManagerApi.createFile(testData.fileFav.name, docLibId);
+    await userManagerApi.nodes.createFile(testData.file.name, docLibId);
+    fileFavId = (await userManagerApi.nodes.createFile(testData.fileFav.name, docLibId)).entry.id;
     fileDocxSharedId = (await userManagerApi.upload.uploadFileWithRename(FILES.docxFile, docLibId, testData.fileDocxShared.name)).entry.id;
     fileDocxSharedFavId = (await userManagerApi.upload.uploadFileWithRename(FILES.docxFile, docLibId, testData.fileDocxSharedFav.name)).entry.id;
-    fileSharedId = await userManagerApi.createFile(testData.fileShared.name, docLibId);
-    fileSharedFavId = await userManagerApi.createFile(testData.fileSharedFav.name, docLibId);
-    fileLockedId = await userManagerApi.createFile(testData.fileLocked.name, docLibId);
-    fileFavLockedId = await userManagerApi.createFile(testData.fileFavLocked.name, docLibId);
-    fileSharedLockedId = await userManagerApi.createFile(testData.fileSharedLocked.name, docLibId);
-    fileSharedFavLockedId = await userManagerApi.createFile(testData.fileSharedFavLocked.name, docLibId);
-    fileGranularPermissionId = await userManagerApi.createFile(testData.fileGranularPermission, docLibId);
+    fileSharedId = (await userManagerApi.nodes.createFile(testData.fileShared.name, docLibId)).entry.id;
+    fileSharedFavId = (await userManagerApi.nodes.createFile(testData.fileSharedFav.name, docLibId)).entry.id;
+    fileLockedId = (await userManagerApi.nodes.createFile(testData.fileLocked.name, docLibId)).entry.id;
+    fileFavLockedId = (await userManagerApi.nodes.createFile(testData.fileFavLocked.name, docLibId)).entry.id;
+    fileSharedLockedId = (await userManagerApi.nodes.createFile(testData.fileSharedLocked.name, docLibId)).entry.id;
+    fileSharedFavLockedId = (await userManagerApi.nodes.createFile(testData.fileSharedFavLocked.name, docLibId)).entry.id;
+    fileGranularPermissionId = (await userManagerApi.nodes.createFile(testData.fileGranularPermission, docLibId)).entry.id;
 
-    fileLockedByUserId = await userManagerApi.createFile(testData.fileLockedByUser, docLibId);
-    await demotedUserActions.lockNodes([fileLockedByUserId]);
+    fileLockedByUserId = (await userManagerApi.nodes.createFile(testData.fileLockedByUser, docLibId)).entry.id;
+    await userDemotedApi.nodes.lockFile(fileLockedByUserId);
     await userDemotedApi.favorites.addFavoriteById('file', fileLockedByUserId);
-    await userDemotedApi.shared.shareFilesByIds([fileLockedByUserId]);
+    await userDemotedApi.shared.shareFileById(fileLockedByUserId);
     await userManagerApi.sites.updateSiteMember(sitePrivate, userDemoted, SITE_ROLES.SITE_CONSUMER.ROLE);
 
     await userManagerApi.nodes.createFolder(testData.folder.name, docLibId);
-    folderFavId = await userManagerApi.createFolder(testData.folderFav.name, docLibId);
-    folderFav2Id = await userManagerApi.createFolder(testData.folderFav2.name, docLibId);
+    folderFavId = (await userManagerApi.nodes.createFolder(testData.folderFav.name, docLibId)).entry.id;
+    folderFav2Id = (await userManagerApi.nodes.createFolder(testData.folderFav2.name, docLibId)).entry.id;
     await userConsumerApi.favorites.addFavoritesByIds('folder', [folderFavId, folderFav2Id]);
 
     await userConsumerApi.favorites.addFavoritesByIds('file', [
@@ -134,7 +129,10 @@ describe('Special permissions : ', () => {
 
     await userCollaboratorApi.favorites.addFavoritesByIds('file', [fileDocxSharedFavId, fileSharedFavId]);
 
-    await managerActions.lockNodes([fileLockedId, fileFavLockedId, fileSharedLockedId, fileSharedFavLockedId]);
+    await userManagerApi.nodes.lockFile(fileLockedId);
+    await userManagerApi.nodes.lockFile(fileFavLockedId);
+    await userManagerApi.nodes.lockFile(fileSharedLockedId);
+    await userManagerApi.nodes.lockFile(fileSharedFavLockedId);
 
     await userManagerApi.nodes.setGranularPermission(fileGranularPermissionId, false, userConsumer, SITE_ROLES.SITE_MANAGER.ROLE);
 

--- a/e2e/suites/actions/copy-move/copy.test.ts
+++ b/e2e/suites/actions/copy-move/copy.test.ts
@@ -37,7 +37,9 @@ import { BrowserActions, Logger } from '@alfresco/adf-testing';
 
 describe('Copy content', () => {
   const random = Utils.random();
+
   const username = `user-${random}`;
+
   const source = `source-${random}`;
   let sourceId: string;
   const destinationPF = `destinationPersonal-${random}`;
@@ -52,10 +54,15 @@ describe('Copy content', () => {
   let destinationIdSearch: string;
 
   const file1 = `copy-file1-${random}.txt`;
+  let file1Id: string;
+
   const folder1 = `copy-folder1-${random}`;
+  let folder1Id: string;
   const fileInFolder = `copy-fileInFolder-${random}.txt`;
+  let fileInFolderId: string;
 
   const folder2 = `copy-folder2-${random}`;
+  let folder2Id: string;
   const fileInFolder2 = fileInFolder;
 
   const folderExisting = `copy-folder-existing-${random}`;
@@ -64,8 +71,12 @@ describe('Copy content', () => {
   const file2InFolderExisting = `copy-file2InFolderExisting-${random}.txt`;
 
   const file2 = `copy-file2-${random}.txt`;
+  let file2Id: string;
   const file3 = `copy-file3-${random}.txt`;
+  let file3Id: string;
   const file4 = `copy-file4-${random}.txt`;
+  let file4Id: string;
+
   const fileLocked1 = `copy-file-locked1-${random}.txt`;
   let fileLocked1Id: string;
 
@@ -75,9 +86,21 @@ describe('Copy content', () => {
   let fileLockedInFolderId: string;
 
   const existingFile = `copy-existing-${random}-file.txt`;
+  let existingFileToCopyId: string;
+
   const existingFolder = `copy-existing-${random}-folder`;
+  let existingFolderToCopyId: string;
+
+  let existingIdPF: string;
+  let existingIdFav: string;
+  let existingIdSearch: string;
+  let folderExistingPFId: string;
+  let folderExistingFavId: string;
+  let folderExistingSearchId: string;
+
   const file2InFolder = `copy-file2InFolder-${random}.txt`;
   const file3InFolder = `copy-file3InFolder-${random}.txt`;
+
   const siteName = `copy-site-${random}`;
   const folderSitePF = `copy-folderSitePersonal-${random}`;
   const folderSiteRF = `copy-folderSiteRecent-${random}`;
@@ -88,7 +111,9 @@ describe('Copy content', () => {
   let locationId: string;
   let destinationId: string;
 
-  const apis = new RepoClient(username, username);
+  const apis = {
+    user: new RepoClient(username, username)
+  };
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
@@ -103,93 +128,98 @@ describe('Copy content', () => {
   beforeAll(async () => {
     try {
       await adminApiActions.createUser({ username });
+
+      const initialFavoritesTotalItems = await apis.user.favorites.getFavoritesTotalItems();
+
+      sourceId = (await apis.user.nodes.createFolder(source)).entry.id;
+      destinationIdPF = (await apis.user.nodes.createFolder(destinationPF)).entry.id;
+      destinationIdRF = (await apis.user.nodes.createFolder(destinationRF)).entry.id;
+      destinationIdSF = (await apis.user.nodes.createFolder(destinationSF)).entry.id;
+      destinationIdFav = (await apis.user.nodes.createFolder(destinationFav)).entry.id;
+      destinationIdSearch = (await apis.user.nodes.createFolder(destinationSearch)).entry.id;
+
+      existingFileToCopyId = (await apis.user.nodes.createFile(existingFile, sourceId)).entry.id;
+
       await userActions.login(username, username);
-
-      const initialFavoritesTotalItems = await apis.favorites.getFavoritesTotalItems();
-
-      sourceId = await apis.createFolder(source);
-      destinationIdPF = await apis.createFolder(destinationPF);
-      destinationIdRF = await apis.createFolder(destinationRF);
-      destinationIdSF = await apis.createFolder(destinationSF);
-      destinationIdFav = await apis.createFolder(destinationFav);
-      destinationIdSearch = await apis.createFolder(destinationSearch);
-
-      const existingFileToCopyId = await apis.createFile(existingFile, sourceId);
-
       await userActions.shareNodes([existingFileToCopyId]);
-      await apis.favorites.addFavoriteById('file', existingFileToCopyId);
+      await apis.user.favorites.addFavoriteById('file', existingFileToCopyId);
 
-      await apis.createFile(existingFile, destinationIdPF);
-      await apis.createFile(existingFile, destinationIdRF);
-      await apis.createFile(existingFile, destinationIdSF);
-      await apis.createFile(existingFile, destinationIdFav);
-      await apis.createFile(existingFile, destinationIdSearch);
+      await apis.user.nodes.createFile(existingFile, destinationIdPF);
+      await apis.user.nodes.createFile(existingFile, destinationIdRF);
+      await apis.user.nodes.createFile(existingFile, destinationIdSF);
+      await apis.user.nodes.createFile(existingFile, destinationIdFav);
+      await apis.user.nodes.createFile(existingFile, destinationIdSearch);
 
-      const existingFolderToCopyId = await apis.createFolder(existingFolder, sourceId);
+      existingFolderToCopyId = (await apis.user.nodes.createFolder(existingFolder, sourceId)).entry.id;
 
-      const existingIdPF = await apis.createFolder(existingFolder, destinationIdPF);
-      await apis.createFolder(existingFolder, destinationIdRF);
-      await apis.createFolder(existingFolder, destinationIdSF);
-      const existingIdFav = await apis.createFolder(existingFolder, destinationIdFav);
-      const existingIdSearch = await apis.createFolder(existingFolder, destinationIdSearch);
-      await apis.createFile(file2InFolder, existingFolderToCopyId);
+      existingIdPF = (await apis.user.nodes.createFolder(existingFolder, destinationIdPF)).entry.id;
+      await apis.user.nodes.createFolder(existingFolder, destinationIdRF);
+      await apis.user.nodes.createFolder(existingFolder, destinationIdSF);
+      existingIdFav = (await apis.user.nodes.createFolder(existingFolder, destinationIdFav)).entry.id;
+      existingIdSearch = (await apis.user.nodes.createFolder(existingFolder, destinationIdSearch)).entry.id;
+      await apis.user.nodes.createFile(file2InFolder, existingFolderToCopyId);
 
-      await apis.createFile(file3InFolder, existingIdPF);
-      await apis.createFile(file3InFolder, existingIdFav);
-      await apis.createFile(file3InFolder, existingIdSearch);
+      await apis.user.nodes.createFile(file3InFolder, existingIdPF);
+      await apis.user.nodes.createFile(file3InFolder, existingIdFav);
+      await apis.user.nodes.createFile(file3InFolder, existingIdSearch);
 
-      await apis.favorites.addFavoriteById('folder', existingFolderToCopyId);
+      await apis.user.favorites.addFavoriteById('folder', existingFolderToCopyId);
 
-      const folder1Id = await apis.createFolder(folder1, sourceId);
-      const fileInFolderId = await apis.createFile(fileInFolder, folder1Id);
-      await apis.favorites.addFavoriteById('folder', folder1Id);
-      await apis.favorites.addFavoriteById('file', fileInFolderId);
+      folder1Id = (await apis.user.nodes.createFolder(folder1, sourceId)).entry.id;
+      fileInFolderId = (await apis.user.nodes.createFile(fileInFolder, folder1Id)).entry.id;
+      await apis.user.favorites.addFavoriteById('folder', folder1Id);
+      await apis.user.favorites.addFavoriteById('file', fileInFolderId);
       await userActions.shareNodes([fileInFolderId]);
 
-      folderExistingId = await apis.createFolder(folderExisting, sourceId);
-      await apis.favorites.addFavoriteById('folder', folderExistingId);
-      await apis.createFile(file1InFolderExisting, folderExistingId);
+      folderExistingId = (await apis.user.nodes.createFolder(folderExisting, sourceId)).entry.id;
+      await apis.user.favorites.addFavoriteById('folder', folderExistingId);
+      await apis.user.nodes.createFile(file1InFolderExisting, folderExistingId);
 
-      const folderExistingPFId = await apis.createFolder(folderExisting, destinationIdPF);
-      await apis.createFile(file2InFolderExisting, folderExistingPFId);
+      folderExistingPFId = (await apis.user.nodes.createFolder(folderExisting, destinationIdPF)).entry.id;
+      await apis.user.nodes.createFile(file2InFolderExisting, folderExistingPFId);
 
-      const folderExistingFavId = await apis.createFolder(folderExisting, destinationIdFav);
-      await apis.createFile(file2InFolderExisting, folderExistingFavId);
+      folderExistingFavId = (await apis.user.nodes.createFolder(folderExisting, destinationIdFav)).entry.id;
+      await apis.user.nodes.createFile(file2InFolderExisting, folderExistingFavId);
 
-      const folderExistingSearchId = await apis.createFolder(folderExisting, destinationIdSearch);
-      await apis.createFile(file2InFolderExisting, folderExistingSearchId);
+      folderExistingSearchId = (await apis.user.nodes.createFolder(folderExisting, destinationIdSearch)).entry.id;
+      await apis.user.nodes.createFile(file2InFolderExisting, folderExistingSearchId);
 
-      const folder2Id = await apis.createFolder(folder2, sourceId);
-      await apis.createFile(fileInFolder2, folder2Id);
-      await apis.favorites.addFavoriteById('folder', folder2Id);
+      folder2Id = (await apis.user.nodes.createFolder(folder2, sourceId)).entry.id;
+      await apis.user.nodes.createFile(fileInFolder2, folder2Id);
+      await apis.user.favorites.addFavoriteById('folder', folder2Id);
 
-      fileLocked1Id = await apis.createFile(fileLocked1, sourceId);
-      await userActions.lockNodes([fileLocked1Id]);
+      fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, sourceId)).entry.id;
+      await apis.user.nodes.lockFile(fileLocked1Id);
 
-      folderWithLockedFilesId = await apis.createFolder(folderWithLockedFiles, sourceId);
-      fileLockedInFolderId = await apis.createFile(fileLockedInFolder, folderWithLockedFilesId);
-      await userActions.lockNodes([fileLockedInFolderId]);
-      await apis.favorites.addFavoriteById('folder', folderWithLockedFilesId);
+      folderWithLockedFilesId = (await apis.user.nodes.createFolder(folderWithLockedFiles, sourceId)).entry.id;
+      fileLockedInFolderId = (await apis.user.nodes.createFile(fileLockedInFolder, folderWithLockedFilesId)).entry.id;
+      await apis.user.nodes.lockFile(fileLockedInFolderId);
+      await apis.user.favorites.addFavoriteById('folder', folderWithLockedFilesId);
 
-      const file1Id = await apis.createFile(file1, sourceId);
-      const file2Id = await apis.createFile(file2, sourceId);
-      const file3Id = await apis.createFile(file3, sourceId);
-      const file4Id = await apis.createFile(file4, sourceId);
+      file1Id = (await apis.user.nodes.createFile(file1, sourceId)).entry.id;
+      file2Id = (await apis.user.nodes.createFile(file2, sourceId)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, sourceId)).entry.id;
+      file4Id = (await apis.user.nodes.createFile(file4, sourceId)).entry.id;
 
       await userActions.shareNodes([file1Id, file2Id, file3Id, file4Id, fileLocked1Id]);
 
-      await apis.favorites.addFavoritesByIds('file', [file1Id, file2Id, file3Id, file4Id, fileLocked1Id]);
+      await apis.user.favorites.addFavoriteById('file', file1Id);
+      await apis.user.favorites.addFavoriteById('file', file2Id);
+      await apis.user.favorites.addFavoriteById('file', file3Id);
+      await apis.user.favorites.addFavoriteById('file', file4Id);
 
-      await apis.sites.createSite(siteName);
-      const docLibId = await apis.sites.getDocLibId(siteName);
-      await apis.createFolder(folderSitePF, docLibId);
-      await apis.createFolder(folderSiteRF, docLibId);
-      await apis.createFolder(folderSiteSF, docLibId);
-      await apis.createFolder(folderSiteFav, docLibId);
-      await apis.createFolder(folderSiteSearch, docLibId);
+      await apis.user.favorites.addFavoriteById('file', fileLocked1Id);
 
-      await apis.shared.waitForFilesToBeShared([existingFileToCopyId, fileInFolderId, file1Id, file2Id, file3Id, file4Id, fileLocked1Id]);
-      await apis.favorites.waitForApi({ expect: initialFavoritesTotalItems + 13 });
+      await apis.user.sites.createSite(siteName);
+      const docLibId = await apis.user.sites.getDocLibId(siteName);
+      await apis.user.nodes.createFolder(folderSitePF, docLibId);
+      await apis.user.nodes.createFolder(folderSiteRF, docLibId);
+      await apis.user.nodes.createFolder(folderSiteSF, docLibId);
+      await apis.user.nodes.createFolder(folderSiteFav, docLibId);
+      await apis.user.nodes.createFolder(folderSiteSearch, docLibId);
+
+      await apis.user.shared.waitForFilesToBeShared([existingFileToCopyId, fileInFolderId, file1Id, file2Id, file3Id, file4Id, fileLocked1Id]);
+      await apis.user.favorites.waitForApi({ expect: initialFavoritesTotalItems + 13 });
 
       await loginPage.loginWith(username);
     } catch (error) {
@@ -203,10 +233,10 @@ describe('Copy content', () => {
 
   afterAll(async () => {
     try {
-      await userActions.login(username, username);
-      await userActions.unlockNodes([fileLocked1Id, fileLockedInFolderId]);
-      await userActions.deleteNodes([sourceId, destinationIdRF, destinationIdPF, destinationIdSF, destinationIdFav, destinationIdSearch]);
-      await userActions.deleteSites([siteName]);
+      await apis.user.nodes.unlockFile(fileLocked1Id);
+      await apis.user.nodes.unlockFile(fileLockedInFolderId);
+      await apis.user.nodes.deleteNodesById([sourceId, destinationIdRF, destinationIdPF, destinationIdSF, destinationIdFav, destinationIdSearch]);
+      await apis.user.sites.deleteSite(siteName);
     } catch (error) {
       Logger.error(`---- afterAll failed : ${error}`);
     }
@@ -608,11 +638,11 @@ describe('Copy content', () => {
 
     await copyDialog.waitForDialogToClose();
     expect(await dataTable.isItemPresent(fileName)).toBe(true, `${fileName} not present in source folder`);
-    expect(await apis.nodes.isFileLockedByName(fileName, locationId)).toBe(true, `${fileName} not locked in ${location}`);
+    expect(await apis.user.nodes.isFileLockedByName(fileName, locationId)).toBe(true, `${fileName} not locked in ${location}`);
     await page.clickPersonalFilesAndWait();
     await dataTable.doubleClickOnRowByName(destination);
     expect(await dataTable.isItemPresent(fileName)).toBe(true, `${fileName} not present in ${destination} folder`);
-    expect(await apis.nodes.isFileLockedByName(fileName, destinationId)).toBe(false, `${fileName} is locked in ${destination}`);
+    expect(await apis.user.nodes.isFileLockedByName(fileName, destinationId)).toBe(false, `${fileName} is locked in ${destination}`);
   }
 
   async function copyFolderThatContainsLockedFile(folderName: string, location: string = '', destination: string, doBefore?: () => void) {
@@ -636,17 +666,16 @@ describe('Copy content', () => {
     await dataTable.doubleClickOnRowByName(destination);
     expect(await dataTable.isItemPresent(folderName)).toBe(true, `${folderName} not present in ${destination} folder`);
     expect(await dataTable.isItemPresent(fileLockedInFolder)).toBe(false, `${fileLockedInFolder} is present in ${destination}`);
-    expect(await apis.nodes.isFileLockedByName(fileLockedInFolder, locationId)).toBe(true, `${fileLockedInFolder} not locked in ${location}`);
+    expect(await apis.user.nodes.isFileLockedByName(fileLockedInFolder, locationId)).toBe(true, `${fileLockedInFolder} not locked in ${location}`);
 
     await dataTable.doubleClickOnRowByName(folderName);
     expect(await dataTable.isItemPresent(fileLockedInFolder)).toBe(
       true,
       `${fileLockedInFolder} is not present in ${folderName} folder from ${destination}`
     );
-    expect(await apis.nodes.isFileLockedByName(fileLockedInFolder, await apis.nodes.getNodeIdFromParent(folderWithLockedFiles, destinationId))).toBe(
-      false,
-      `${fileLockedInFolder} is locked in ${destination}`
-    );
+    expect(
+      await apis.user.nodes.isFileLockedByName(fileLockedInFolder, await apis.user.nodes.getNodeIdFromParent(folderWithLockedFiles, destinationId))
+    ).toBe(false, `${fileLockedInFolder} is locked in ${destination}`);
   }
 
   async function undoCopyFile(fileName: string, location: string = '', destination: string, doBefore?: () => void) {

--- a/e2e/suites/actions/copy-move/destination-picker-dialog.test.ts
+++ b/e2e/suites/actions/copy-move/destination-picker-dialog.test.ts
@@ -23,16 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  LoginPage,
-  BrowsingPage,
-  ContentNodeSelectorDialog,
-  RepoClient,
-  Utils,
-  AdminActions,
-  SITE_VISIBILITY,
-  UserActions
-} from '@alfresco/aca-testing-shared';
+import { LoginPage, BrowsingPage, ContentNodeSelectorDialog, RepoClient, Utils, AdminActions } from '@alfresco/aca-testing-shared';
 
 describe('Destination picker dialog : ', () => {
   const random = Utils.random();
@@ -72,9 +63,7 @@ describe('Destination picker dialog : ', () => {
   const consumerApi = new RepoClient(consumer, consumer);
   const contributorApi = new RepoClient(contributor, contributor);
   const collaboratorApi = new RepoClient(collaborator, collaborator);
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
@@ -89,8 +78,6 @@ describe('Destination picker dialog : ', () => {
     await adminApiActions.createUser({ username: contributor });
     await adminApiActions.createUser({ username: collaborator });
 
-    await userActions.login(username, username);
-
     fileId = (await userApi.nodes.createFile(file)).entry.id;
 
     destinationId = (await userApi.nodes.createFolder(destination)).entry.id;
@@ -102,7 +89,7 @@ describe('Destination picker dialog : ', () => {
     searchSubFolder1Id = (await userApi.nodes.createFolder(searchSubFolder1, searchFolderId)).entry.id;
     await userApi.nodes.createFolder(searchSubFolder2, searchSubFolder1Id);
 
-    await userApi.sites.createSite(site, SITE_VISIBILITY.PRIVATE);
+    await userApi.sites.createSitePrivate(site);
     const docLibId = await userApi.sites.getDocLibId(site);
     searchFolderSiteId = (await userApi.nodes.createFolder(searchFolder, docLibId)).entry.id;
     searchSubFolder1SiteId = (await userApi.nodes.createFolder(searchSubFolder1, searchFolderSiteId)).entry.id;
@@ -123,16 +110,15 @@ describe('Destination picker dialog : ', () => {
   });
 
   afterAll(async () => {
-    await userActions.login(username, username);
-    await userActions.deleteNodes([fileId, destinationId]);
-    await userActions.deleteSites([site]);
+    await userApi.nodes.deleteNodeById(fileId);
+    await userApi.nodes.deleteNodeById(destinationId);
+    await userApi.sites.deleteSite(site);
 
     await consumerApi.nodes.deleteNodeById(fileIdConsumer);
     await contributorApi.nodes.deleteNodeById(fileIdContributor);
     await collaboratorApi.nodes.deleteNodeById(fileIdCollaborator);
 
-    await adminApiActions.login();
-    await adminApiActions.deleteNodes([adminFolderId]);
+    await adminApiActions.nodes.deleteNodeById(adminFolderId);
   });
 
   afterEach(async () => {

--- a/e2e/suites/actions/copy-move/move.test.ts
+++ b/e2e/suites/actions/copy-move/move.test.ts
@@ -55,7 +55,9 @@ describe('Move content', () => {
   const folderSiteSF = `folderSiteShared-${Utils.random()}`;
   const folderSiteFav = `folderSiteFavorites-${Utils.random()}`;
 
-  const apis = new RepoClient(username, username);
+  const apis = {
+    user: new RepoClient(username, username)
+  };
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
@@ -68,78 +70,84 @@ describe('Move content', () => {
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
 
-    await apis.sites.createSite(siteName);
-    const docLibId = await apis.sites.getDocLibId(siteName);
+    await apis.user.sites.createSite(siteName);
+    const docLibId = await apis.user.sites.getDocLibId(siteName);
+    await apis.user.nodes.createFolder(folderSitePF, docLibId);
+    await apis.user.nodes.createFolder(folderSiteRF, docLibId);
+    await apis.user.nodes.createFolder(folderSiteSF, docLibId);
+    await apis.user.nodes.createFolder(folderSiteFav, docLibId);
 
-    await apis.createFolder(folderSitePF, docLibId);
-    await apis.createFolder(folderSiteRF, docLibId);
-    await apis.createFolder(folderSiteSF, docLibId);
-    await apis.createFolder(folderSiteFav, docLibId);
+    sourceIdPF = (await apis.user.nodes.createFolder(sourcePF)).entry.id;
+    destinationIdPF = (await apis.user.nodes.createFolder(destinationPF)).entry.id;
 
-    sourceIdPF = await apis.createFolder(sourcePF);
-    destinationIdPF = await apis.createFolder(destinationPF);
+    sourceIdRF = (await apis.user.nodes.createFolder(sourceRF)).entry.id;
+    destinationIdRF = (await apis.user.nodes.createFolder(destinationRF)).entry.id;
 
-    sourceIdRF = await apis.createFolder(sourceRF);
-    destinationIdRF = await apis.createFolder(destinationRF);
+    sourceIdSF = (await apis.user.nodes.createFolder(sourceSF)).entry.id;
+    destinationIdSF = (await apis.user.nodes.createFolder(destinationSF)).entry.id;
 
-    sourceIdSF = await apis.createFolder(sourceSF);
-    destinationIdSF = await apis.createFolder(destinationSF);
-
-    sourceIdFav = await apis.createFolder(sourceFav);
-    destinationIdFav = await apis.createFolder(destinationFav);
+    sourceIdFav = (await apis.user.nodes.createFolder(sourceFav)).entry.id;
+    destinationIdFav = (await apis.user.nodes.createFolder(destinationFav)).entry.id;
 
     await loginPage.loginWith(username);
   });
 
   afterAll(async () => {
-    await apis.nodes.deleteNodesById([
-      sourceIdPF,
-      sourceIdRF,
-      sourceIdSF,
-      sourceIdFav,
-      destinationIdPF,
-      destinationIdRF,
-      destinationIdSF,
-      destinationIdFav
-    ]);
-    await apis.sites.deleteSite(siteName);
+    await apis.user.nodes.deleteNodeById(sourceIdPF);
+    await apis.user.nodes.deleteNodeById(sourceIdRF);
+    await apis.user.nodes.deleteNodeById(sourceIdSF);
+    await apis.user.nodes.deleteNodeById(sourceIdFav);
+    await apis.user.nodes.deleteNodeById(destinationIdPF);
+    await apis.user.nodes.deleteNodeById(destinationIdRF);
+    await apis.user.nodes.deleteNodeById(destinationIdSF);
+    await apis.user.nodes.deleteNodeById(destinationIdFav);
+    await apis.user.sites.deleteSite(siteName);
   });
 
   describe('from Personal Files', () => {
     const file1 = `file1-${Utils.random()}.txt`;
+
     const folder1 = `folder1-${Utils.random()}`;
+    let folder1Id;
     const fileInFolder = `fileInFolder-${Utils.random()}.txt`;
+
     const file2 = `file2-${Utils.random()}.txt`;
     const file3 = `file3-${Utils.random()}.txt`;
+
     const file4 = `file4-${Utils.random()}.txt`;
     const folder2 = `folder2-${Utils.random()}`;
+    let folder2Id;
     const fileInFolder2 = `fileInFolder2-${Utils.random()}.txt`;
+
     const existingFile = `existing-${Utils.random()}`;
+
     const existingFolder = `existing-${Utils.random()}`;
+    let existingId1;
+    let existingId2;
+
     const file2InFolder = `file2InFolder-${Utils.random()}.txt`;
     const file3InFolder = `file3InFolder-${Utils.random()}.txt`;
 
     beforeAll(async () => {
-      await apis.createFile(file1, sourceIdPF);
+      await apis.user.nodes.createFile(file1, sourceIdPF);
 
-      const folder1Id = await apis.createFolder(folder1, sourceIdPF);
-      await apis.createFile(fileInFolder, folder1Id);
+      folder1Id = (await apis.user.nodes.createFolder(folder1, sourceIdPF)).entry.id;
+      await apis.user.nodes.createFile(fileInFolder, folder1Id);
 
-      await apis.createFile(file2, sourceIdPF);
-      await apis.createFile(file3, sourceIdPF);
-      await apis.createFile(file4, sourceIdPF);
+      await apis.user.nodes.createFile(file2, sourceIdPF);
+      await apis.user.nodes.createFile(file3, sourceIdPF);
 
-      await apis.createFile(`${existingFile}.txt`, sourceIdPF);
-      await apis.createFile(`${existingFile}.txt`, destinationIdPF);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, sourceIdPF);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, destinationIdPF);
 
-      const existingId1 = await apis.createFolder(existingFolder, sourceIdPF);
-      await apis.createFile(file2InFolder, existingId1);
+      existingId1 = (await apis.user.nodes.createFolder(existingFolder, sourceIdPF)).entry.id;
+      existingId2 = (await apis.user.nodes.createFolder(existingFolder, destinationIdPF)).entry.id;
+      await apis.user.nodes.createFile(file2InFolder, existingId1);
+      await apis.user.nodes.createFile(file3InFolder, existingId2);
 
-      const existingId2 = await apis.createFolder(existingFolder, destinationIdPF);
-      await apis.createFile(file3InFolder, existingId2);
-
-      const folder2Id = await apis.createFolder(folder2, sourceIdPF);
-      await apis.createFile(fileInFolder2, folder2Id);
+      await apis.user.nodes.createFile(file4, sourceIdPF);
+      folder2Id = (await apis.user.nodes.createFolder(folder2, sourceIdPF)).entry.id;
+      await apis.user.nodes.createFile(fileInFolder2, folder2Id);
     });
 
     beforeEach(async () => {
@@ -285,20 +293,23 @@ describe('Move content', () => {
 
   describe('from Recent Files', () => {
     const file1 = `file1-${Utils.random()}.txt`;
+
     const file2 = `file2-${Utils.random()}.txt`;
     const file3 = `file3-${Utils.random()}.txt`;
+
     const file4 = `file4-${Utils.random()}.txt`;
+
     const existingFile = `existing-${Utils.random()}`;
 
     beforeAll(async () => {
-      await apis.createFile(file1, sourceIdRF);
-      await apis.createFile(file2, sourceIdRF);
-      await apis.createFile(file3, sourceIdRF);
-      await apis.createFile(`${existingFile}.txt`, sourceIdRF);
-      await apis.createFile(`${existingFile}.txt`, destinationIdRF);
-      await apis.createFile(file4, sourceIdRF);
+      await apis.user.nodes.createFile(file1, sourceIdRF);
+      await apis.user.nodes.createFile(file2, sourceIdRF);
+      await apis.user.nodes.createFile(file3, sourceIdRF);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, sourceIdRF);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, destinationIdRF);
+      await apis.user.nodes.createFile(file4, sourceIdRF);
 
-      await apis.search.waitForApi(username, { expect: 16 });
+      await apis.user.search.waitForApi(username, { expect: 16 });
     });
 
     beforeEach(async () => {
@@ -397,28 +408,36 @@ describe('Move content', () => {
 
   describe('from Shared Files', () => {
     const file1 = `file1-${Utils.random()}.txt`;
+    let file1Id;
+
     const file2 = `file2-${Utils.random()}.txt`;
+    let file2Id;
     const file3 = `file3-${Utils.random()}.txt`;
+    let file3Id;
+
     const file4 = `file4-${Utils.random()}.txt`;
+    let file4Id;
+
     const existingFile = `existing-${Utils.random()}`;
+    let existingFileId;
 
     beforeAll(async () => {
-      const file1Id = await apis.createFile(file1, sourceIdSF);
+      file1Id = (await apis.user.nodes.createFile(file1, sourceIdSF)).entry.id;
 
       await userActions.login(username, username);
       await userActions.shareNodes([file1Id]);
 
-      const file2Id = await apis.createFile(file2, sourceIdSF);
-      const file3Id = await apis.createFile(file3, sourceIdSF);
+      file2Id = (await apis.user.nodes.createFile(file2, sourceIdSF)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, sourceIdSF)).entry.id;
       await userActions.shareNodes([file2Id, file3Id]);
 
-      const existingFileId = await apis.createFile(`${existingFile}.txt`, sourceIdSF);
+      existingFileId = (await apis.user.nodes.createFile(`${existingFile}.txt`, sourceIdSF)).entry.id;
       await userActions.shareNodes([existingFileId]);
-      await apis.createFile(`${existingFile}.txt`, destinationIdSF);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, destinationIdSF);
 
-      const file4Id = await apis.createFile(file4, sourceIdSF);
+      file4Id = (await apis.user.nodes.createFile(file4, sourceIdSF)).entry.id;
       await userActions.shareNodes([file4Id]);
-      await apis.shared.waitForFilesToBeShared([file1Id, file2Id, file3Id, existingFileId, file4Id]);
+      await apis.user.shared.waitForFilesToBeShared([file1Id, file2Id, file3Id, existingFileId, file4Id]);
     });
 
     beforeEach(async () => {
@@ -517,51 +536,62 @@ describe('Move content', () => {
 
   describe('from Favorites', () => {
     const file1 = `file1-${Utils.random()}.txt`;
+    let file1Id;
+
     const folder1 = `folder1-${Utils.random()}`;
+    let folder1Id;
     const fileInFolder = `fileInFolder-${Utils.random()}.txt`;
+
     const file2 = `file2-${Utils.random()}.txt`;
+    let file2Id;
     const file3 = `file3-${Utils.random()}.txt`;
+    let file3Id;
+
     const file4 = `file4-${Utils.random()}.txt`;
+    let file4Id;
     const folder2 = `folder2-${Utils.random()}`;
+    let folder2Id;
     const fileInFolder2 = `fileInFolder2-${Utils.random()}.txt`;
+
     const existingFile = `existing-${Utils.random()}`;
+    let existingFileId;
+
     const existingFolder = `existing-${Utils.random()}`;
+    let existingId1;
+    let existingId2;
     const file2InFolder = `file2InFolder-${Utils.random()}.txt`;
     const file3InFolder = `file3InFolder-${Utils.random()}.txt`;
 
-    async function createFavoriteFile(name: string, parentId: string) {
-      const fileId = await apis.createFile(name, parentId);
-      return apis.favorites.addFavoriteById('file', fileId);
-    }
-
-    async function createFavoriteFolder(name: string, parentId: string): Promise<string> {
-      const folderId = await apis.createFolder(name, parentId);
-      await apis.favorites.addFavoriteById('folder', folderId);
-      return folderId;
-    }
-
     beforeAll(async () => {
-      const folder1Id = await createFavoriteFolder(folder1, sourceIdFav);
-      await apis.createFile(fileInFolder, folder1Id);
+      file1Id = (await apis.user.nodes.createFile(file1, sourceIdFav)).entry.id;
+      await apis.user.favorites.addFavoriteById('file', file1Id);
 
-      await createFavoriteFile(file1, sourceIdFav);
-      await createFavoriteFile(file2, sourceIdFav);
-      await createFavoriteFile(file3, sourceIdFav);
-      await createFavoriteFile(file4, sourceIdFav);
-      await createFavoriteFile(`${existingFile}.txt`, sourceIdFav);
+      folder1Id = (await apis.user.nodes.createFolder(folder1, sourceIdFav)).entry.id;
+      await apis.user.nodes.createFile(fileInFolder, folder1Id);
+      await apis.user.favorites.addFavoriteById('folder', folder1Id);
 
-      await apis.createFile(`${existingFile}.txt`, destinationIdFav);
+      file2Id = (await apis.user.nodes.createFile(file2, sourceIdFav)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, sourceIdFav)).entry.id;
+      await apis.user.favorites.addFavoriteById('file', file2Id);
+      await apis.user.favorites.addFavoriteById('file', file3Id);
 
-      const existingId1 = await createFavoriteFolder(existingFolder, sourceIdFav);
-      await apis.createFile(file2InFolder, existingId1);
+      existingFileId = (await apis.user.nodes.createFile(`${existingFile}.txt`, sourceIdFav)).entry.id;
+      await apis.user.favorites.addFavoriteById('file', existingFileId);
+      await apis.user.nodes.createFile(`${existingFile}.txt`, destinationIdFav);
 
-      const existingId2 = await apis.createFolder(existingFolder, destinationIdFav);
-      await apis.createFile(file3InFolder, existingId2);
+      existingId1 = (await apis.user.nodes.createFolder(existingFolder, sourceIdFav)).entry.id;
+      existingId2 = (await apis.user.nodes.createFolder(existingFolder, destinationIdFav)).entry.id;
+      await apis.user.nodes.createFile(file2InFolder, existingId1);
+      await apis.user.nodes.createFile(file3InFolder, existingId2);
+      await apis.user.favorites.addFavoriteById('folder', existingId1);
 
-      const folder2Id = await createFavoriteFolder(folder2, sourceIdFav);
-      await apis.createFile(fileInFolder2, folder2Id);
+      file4Id = (await apis.user.nodes.createFile(file4, sourceIdFav)).entry.id;
+      folder2Id = (await apis.user.nodes.createFolder(folder2, sourceIdFav)).entry.id;
+      await apis.user.nodes.createFile(fileInFolder2, folder2Id);
+      await apis.user.favorites.addFavoriteById('file', file4Id);
+      await apis.user.favorites.addFavoriteById('folder', folder2Id);
 
-      await apis.favorites.waitForApi({ expect: 9 });
+      await apis.user.favorites.waitForApi({ expect: 9 });
     });
 
     beforeEach(async () => {

--- a/e2e/suites/actions/create/create-file-from-template.test.ts
+++ b/e2e/suites/actions/create/create-file-from-template.test.ts
@@ -32,8 +32,7 @@ import {
   clearTextWithBackspace,
   AdminActions,
   RepoClient,
-  NodeContentTree,
-  UserActions
+  NodeContentTree
 } from '@alfresco/aca-testing-shared';
 import { BrowserActions, Logger } from '@alfresco/adf-testing';
 
@@ -81,7 +80,6 @@ describe('Create file from template', () => {
   const userApi = new RepoClient(username, username);
 
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
@@ -115,22 +113,20 @@ describe('Create file from template', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    parentId = await userApi.createFolder(parent);
+    parentId = (await userApi.nodes.createFolder(parent)).entry.id;
     await userApi.nodes.createFile(duplicateFileName, parentId);
 
     await userApi.sites.createSite(siteName);
     docLibUserSite = await userApi.sites.getDocLibId(siteName);
-    await userApi.createFile(duplicateFileSite, docLibUserSite);
+    await userApi.nodes.createFile(duplicateFileSite, docLibUserSite);
 
     await loginPage.loginWith(username);
   });
 
   afterAll(async () => {
-    await userActions.login(username, username);
-    await userActions.deleteNodes([parentId]);
-    await userActions.deleteSites([siteName]);
+    await userApi.nodes.deleteNodeById(parentId);
+    await userApi.sites.deleteSite(siteName);
 
     await adminApiActions.login();
     await adminApiActions.cleanupNodeTemplatesItems([

--- a/e2e/suites/actions/create/create-folder-from-template.test.ts
+++ b/e2e/suites/actions/create/create-folder-from-template.test.ts
@@ -32,8 +32,7 @@ import {
   clearTextWithBackspace,
   AdminActions,
   RepoClient,
-  NodeContentTree,
-  UserActions
+  NodeContentTree
 } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
@@ -107,7 +106,6 @@ describe('Create folder from template', () => {
 
   const userApi = new RepoClient(username, username);
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
@@ -117,7 +115,6 @@ describe('Create folder from template', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
     parentId = (await userApi.nodes.createFolder(parent)).entry.id;
     await userApi.nodes.createFolder(duplicateFolderName, parentId);
@@ -135,8 +132,8 @@ describe('Create folder from template', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
-    await userActions.deleteSites([siteName]);
+    await userApi.nodes.deleteNodeById(parentId);
+    await userApi.sites.deleteSite(siteName);
 
     await adminApiActions.login();
     await adminApiActions.cleanupSpaceTemplatesItems([

--- a/e2e/suites/actions/create/create-folder.test.ts
+++ b/e2e/suites/actions/create/create-folder.test.ts
@@ -30,8 +30,7 @@ import {
   CreateOrEditFolderDialog,
   Utils,
   clearTextWithBackspace,
-  RepoClient,
-  UserActions
+  RepoClient
 } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
@@ -60,9 +59,7 @@ describe('Create folder', () => {
   const page = new BrowsingPage();
   const createDialog = new CreateOrEditFolderDialog();
   const { dataTable } = page;
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   async function openCreateFolderDialog(name: string) {
     await page.dataTable.doubleClickOnRowByName(name);
@@ -72,21 +69,20 @@ describe('Create folder', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    parentId = await apis.user.createFolder(parent);
-    await apis.user.createFolder(duplicateFolderName, parentId);
+    parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
+    await apis.user.nodes.createFolder(duplicateFolderName, parentId);
 
     await apis.user.sites.createSite(siteName);
     docLibUserSite = await apis.user.sites.getDocLibId(siteName);
-    await apis.user.createFolder(duplicateFolderSite, docLibUserSite);
+    await apis.user.nodes.createFolder(duplicateFolderSite, docLibUserSite);
 
     await loginPage.loginWith(username);
   });
 
   afterAll(async () => {
-    await userActions.deleteSites([siteName]);
-    await userActions.deleteNodes([parentId]);
+    await apis.user.sites.deleteSite(siteName);
+    await apis.user.nodes.deleteNodeById(parentId);
   });
 
   describe('on Personal Files', () => {

--- a/e2e/suites/actions/create/create-library.test.ts
+++ b/e2e/suites/actions/create/create-library.test.ts
@@ -114,7 +114,7 @@ describe('Create library', () => {
     expect(await page.breadcrumb.currentItem.getText()).toEqual(site1Name, `Not navigated into ${site1Name}`);
     await page.goToMyLibrariesAndWait();
     expect(await dataTable.isItemPresent(site1Name)).toBe(true, `${site1Name} not in the list`);
-    expect((await apis.user.sites.getSite(site1Name)).entry.visibility).toEqual(SITE_VISIBILITY.PUBLIC);
+    expect(await apis.user.sites.getVisibility(site1Name)).toEqual(SITE_VISIBILITY.PUBLIC);
   });
 
   it('[C289880] Create a moderated library', async () => {
@@ -128,7 +128,7 @@ describe('Create library', () => {
     expect(await page.breadcrumb.currentItem.getText()).toEqual(site2Name, `Not navigated into ${site2Name}`);
     await page.goToMyLibrariesAndWait();
     expect(await dataTable.isItemPresent(site2Name)).toBe(true, `${site2Name} not in the list`);
-    expect((await apis.user.sites.getSite(site2Name)).entry.visibility).toEqual(SITE_VISIBILITY.MODERATED);
+    expect(await apis.user.sites.getVisibility(site2Name)).toEqual(SITE_VISIBILITY.MODERATED);
   });
 
   it('[C289881] Create a private library', async () => {
@@ -142,7 +142,7 @@ describe('Create library', () => {
     expect(await page.breadcrumb.currentItem.getText()).toEqual(site3Name, `Not navigated into ${site3Name}`);
     await page.goToMyLibrariesAndWait();
     expect(await dataTable.isItemPresent(site3Name)).toBe(true, `${site3Name} not in the list`);
-    expect((await apis.user.sites.getSite(site3Name)).entry.visibility).toEqual(SITE_VISIBILITY.PRIVATE);
+    expect(await apis.user.sites.getVisibility(site3Name)).toEqual(SITE_VISIBILITY.PRIVATE);
   });
 
   it('[C289882] Create a library with a given ID and description', async () => {
@@ -158,8 +158,8 @@ describe('Create library', () => {
     expect(await page.breadcrumb.currentItem.getText()).toEqual(site4.name, `Not navigated into ${site4.name}`);
     await page.goToMyLibrariesAndWait();
     expect(await dataTable.isItemPresent(site4.name)).toBe(true, `${site4.name} not in the list`);
-    expect((await apis.user.sites.getSite(site4.id)).entry.visibility).toEqual(SITE_VISIBILITY.PUBLIC);
-    expect((await apis.user.sites.getSite(site4.id)).entry.description).toEqual(site4.description);
+    expect(await apis.user.sites.getVisibility(site4.id)).toEqual(SITE_VISIBILITY.PUBLIC);
+    expect(await apis.user.sites.getDescription(site4.id)).toEqual(site4.description);
   });
 
   it('[C280027] Duplicate library ID', async () => {
@@ -217,6 +217,6 @@ describe('Create library', () => {
     expect(await page.breadcrumb.currentItem.getText()).toEqual(duplicateSite.name, `Not navigated into ${duplicateSite.name}`);
     await page.goToMyLibrariesAndWait();
     expect(await dataTable.isItemPresent(`${duplicateSite.name} (${duplicateSite.id}-2)`)).toBe(true, `${duplicateSite.name} not in the list`);
-    expect((await apis.user.sites.getSite(`${duplicateSite.id}-2`)).entry.title).toEqual(duplicateSite.name);
+    expect(await apis.user.sites.getTitle(`${duplicateSite.id}-2`)).toEqual(duplicateSite.name);
   });
 });

--- a/e2e/suites/actions/delete/delete-undo-delete.test.ts
+++ b/e2e/suites/actions/delete/delete-undo-delete.test.ts
@@ -42,7 +42,6 @@ describe('Delete and undo delete', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
   });
 
   afterAll(async () => {
@@ -156,11 +155,17 @@ describe('Delete and undo delete', () => {
     const file7 = `file7-${Utils.random()}.txt`;
 
     const folder1 = `folder1-${Utils.random()}`;
+    let folder1Id: string;
     const folder2 = `folder2-${Utils.random()}`;
+    let folder2Id: string;
     const folder3 = `folder3-${Utils.random()}`;
+    let folder3Id: string;
     const folder4 = `folder4-${Utils.random()}`;
+    let folder4Id: string;
     const folder5 = `folder5-${Utils.random()}`;
+    let folder5Id: string;
     const folder6 = `folder6-${Utils.random()}`;
+    let folder6Id: string;
 
     const file1InFolder = `file1InFolder-${Utils.random()}.txt`;
     const file2InFolder = `file2InFolder-${Utils.random()}.txt`;
@@ -177,31 +182,34 @@ describe('Delete and undo delete', () => {
     let parentId: string;
 
     beforeAll(async () => {
-      parentId = await apis.user.createFolder(parent);
+      parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
 
-      await apis.user.createFile(file1, parentId);
-      await apis.user.createFile(file2, parentId);
-      await apis.user.createFile(file3, parentId);
-      await apis.user.createFile(file4, parentId);
-      await apis.user.createFile(file5, parentId);
-      await apis.user.createFile(file6, parentId);
-      await apis.user.createFile(file7, parentId);
+      await apis.user.nodes.createFile(file1, parentId);
+      await apis.user.nodes.createFile(file2, parentId);
+      await apis.user.nodes.createFile(file3, parentId);
+      await apis.user.nodes.createFile(file4, parentId);
+      await apis.user.nodes.createFile(file5, parentId);
+      await apis.user.nodes.createFile(file6, parentId);
+      await apis.user.nodes.createFile(file7, parentId);
 
-      const folder1Id = await apis.user.createFolder(folder1, parentId);
-      const folder2Id = await apis.user.createFolder(folder2, parentId);
-      const folder3Id = await apis.user.createFolder(folder3, parentId);
-      const folder4Id = await apis.user.createFolder(folder4, parentId);
-      const folder5Id = await apis.user.createFolder(folder5, parentId);
-      const folder6Id = await apis.user.createFolder(folder6, parentId);
+      folder1Id = (await apis.user.nodes.createFolder(folder1, parentId)).entry.id;
+      folder2Id = (await apis.user.nodes.createFolder(folder2, parentId)).entry.id;
+      folder3Id = (await apis.user.nodes.createFolder(folder3, parentId)).entry.id;
+      folder4Id = (await apis.user.nodes.createFolder(folder4, parentId)).entry.id;
+      folder5Id = (await apis.user.nodes.createFolder(folder5, parentId)).entry.id;
+      folder6Id = (await apis.user.nodes.createFolder(folder6, parentId)).entry.id;
 
-      await apis.user.createFile(file1InFolder, folder1Id);
-      fileLocked1Id = await apis.user.createFile(fileLocked1, folder2Id);
-      fileLocked2Id = await apis.user.createFile(fileLocked2, folder3Id);
-      fileLocked3Id = await apis.user.createFile(fileLocked3, folder4Id);
-      fileLocked4Id = await apis.user.createFile(fileLocked4, folder5Id);
-      await apis.user.createFile(file2InFolder, folder6Id);
+      await apis.user.nodes.createFile(file1InFolder, folder1Id);
+      fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, folder2Id)).entry.id;
+      fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, folder3Id)).entry.id;
+      fileLocked3Id = (await apis.user.nodes.createFile(fileLocked3, folder4Id)).entry.id;
+      fileLocked4Id = (await apis.user.nodes.createFile(fileLocked4, folder5Id)).entry.id;
+      await apis.user.nodes.createFile(file2InFolder, folder6Id);
 
-      await userActions.lockNodes([fileLocked1Id, fileLocked2Id, fileLocked3Id, fileLocked4Id], 'FULL');
+      await apis.user.nodes.lockFile(fileLocked1Id, 'FULL');
+      await apis.user.nodes.lockFile(fileLocked2Id, 'FULL');
+      await apis.user.nodes.lockFile(fileLocked3Id, 'FULL');
+      await apis.user.nodes.lockFile(fileLocked4Id, 'FULL');
 
       await loginPage.loginWith(username);
     });
@@ -213,8 +221,12 @@ describe('Delete and undo delete', () => {
 
     afterAll(async () => {
       try {
+        await apis.user.nodes.unlockFile(fileLocked1Id);
+        await apis.user.nodes.unlockFile(fileLocked2Id);
+        await apis.user.nodes.unlockFile(fileLocked3Id);
+        await apis.user.nodes.unlockFile(fileLocked4Id);
+
         await userActions.login(username, username);
-        await userActions.unlockNodes([fileLocked1Id, fileLocked2Id, fileLocked3Id, fileLocked4Id]);
         await userActions.deleteNodes([parentId]);
         await userActions.emptyTrashcan();
       } catch (error) {
@@ -330,25 +342,31 @@ describe('Delete and undo delete', () => {
 
   describe('on Shared Files', () => {
     const sharedFile1 = `sharedFile1-${Utils.random()}.txt`;
+    let sharedFile1Id: string;
     const sharedFile2 = `sharedFile2-${Utils.random()}.txt`;
+    let sharedFile2Id: string;
     const sharedFile3 = `sharedFile3-${Utils.random()}.txt`;
+    let sharedFile3Id: string;
     const sharedFile4 = `sharedFile4-${Utils.random()}.txt`;
+    let sharedFile4Id: string;
     const sharedFile5 = `sharedFile5-${Utils.random()}.txt`;
+    let sharedFile5Id: string;
     const sharedFile6 = `sharedFile6-${Utils.random()}.txt`;
+    let sharedFile6Id: string;
 
     const parent = `parentSF-${Utils.random()}`;
     let parentId: string;
 
     beforeAll(async () => {
       try {
-        parentId = await apis.user.createFolder(parent);
+        parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
 
-        const sharedFile1Id = await apis.user.createFile(sharedFile1, parentId);
-        const sharedFile2Id = await apis.user.createFile(sharedFile2, parentId);
-        const sharedFile3Id = await apis.user.createFile(sharedFile3, parentId);
-        const sharedFile4Id = await apis.user.createFile(sharedFile4, parentId);
-        const sharedFile5Id = await apis.user.createFile(sharedFile5, parentId);
-        const sharedFile6Id = await apis.user.createFile(sharedFile6, parentId);
+        sharedFile1Id = (await apis.user.nodes.createFile(sharedFile1, parentId)).entry.id;
+        sharedFile2Id = (await apis.user.nodes.createFile(sharedFile2, parentId)).entry.id;
+        sharedFile3Id = (await apis.user.nodes.createFile(sharedFile3, parentId)).entry.id;
+        sharedFile4Id = (await apis.user.nodes.createFile(sharedFile4, parentId)).entry.id;
+        sharedFile5Id = (await apis.user.nodes.createFile(sharedFile5, parentId)).entry.id;
+        sharedFile6Id = (await apis.user.nodes.createFile(sharedFile6, parentId)).entry.id;
 
         await apis.user.shared.shareFilesByIds([sharedFile1Id, sharedFile2Id, sharedFile3Id, sharedFile4Id, sharedFile5Id, sharedFile6Id]);
         await apis.user.shared.waitForFilesToBeShared([sharedFile1Id, sharedFile2Id, sharedFile3Id, sharedFile4Id, sharedFile5Id, sharedFile6Id]);
@@ -422,19 +440,32 @@ describe('Delete and undo delete', () => {
     let parentId: string;
 
     const favFile1 = `favFile1-${Utils.random()}.txt`;
+    let favFile1Id: string;
     const favFile2 = `favFile2-${Utils.random()}.txt`;
+    let favFile2Id: string;
     const favFile3 = `favFile3-${Utils.random()}.txt`;
+    let favFile3Id: string;
     const favFile4 = `favFile4-${Utils.random()}.txt`;
+    let favFile4Id: string;
     const favFile5 = `favFile5-${Utils.random()}.txt`;
+    let favFile5Id: string;
     const favFile6 = `favFile6-${Utils.random()}.txt`;
+    let favFile6Id: string;
     const favFile7 = `favFile7-${Utils.random()}.txt`;
+    let favFile7Id: string;
 
     const favFolder1 = `favFolder1-${Utils.random()}`;
+    let favFolder1Id: string;
     const favFolder2 = `favFolder2-${Utils.random()}`;
+    let favFolder2Id: string;
     const favFolder3 = `favFolder3-${Utils.random()}`;
+    let favFolder3Id: string;
     const favFolder4 = `favFolder4-${Utils.random()}`;
+    let favFolder4Id: string;
     const favFolder5 = `favFolder5-${Utils.random()}`;
+    let favFolder5Id: string;
     const favFolder6 = `favFolder6-${Utils.random()}`;
+    let favFolder6Id: string;
 
     const file1InFolder = `file1InFolder-${Utils.random()}.txt`;
     const file2InFolder = `file2InFolder-${Utils.random()}.txt`;
@@ -449,31 +480,34 @@ describe('Delete and undo delete', () => {
 
     beforeAll(async () => {
       try {
-        parentId = await apis.user.createFolder(parent);
+        parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
 
-        const favFile1Id = await apis.user.createFile(favFile1, parentId);
-        const favFile2Id = await apis.user.createFile(favFile2, parentId);
-        const favFile3Id = await apis.user.createFile(favFile3, parentId);
-        const favFile4Id = await apis.user.createFile(favFile4, parentId);
-        const favFile5Id = await apis.user.createFile(favFile5, parentId);
-        const favFile6Id = await apis.user.createFile(favFile6, parentId);
-        const favFile7Id = await apis.user.createFile(favFile7, parentId);
+        favFile1Id = (await apis.user.nodes.createFile(favFile1, parentId)).entry.id;
+        favFile2Id = (await apis.user.nodes.createFile(favFile2, parentId)).entry.id;
+        favFile3Id = (await apis.user.nodes.createFile(favFile3, parentId)).entry.id;
+        favFile4Id = (await apis.user.nodes.createFile(favFile4, parentId)).entry.id;
+        favFile5Id = (await apis.user.nodes.createFile(favFile5, parentId)).entry.id;
+        favFile6Id = (await apis.user.nodes.createFile(favFile6, parentId)).entry.id;
+        favFile7Id = (await apis.user.nodes.createFile(favFile7, parentId)).entry.id;
 
-        const favFolder1Id = await apis.user.createFolder(favFolder1, parentId);
-        const favFolder2Id = await apis.user.createFolder(favFolder2, parentId);
-        const favFolder3Id = await apis.user.createFolder(favFolder3, parentId);
-        const favFolder4Id = await apis.user.createFolder(favFolder4, parentId);
-        const favFolder5Id = await apis.user.createFolder(favFolder5, parentId);
-        const favFolder6Id = await apis.user.createFolder(favFolder6, parentId);
+        favFolder1Id = (await apis.user.nodes.createFolder(favFolder1, parentId)).entry.id;
+        favFolder2Id = (await apis.user.nodes.createFolder(favFolder2, parentId)).entry.id;
+        favFolder3Id = (await apis.user.nodes.createFolder(favFolder3, parentId)).entry.id;
+        favFolder4Id = (await apis.user.nodes.createFolder(favFolder4, parentId)).entry.id;
+        favFolder5Id = (await apis.user.nodes.createFolder(favFolder5, parentId)).entry.id;
+        favFolder6Id = (await apis.user.nodes.createFolder(favFolder6, parentId)).entry.id;
 
-        await apis.user.createFile(file1InFolder, favFolder1Id);
-        fileLocked1Id = await apis.user.createFile(fileLocked1, favFolder2Id);
-        fileLocked2Id = await apis.user.createFile(fileLocked2, favFolder3Id);
-        fileLocked3Id = await apis.user.createFile(fileLocked3, favFolder4Id);
-        fileLocked4Id = await apis.user.createFile(fileLocked4, favFolder5Id);
+        await apis.user.nodes.createFile(file1InFolder, favFolder1Id);
+        fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, favFolder2Id)).entry.id;
+        fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, favFolder3Id)).entry.id;
+        fileLocked3Id = (await apis.user.nodes.createFile(fileLocked3, favFolder4Id)).entry.id;
+        fileLocked4Id = (await apis.user.nodes.createFile(fileLocked4, favFolder5Id)).entry.id;
         await apis.user.nodes.createFile(file2InFolder, favFolder6Id);
 
-        await userActions.lockNodes([fileLocked1Id, fileLocked2Id, fileLocked3Id, fileLocked4Id], 'FULL');
+        await apis.user.nodes.lockFile(fileLocked1Id, 'FULL');
+        await apis.user.nodes.lockFile(fileLocked2Id, 'FULL');
+        await apis.user.nodes.lockFile(fileLocked3Id, 'FULL');
+        await apis.user.nodes.lockFile(fileLocked4Id, 'FULL');
 
         const initialFavoritesTotalItems = await apis.user.favorites.getFavoritesTotalItems();
         await apis.user.favorites.addFavoritesByIds('file', [favFile1Id, favFile2Id, favFile3Id, favFile4Id, favFile5Id, favFile6Id, favFile7Id]);
@@ -492,8 +526,12 @@ describe('Delete and undo delete', () => {
 
     afterAll(async () => {
       try {
+        await apis.user.nodes.unlockFile(fileLocked1Id);
+        await apis.user.nodes.unlockFile(fileLocked2Id);
+        await apis.user.nodes.unlockFile(fileLocked3Id);
+        await apis.user.nodes.unlockFile(fileLocked4Id);
+
         await userActions.login(username, username);
-        await userActions.unlockNodes([fileLocked1Id, fileLocked2Id, fileLocked3Id, fileLocked4Id]);
         await userActions.deleteNodes([parentId]);
         await userActions.emptyTrashcan();
       } catch (error) {

--- a/e2e/suites/actions/edit/edit-offline.test.ts
+++ b/e2e/suites/actions/edit/edit-offline.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, FILES, RepoClient, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, FILES, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('Edit offline', () => {
   const username = `user-${Utils.random()}`;
@@ -53,11 +53,9 @@ describe('Edit offline', () => {
   const { searchInput } = page.header;
 
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    userActions.login(username, username);
   });
 
   describe('on Personal Files', () => {
@@ -67,13 +65,14 @@ describe('Edit offline', () => {
     let fileLocked2Id: string;
 
     beforeAll(async () => {
-      parentPFId = await apis.user.createFolder(parentPF);
+      parentPFId = (await apis.user.nodes.createFolder(parentPF)).entry.id;
 
       file1Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentPFId, file1)).entry.id;
       fileLockedId = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentPFId, fileLocked)).entry.id;
       fileLocked2Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentPFId, fileLocked2)).entry.id;
 
-      await userActions.lockNodes([fileLockedId, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLockedId);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await loginPage.loginWith(username);
     });
@@ -88,8 +87,7 @@ describe('Edit offline', () => {
     });
 
     afterAll(async () => {
-      userActions.login(username, username);
-      await userActions.deleteNodes([parentPFId]);
+      await apis.user.nodes.deleteNodeById(parentPFId);
     });
 
     it('[C297538] File is locked and downloaded when clicking Edit Offline', async () => {
@@ -123,13 +121,14 @@ describe('Edit offline', () => {
     let fileLocked2Id: string;
 
     beforeAll(async () => {
-      parentSFId = await apis.user.createFolder(parentSF);
+      parentSFId = (await apis.user.nodes.createFolder(parentSF)).entry.id;
 
       file1Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSFId, file1)).entry.id;
       fileLockedId = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSFId, fileLocked)).entry.id;
       fileLocked2Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSFId, fileLocked2)).entry.id;
 
-      await userActions.lockNodes([fileLockedId, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLockedId);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.shared.shareFilesByIds([file1Id, fileLockedId, fileLocked2Id]);
       await apis.user.shared.waitForFilesToBeShared([file1Id, fileLockedId, fileLocked2Id]);
@@ -138,7 +137,7 @@ describe('Edit offline', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteNodes([parentSFId]);
+      await apis.user.nodes.deleteNodeById(parentSFId);
     });
 
     beforeEach(async () => {
@@ -180,7 +179,7 @@ describe('Edit offline', () => {
     let fileLocked2Id: string;
 
     beforeAll(async () => {
-      parentRFId = await apis.user.createFolder(parentRF);
+      parentRFId = (await apis.user.nodes.createFolder(parentRF)).entry.id;
 
       await apis.user.search.waitForApi(username, { expect: 0 });
 
@@ -188,7 +187,8 @@ describe('Edit offline', () => {
       fileLockedId = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentRFId, fileLocked)).entry.id;
       fileLocked2Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentRFId, fileLocked2)).entry.id;
 
-      await userActions.lockNodes([fileLockedId, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLockedId);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.search.waitForApi(username, { expect: 3 });
 
@@ -196,7 +196,7 @@ describe('Edit offline', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteNodes([parentRFId]);
+      await apis.user.nodes.deleteNodeById(parentRFId);
     });
 
     beforeEach(async () => {
@@ -237,12 +237,13 @@ describe('Edit offline', () => {
     let fileLocked2Id: string;
 
     beforeAll(async () => {
-      parentFavId = await apis.user.createFolder(parentFav);
+      parentFavId = (await apis.user.nodes.createFolder(parentFav)).entry.id;
 
       fileLockedId = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentFavId, fileLocked)).entry.id;
       fileLocked2Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentFavId, fileLocked2)).entry.id;
 
-      userActions.lockNodes([fileLockedId, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLockedId);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.favorites.addFavoritesByIds('file', [fileLockedId, fileLocked2Id]);
       await apis.user.favorites.waitForApi({ expect: 2 });
@@ -251,7 +252,7 @@ describe('Edit offline', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteNodes([parentFavId]);
+      await apis.user.nodes.deleteNodeById(parentFavId);
     });
 
     beforeEach(async () => {
@@ -285,13 +286,14 @@ describe('Edit offline', () => {
     let fileSearchLocked2Id: string;
 
     beforeAll(async () => {
-      parentSearchId = await apis.user.createFolder(parentSearch);
+      parentSearchId = (await apis.user.nodes.createFolder(parentSearch)).entry.id;
 
       fileSearch1Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSearchId, fileSearch1)).entry.id;
       fileSearchLockedId = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSearchId, fileSearchLocked)).entry.id;
       fileSearchLocked2Id = (await apis.user.upload.uploadFileWithRename(FILES.docxFile, parentSearchId, fileSearchLocked2)).entry.id;
 
-      await userActions.lockNodes([fileSearchLockedId, fileSearchLocked2Id]);
+      await apis.user.nodes.lockFile(fileSearchLockedId);
+      await apis.user.nodes.lockFile(fileSearchLocked2Id);
 
       await apis.user.search.waitForNodes(searchRandom, { expect: 3 });
 
@@ -299,7 +301,7 @@ describe('Edit offline', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteNodes([parentSearchId]);
+      await apis.user.nodes.deleteNodeById(parentSearchId);
     });
 
     beforeEach(async () => {

--- a/e2e/suites/actions/favorite/mark-favorite.test.ts
+++ b/e2e/suites/actions/favorite/mark-favorite.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, SITE_VISIBILITY, RepoClient, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, SITE_VISIBILITY, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('Mark items as favorites', () => {
   const username = `user-${Utils.random()}`;
@@ -84,11 +84,9 @@ describe('Mark items as favorites', () => {
   const { searchInput } = page.header;
 
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
     parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
 
@@ -125,7 +123,7 @@ describe('Mark items as favorites', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
   });
 
   afterEach(async () => {
@@ -362,15 +360,15 @@ describe('Mark items as favorites', () => {
 
   describe('on Search Results', () => {
     beforeAll(async () => {
-      fileSearchNotFav1Id = await apis.user.createFile(fileSearchNotFav1, parentId);
-      fileSearchNotFav2Id = await apis.user.createFile(fileSearchNotFav2, parentId);
-      fileSearchNotFav3Id = await apis.user.createFile(fileSearchNotFav3, parentId);
-      fileSearchNotFav4Id = await apis.user.createFile(fileSearchNotFav4, parentId);
-      fileSearchFav1Id = await apis.user.createFile(fileSearchFav1, parentId);
-      fileSearchFav2Id = await apis.user.createFile(fileSearchFav2, parentId);
-      fileSearchFav3Id = await apis.user.createFile(fileSearchFav3, parentId);
-      fileSearchFav4Id = await apis.user.createFile(fileSearchFav4, parentId);
-      folderSearchId = await apis.user.createFolder(folderSearch, parentId);
+      fileSearchNotFav1Id = (await apis.user.nodes.createFile(fileSearchNotFav1, parentId)).entry.id;
+      fileSearchNotFav2Id = (await apis.user.nodes.createFile(fileSearchNotFav2, parentId)).entry.id;
+      fileSearchNotFav3Id = (await apis.user.nodes.createFile(fileSearchNotFav3, parentId)).entry.id;
+      fileSearchNotFav4Id = (await apis.user.nodes.createFile(fileSearchNotFav4, parentId)).entry.id;
+      fileSearchFav1Id = (await apis.user.nodes.createFile(fileSearchFav1, parentId)).entry.id;
+      fileSearchFav2Id = (await apis.user.nodes.createFile(fileSearchFav2, parentId)).entry.id;
+      fileSearchFav3Id = (await apis.user.nodes.createFile(fileSearchFav3, parentId)).entry.id;
+      fileSearchFav4Id = (await apis.user.nodes.createFile(fileSearchFav4, parentId)).entry.id;
+      folderSearchId = (await apis.user.nodes.createFolder(folderSearch, parentId)).entry.id;
       await apis.user.search.waitForNodes(searchRandom, { expect: 9 });
 
       await apis.user.favorites.addFavoritesByIds('file', [fileSearchFav1Id, fileSearchFav2Id, fileSearchFav3Id, fileSearchFav4Id]);
@@ -478,15 +476,15 @@ describe('Mark items as favorites', () => {
       await apis.user.sites.createSite(siteName, SITE_VISIBILITY.PUBLIC);
       const docLibId = await apis.user.sites.getDocLibId(siteName);
 
-      folderSiteId = await apis.user.createFolder(folderSite, docLibId);
-      fileSiteNotFav1Id = await apis.user.createFile(fileSiteNotFav1, folderSiteId);
-      fileSiteNotFav2Id = await apis.user.createFile(fileSiteNotFav2, folderSiteId);
-      fileSiteNotFav3Id = await apis.user.createFile(fileSiteNotFav3, folderSiteId);
-      fileSiteNotFav4Id = await apis.user.createFile(fileSiteNotFav4, folderSiteId);
-      fileSiteFav1Id = await apis.user.createFile(fileSiteFav1, folderSiteId);
-      fileSiteFav2Id = await apis.user.createFile(fileSiteFav2, folderSiteId);
-      fileSiteFav3Id = await apis.user.createFile(fileSiteFav3, folderSiteId);
-      fileSiteFav4Id = await apis.user.createFile(fileSiteFav4, folderSiteId);
+      folderSiteId = (await apis.user.nodes.createFolder(folderSite, docLibId)).entry.id;
+      fileSiteNotFav1Id = (await apis.user.nodes.createFile(fileSiteNotFav1, folderSiteId)).entry.id;
+      fileSiteNotFav2Id = (await apis.user.nodes.createFile(fileSiteNotFav2, folderSiteId)).entry.id;
+      fileSiteNotFav3Id = (await apis.user.nodes.createFile(fileSiteNotFav3, folderSiteId)).entry.id;
+      fileSiteNotFav4Id = (await apis.user.nodes.createFile(fileSiteNotFav4, folderSiteId)).entry.id;
+      fileSiteFav1Id = (await apis.user.nodes.createFile(fileSiteFav1, folderSiteId)).entry.id;
+      fileSiteFav2Id = (await apis.user.nodes.createFile(fileSiteFav2, folderSiteId)).entry.id;
+      fileSiteFav3Id = (await apis.user.nodes.createFile(fileSiteFav3, folderSiteId)).entry.id;
+      fileSiteFav4Id = (await apis.user.nodes.createFile(fileSiteFav4, folderSiteId)).entry.id;
 
       await apis.user.favorites.addFavoritesByIds('file', [fileSiteFav1Id, fileSiteFav2Id, fileSiteFav3Id, fileSiteFav4Id]);
 
@@ -497,7 +495,7 @@ describe('Mark items as favorites', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteSites([siteName]);
+      await apis.user.sites.deleteSite(siteName);
     });
 
     beforeEach(async () => {

--- a/e2e/suites/actions/share/share-file.test.ts
+++ b/e2e/suites/actions/share/share-file.test.ts
@@ -54,13 +54,12 @@ describe('Share a file', () => {
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    parentId = await apis.user.createFolder(parent);
+    parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
   });
 
   describe('when logged out', () => {
@@ -68,7 +67,7 @@ describe('Share a file', () => {
     let file6Id: string;
 
     beforeAll(async () => {
-      file6Id = await apis.user.createFile(file6, parentId);
+      file6Id = (await apis.user.nodes.createFile(file6, parentId)).entry.id;
 
       const sharedId = (await apis.user.shared.shareFileById(file6Id)).entry.id;
       file6SharedLink = `${shareLinkPreUrl}${sharedId}`;
@@ -76,7 +75,7 @@ describe('Share a file', () => {
     });
 
     afterAll(async () => {
-      await userActions.deleteNodes([file6Id]);
+      await apis.user.nodes.deleteNodeById(file6Id);
     });
 
     it('[C286326] A non-logged user can download the shared file from the viewer', async () => {
@@ -113,13 +112,13 @@ describe('Share a file', () => {
       let file9Id: string;
 
       beforeAll(async () => {
-        file3Id = await apis.user.createFile(file3, parentId);
-        file4Id = await apis.user.createFile(file4, parentId);
-        file5Id = await apis.user.createFile(file5, parentId);
-        file6Id = await apis.user.createFile(file6, parentId);
-        file7Id = await apis.user.createFile(file7, parentId);
-        file8Id = await apis.user.createFile(file8, parentId);
-        file9Id = await apis.user.createFile(file9, parentId);
+        file3Id = (await apis.user.nodes.createFile(file3, parentId)).entry.id;
+        file4Id = (await apis.user.nodes.createFile(file4, parentId)).entry.id;
+        file5Id = (await apis.user.nodes.createFile(file5, parentId)).entry.id;
+        file6Id = (await apis.user.nodes.createFile(file6, parentId)).entry.id;
+        file7Id = (await apis.user.nodes.createFile(file7, parentId)).entry.id;
+        file8Id = (await apis.user.nodes.createFile(file8, parentId)).entry.id;
+        file9Id = (await apis.user.nodes.createFile(file9, parentId)).entry.id;
 
         await userActions.login(username, username);
         await userActions.shareNodes([file6Id, file7Id], expiryDate);
@@ -138,7 +137,7 @@ describe('Share a file', () => {
       });
 
       afterAll(async () => {
-        await userActions.deleteNodes([file3Id, file4Id, file5Id, file6Id, file7Id, file8Id, file9Id]);
+        await apis.user.nodes.deleteNodesById([file3Id, file4Id, file5Id, file6Id, file7Id, file8Id, file9Id]);
       });
 
       it('[C286327] Share dialog default values', async () => {

--- a/e2e/suites/actions/share/unshare-file-search-results.test.ts
+++ b/e2e/suites/actions/share/unshare-file-search-results.test.ts
@@ -82,12 +82,12 @@ describe('Unshare a file from Search Results', () => {
     try {
       await adminApiActions.createUser({ username });
 
-      parentId = await apis.user.createFolder(parent);
+      parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
 
-      file1Id = await apis.user.createFile(file1, parentId);
-      file2Id = await apis.user.createFile(file2, parentId);
-      file3Id = await apis.user.createFile(file3, parentId);
-      file4Id = await apis.user.createFile(file4, parentId);
+      file1Id = (await apis.user.nodes.createFile(file1, parentId)).entry.id;
+      file2Id = (await apis.user.nodes.createFile(file2, parentId)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, parentId)).entry.id;
+      file4Id = (await apis.user.nodes.createFile(file4, parentId)).entry.id;
 
       await adminApiActions.login();
       await adminApiActions.sites.createSite(sitePrivate, SITE_VISIBILITY.PRIVATE);
@@ -114,7 +114,7 @@ describe('Unshare a file from Search Results', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
     await adminApiActions.sites.deleteSite(sitePrivate);
   });
 

--- a/e2e/suites/actions/upload-download/upload-file.test.ts
+++ b/e2e/suites/actions/upload-download/upload-file.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, RepoClient, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('Upload files', () => {
   const username = `user-${Utils.random()}`;
@@ -38,15 +38,11 @@ describe('Upload files', () => {
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
   const { dataTable } = page;
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
-
-    folder1Id = await apis.user.createFolder(folder1);
+    folder1Id = (await apis.user.nodes.createFolder(folder1)).entry.id;
 
     await loginPage.loginWith(username);
   });
@@ -61,7 +57,7 @@ describe('Upload files', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([folder1Id]);
+    await apis.user.nodes.deleteNodeById(folder1Id);
   });
 
   it('Upload a file', async () => {

--- a/e2e/suites/actions/upload-download/upload-new-version.test.ts
+++ b/e2e/suites/actions/upload-download/upload-new-version.test.ts
@@ -31,8 +31,7 @@ import {
   FILES,
   RepoClient,
   Utils,
-  UploadNewVersionDialog,
-  UserActions
+  UploadNewVersionDialog
 } from '@alfresco/aca-testing-shared';
 
 describe('Upload new version', () => {
@@ -96,38 +95,39 @@ describe('Upload new version', () => {
   const { dataTable, toolbar } = page;
   const uploadNewVersionDialog = new UploadNewVersionDialog();
   const { searchInput } = page.header;
-
-  const adminActions = new AdminActions();
-  const userActions = new UserActions();
+  const adminApiActions = new AdminActions();
 
   beforeAll(async () => {
-    await adminActions.createUser({ username });
-    userActions.login(username, username);
+    await adminApiActions.createUser({ username });
 
-    parentPFId = await apis.user.createFolder(parentPF);
-    parentSFId = await apis.user.createFolder(parentSF);
-    parentRFId = await apis.user.createFolder(parentRF);
-    parentFavId = await apis.user.createFolder(parentFav);
-    parentSearchId = await apis.user.createFolder(parentSearch);
+    parentPFId = (await apis.user.nodes.createFolder(parentPF)).entry.id;
+    parentSFId = (await apis.user.nodes.createFolder(parentSF)).entry.id;
+    parentRFId = (await apis.user.nodes.createFolder(parentRF)).entry.id;
+    parentFavId = (await apis.user.nodes.createFolder(parentFav)).entry.id;
+    parentSearchId = (await apis.user.nodes.createFolder(parentSearch)).entry.id;
   });
 
   afterAll(async () => {
-    userActions.login(username, username);
-    await userActions.deleteNodes([parentPFId, parentSFId, parentRFId, parentFavId, parentSearchId]);
+    await apis.user.nodes.deleteNodeById(parentPFId);
+    await apis.user.nodes.deleteNodeById(parentSFId);
+    await apis.user.nodes.deleteNodeById(parentRFId);
+    await apis.user.nodes.deleteNodeById(parentFavId);
+    await apis.user.nodes.deleteNodeById(parentSearchId);
   });
 
   describe('on Search Results', () => {
     beforeAll(async () => {
       fileId = (await apis.user.upload.uploadFile(file, parentSearchId)).entry.id;
-      fileSearch1Id = await apis.user.createFile(fileSearch1, parentSearchId);
-      fileSearch2Id = await apis.user.createFile(fileSearch2, parentSearchId);
-      fileSearch3Id = await apis.user.createFile(fileSearch3, parentSearchId);
-      fileSearch4Id = await apis.user.createFile(fileSearch4, parentSearchId);
+      fileSearch1Id = (await apis.user.nodes.createFile(fileSearch1, parentSearchId)).entry.id;
+      fileSearch2Id = (await apis.user.nodes.createFile(fileSearch2, parentSearchId)).entry.id;
+      fileSearch3Id = (await apis.user.nodes.createFile(fileSearch3, parentSearchId)).entry.id;
+      fileSearch4Id = (await apis.user.nodes.createFile(fileSearch4, parentSearchId)).entry.id;
 
-      fileLockedSearch1Id = await apis.user.createFile(fileLockedSearch1, parentSearchId);
-      fileLockedSearch2Id = await apis.user.createFile(fileLockedSearch2, parentSearchId);
+      fileLockedSearch1Id = (await apis.user.nodes.createFile(fileLockedSearch1, parentSearchId)).entry.id;
+      fileLockedSearch2Id = (await apis.user.nodes.createFile(fileLockedSearch2, parentSearchId)).entry.id;
 
-      userActions.lockNodes([fileLockedSearch1Id, fileLockedSearch2Id]);
+      await apis.user.nodes.lockFile(fileLockedSearch1Id);
+      await apis.user.nodes.lockFile(fileLockedSearch2Id);
 
       await apis.user.search.waitForNodes(searchRandom, { expect: 6 });
 
@@ -301,7 +301,9 @@ describe('Upload new version', () => {
       fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, parentPFId)).entry.id;
       fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, parentPFId)).entry.id;
 
-      await userActions.lockNodes([fileLocked1Id, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLocked1Id);
+      await apis.user.nodes.lockFile(fileLocked2Id);
+
       await loginPage.loginWith(username);
     });
 
@@ -437,15 +439,16 @@ describe('Upload new version', () => {
   describe('on Shared Files', () => {
     beforeAll(async () => {
       fileId = (await apis.user.upload.uploadFile(file, parentSFId)).entry.id;
-      file1Id = await apis.user.createFile(file1, parentSFId);
-      file2Id = await apis.user.createFile(file2, parentSFId);
-      file3Id = await apis.user.createFile(file3, parentSFId);
-      file4Id = await apis.user.createFile(file4, parentSFId);
+      file1Id = (await apis.user.nodes.createFile(file1, parentSFId)).entry.id;
+      file2Id = (await apis.user.nodes.createFile(file2, parentSFId)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, parentSFId)).entry.id;
+      file4Id = (await apis.user.nodes.createFile(file4, parentSFId)).entry.id;
 
-      fileLocked1Id = await apis.user.createFile(fileLocked1, parentSFId);
-      fileLocked2Id = await apis.user.createFile(fileLocked2, parentSFId);
+      fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, parentSFId)).entry.id;
+      fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, parentSFId)).entry.id;
 
-      await userActions.lockNodes([fileLocked1Id, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLocked1Id);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.shared.shareFilesByIds([fileId, file1Id, file2Id, file3Id, file4Id, fileLocked1Id, fileLocked2Id]);
       await apis.user.shared.waitForFilesToBeShared([fileId, file1Id, file2Id, file3Id, file4Id, fileLocked1Id, fileLocked2Id]);
@@ -584,15 +587,16 @@ describe('Upload new version', () => {
     beforeAll(async () => {
       const initialRecentTotalItems = await apis.user.search.getTotalItems(username);
       fileId = (await apis.user.upload.uploadFile(file, parentRFId)).entry.id;
-      file1Id = await apis.user.createFile(file1, parentRFId);
-      file2Id = await apis.user.createFile(file2, parentRFId);
-      file3Id = await apis.user.createFile(file3, parentRFId);
-      file4Id = await apis.user.createFile(file4, parentRFId);
+      file1Id = (await apis.user.nodes.createFile(file1, parentRFId)).entry.id;
+      file2Id = (await apis.user.nodes.createFile(file2, parentRFId)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, parentRFId)).entry.id;
+      file4Id = (await apis.user.nodes.createFile(file4, parentRFId)).entry.id;
 
-      fileLocked1Id = await apis.user.createFile(fileLocked1, parentRFId);
-      fileLocked2Id = await apis.user.createFile(fileLocked2, parentRFId);
+      fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, parentRFId)).entry.id;
+      fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, parentRFId)).entry.id;
 
-      await userActions.lockNodes([fileLocked1Id, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLocked1Id);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.search.waitForApi(username, { expect: initialRecentTotalItems + 7 });
 
@@ -730,15 +734,16 @@ describe('Upload new version', () => {
     beforeAll(async () => {
       const initialFavoritesTotalItems = await apis.user.favorites.getFavoritesTotalItems();
       fileId = (await apis.user.upload.uploadFile(file, parentFavId)).entry.id;
-      file1Id = await apis.user.createFile(file1, parentFavId);
-      file2Id = await apis.user.createFile(file2, parentFavId);
-      file3Id = await apis.user.createFile(file3, parentFavId);
-      file4Id = await apis.user.createFile(file4, parentFavId);
+      file1Id = (await apis.user.nodes.createFile(file1, parentFavId)).entry.id;
+      file2Id = (await apis.user.nodes.createFile(file2, parentFavId)).entry.id;
+      file3Id = (await apis.user.nodes.createFile(file3, parentFavId)).entry.id;
+      file4Id = (await apis.user.nodes.createFile(file4, parentFavId)).entry.id;
 
-      fileLocked1Id = await apis.user.createFile(fileLocked1, parentFavId);
-      fileLocked2Id = await apis.user.createFile(fileLocked2, parentFavId);
+      fileLocked1Id = (await apis.user.nodes.createFile(fileLocked1, parentFavId)).entry.id;
+      fileLocked2Id = (await apis.user.nodes.createFile(fileLocked2, parentFavId)).entry.id;
 
-      await userActions.lockNodes([fileLocked1Id, fileLocked2Id]);
+      await apis.user.nodes.lockFile(fileLocked1Id);
+      await apis.user.nodes.lockFile(fileLocked2Id);
 
       await apis.user.favorites.addFavoritesByIds('file', [fileId, file1Id, file2Id, file3Id, file4Id, fileLocked1Id, fileLocked2Id]);
       await apis.user.favorites.waitForApi({ expect: initialFavoritesTotalItems + 7 });

--- a/e2e/suites/actions/upload-download/version-actions.test.ts
+++ b/e2e/suites/actions/upload-download/version-actions.test.ts
@@ -23,17 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  AdminActions,
-  LoginPage,
-  BrowsingPage,
-  FILES,
-  RepoClient,
-  Utils,
-  ManageVersionsDialog,
-  Viewer,
-  UserActions
-} from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, FILES, RepoClient, Utils, ManageVersionsDialog, Viewer } from '@alfresco/aca-testing-shared';
 import { browser } from 'protractor';
 import { Logger } from '@alfresco/adf-testing';
 
@@ -58,14 +48,11 @@ describe('Version actions', () => {
   const versionManagePage = new ManageVersionsDialog();
   const viewerPage = new Viewer();
   const { searchInput } = page.header;
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     try {
       await adminApiActions.createUser({ username });
-      await userActions.login(username, username);
 
       parentFolderId = (await apis.user.nodes.createFolder(parentFolder)).entry.id;
 
@@ -95,7 +82,7 @@ describe('Version actions', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentFolderId]);
+    await apis.user.nodes.deleteNodeById(parentFolderId);
   });
 
   describe('on Personal Files', () => {

--- a/e2e/suites/application/general.test.ts
+++ b/e2e/suites/application/general.test.ts
@@ -25,26 +25,23 @@
 
 import { browser } from 'protractor';
 import { BrowserActions } from '@alfresco/adf-testing';
-import { BrowsingPage, LoginPage, CreateOrEditFolderDialog, Utils, AdminActions } from '@alfresco/aca-testing-shared';
+import { BrowsingPage, LoginPage, CreateOrEditFolderDialog, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('General', () => {
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
   const createDialog = new CreateOrEditFolderDialog();
-
-  const adminActions = new AdminActions();
-
+  const adminApi = new RepoClient();
   const folder = `folder-${Utils.random()}`;
   let folderId: string;
 
   describe('on session expire', () => {
     beforeAll(async () => {
-      adminActions.login();
-      folderId = (await adminActions.nodes.createFolder(folder)).entry.id;
+      folderId = (await adminApi.nodes.createFolder(folder)).entry.id;
     });
 
     afterAll(async () => {
-      await adminActions.deleteNodes([folderId]);
+      await adminApi.nodes.deleteNodeById(folderId);
     });
 
     it('[C286473] should close opened dialogs', async () => {
@@ -54,7 +51,7 @@ describe('General', () => {
       await createDialog.waitForDialogToOpen();
       await createDialog.enterName(folder);
 
-      await adminActions.logout();
+      await adminApi.logout();
 
       await BrowserActions.click(createDialog.createButton);
 

--- a/e2e/suites/extensions/ext-context-submenus.test.ts
+++ b/e2e/suites/extensions/ext-context-submenus.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, EXTENSIBILITY_CONFIGS, RepoClient, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, EXTENSIBILITY_CONFIGS, RepoClient, Utils } from '@alfresco/aca-testing-shared';
 
 describe('Extensions - Context submenu', () => {
   const username = `user-${Utils.random()}`;
@@ -51,16 +51,12 @@ describe('Extensions - Context submenu', () => {
   const page = new BrowsingPage();
   const { dataTable } = page;
   const contextMenu = dataTable.menu;
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
-
-    fileId = await apis.user.createFile(file);
-    folderId = await apis.user.createFolder(folder);
+    fileId = (await apis.user.nodes.createFile(file)).entry.id;
+    folderId = (await apis.user.nodes.createFolder(folder)).entry.id;
 
     await loginPage.load();
     await Utils.setSessionStorageFromConfig(EXTENSIBILITY_CONFIGS.CONTEXT_SUBMENUS);
@@ -74,7 +70,8 @@ describe('Extensions - Context submenu', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([fileId, folderId]);
+    await apis.user.nodes.deleteNodeById(fileId, true);
+    await apis.user.nodes.deleteNodeById(folderId, true);
   });
 
   it('[C286717] Displays the submenu actions set from config', async () => {

--- a/e2e/suites/extensions/ext-info-drawer.test.ts
+++ b/e2e/suites/extensions/ext-info-drawer.test.ts
@@ -23,16 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  AdminActions,
-  LoginPage,
-  BrowsingPage,
-  InfoDrawer,
-  RepoClient,
-  EXTENSIBILITY_CONFIGS,
-  Utils,
-  UserActions
-} from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, InfoDrawer, RepoClient, EXTENSIBILITY_CONFIGS, Utils } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
 describe('Extensions - Info Drawer', () => {
@@ -71,19 +62,15 @@ describe('Extensions - Info Drawer', () => {
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
-
-    fileId = await apis.user.createFile(file);
+    fileId = (await apis.user.nodes.createFile(file)).entry.id;
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([fileId]);
+    await apis.user.nodes.deleteNodeById(fileId);
   });
 
   describe('', () => {

--- a/e2e/suites/extensions/ext-metadata.test.ts
+++ b/e2e/suites/extensions/ext-metadata.test.ts
@@ -31,8 +31,7 @@ import {
   EXTENSIBILITY_CONFIGS,
   Utils,
   InfoDrawer,
-  MetadataCard,
-  UserActions
+  MetadataCard
 } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
@@ -72,14 +71,10 @@ describe('Extensions - Metadata presets', () => {
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
-
     fileId = (await apis.user.nodes.createImage(file)).entry.id;
 
     await loginPage.load();
@@ -100,7 +95,7 @@ describe('Extensions - Metadata presets', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([fileId]);
+    await apis.user.nodes.deleteNodeById(fileId);
   });
 
   it('[C286636] Set groups of properties to display', async () => {

--- a/e2e/suites/info-drawer/general.test.ts
+++ b/e2e/suites/info-drawer/general.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AdminActions, LoginPage, BrowsingPage, RepoClient, InfoDrawer, Utils, UserActions } from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, RepoClient, InfoDrawer, Utils } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
 describe('General', () => {
@@ -44,23 +44,20 @@ describe('General', () => {
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
   const { dataTable } = page;
-
   const adminApiActions = new AdminActions();
-  const userActions = new UserActions();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
 
-    parentId = await apis.user.createFolder(parent);
-    await apis.user.createFile(file1, parentId);
-    await apis.user.createFolder(folder1, parentId);
+    parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
+    await apis.user.nodes.createFile(file1, parentId);
+    await apis.user.nodes.createFolder(folder1, parentId);
 
     await loginPage.loginWith(username);
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
   });
 
   beforeEach(async () => {

--- a/e2e/suites/list-views/generic-errors.test.ts
+++ b/e2e/suites/list-views/generic-errors.test.ts
@@ -52,10 +52,9 @@ describe('Generic errors', () => {
     try {
       await adminApiActions.createUser({ username });
       await adminApiActions.createUser({ username: username2 });
-      await userActions.login(username, username);
 
-      parentId = await apis.user.createFolder(parent);
-      file1Id = await apis.user.createFile(file1, parentId);
+      parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
+      file1Id = (await apis.user.nodes.createFile(file1, parentId)).entry.id;
       await apis.user.nodes.createFile(file2, parentId);
 
       await loginPage.loginWith(username);
@@ -75,7 +74,7 @@ describe('Generic errors', () => {
     await dataTable.doubleClickOnRowByName(parent);
     await dataTable.doubleClickOnRowByName(file1);
     const URL = await browser.getCurrentUrl();
-    await userActions.deleteNodes([file1Id], false);
+    await apis.user.nodes.deleteNodeById(file1Id, false);
     await browser.get(URL);
 
     expect(await page.genericError.isDisplayed()).toBe(true, 'Generic error page not displayed');

--- a/e2e/suites/list-views/trash.test.ts
+++ b/e2e/suites/list-views/trash.test.ts
@@ -93,12 +93,13 @@ describe('Trash', () => {
   afterAll(async () => {
     try {
       await adminApiActions.login();
-      await adminApiActions.deleteSites([siteName]);
+      await adminApiActions.sites.deleteSite(siteName);
       await adminApiActions.trashcanApi.deleteDeletedNode(fileAdminId);
       await adminApiActions.trashcanApi.deleteDeletedNode(folderAdminId);
 
+      await apis.user.nodes.deleteNodeById(folderNotDeletedId);
+
       await userActions.login(username, username);
-      await userActions.deleteNodes([folderNotDeletedId]);
       await userActions.emptyTrashcan();
     } catch (error) {
       Logger.error(`----- afterAll failed : ${error}`);

--- a/e2e/suites/pagination/multiple-pages-libraries.test.ts
+++ b/e2e/suites/pagination/multiple-pages-libraries.test.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { LoginPage, BrowsingPage, Utils, AdminActions, RepoClient, SITE_VISIBILITY } from '@alfresco/aca-testing-shared';
+import { LoginPage, BrowsingPage, Utils, AdminActions, RepoClient } from '@alfresco/aca-testing-shared';
 import { Logger } from '@alfresco/adf-testing';
 
 describe('Pagination on multiple pages', () => {
@@ -46,7 +46,7 @@ describe('Pagination on multiple pages', () => {
     try {
       await adminApiActions.createUser({ username });
 
-      await userApi.sites.createSites(sites, SITE_VISIBILITY.PRIVATE);
+      await userApi.sites.createSitesPrivate(sites);
       await userApi.sites.waitForSitesToBeCreated(sites);
 
       await loginPage.loginWith(username);

--- a/e2e/suites/viewer/viewer-actions.test.ts
+++ b/e2e/suites/viewer/viewer-actions.test.ts
@@ -59,15 +59,12 @@ describe('Viewer actions', () => {
   const copyMoveDialog = new ContentNodeSelectorDialog();
   const shareDialog = new ShareDialog();
   const uploadNewVersionDialog = new UploadNewVersionDialog();
-
   const adminApiActions = new AdminActions();
   const userActions = new UserActions();
-
   const uploadFilesDialog = new UploadFilesDialog();
 
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
-    await userActions.login(username, username);
   });
 
   describe('from Personal Files', () => {
@@ -94,8 +91,8 @@ describe('Viewer actions', () => {
 
     beforeAll(async () => {
       try {
-        parentId = await apis.user.createFolder(parent);
-        destinationId = await apis.user.createFolder(destination);
+        parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
+        destinationId = (await apis.user.nodes.createFolder(destination)).entry.id;
 
         await apis.user.upload.uploadFileWithRename(docxFile, parentId, docxPersonalFiles);
 
@@ -108,7 +105,10 @@ describe('Viewer actions', () => {
         fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
         fileForUploadNewVersionId2 = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion2)).entry.id;
 
-        await userActions.lockNodes([fileForCancelEditingId, fileForUploadNewVersionId, fileForUploadNewVersionId2]);
+        await apis.user.nodes.lockFile(fileForCancelEditingId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId2);
+
         await loginPage.loginWith(username);
       } catch (error) {
         Logger.error(`----- beforeAll failed : ${error}`);
@@ -257,7 +257,7 @@ describe('Viewer actions', () => {
       try {
         await apis.user.sites.createSite(siteName);
         const docLibId = await apis.user.sites.getDocLibId(siteName);
-        destinationId = await apis.user.createFolder(destination);
+        destinationId = (await apis.user.nodes.createFolder(destination)).entry.id;
 
         await apis.user.upload.uploadFile(docxFile2, docLibId);
 
@@ -268,7 +268,8 @@ describe('Viewer actions', () => {
         fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, docLibId, fileForCancelEditing)).entry.id;
         fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, docLibId, fileForUploadNewVersion)).entry.id;
 
-        await userActions.lockNodes([fileForCancelEditingId, fileForUploadNewVersionId]);
+        await apis.user.nodes.lockFile(fileForCancelEditingId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId);
 
         await loginPage.loginWith(username);
       } catch (error) {
@@ -349,7 +350,8 @@ describe('Viewer actions', () => {
         fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
         fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
 
-        await userActions.lockNodes([fileForCancelEditingId, fileForUploadNewVersionId]);
+        await apis.user.nodes.lockFile(fileForCancelEditingId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId);
 
         await apis.user.upload.uploadFileWithRename(xlsxFileForMove, parentId, xlsxRecentFiles);
         await apis.user.upload.uploadFileWithRename(pdfFileForDelete, parentId, pdfRecentFiles);
@@ -437,7 +439,8 @@ describe('Viewer actions', () => {
         fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
         fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
 
-        await userActions.lockNodes([fileForCancelEditingId, fileForUploadNewVersionId]);
+        await apis.user.nodes.lockFile(fileForCancelEditingId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId);
 
         await apis.user.shared.shareFilesByIds([
           docxFileId,
@@ -507,27 +510,37 @@ describe('Viewer actions', () => {
     let destinationId: string;
 
     const docxFavorites = `docxFav-${Utils.random()}.docx`;
+    let docxFileId: string;
+
     const xlsxFavorites = `xlsxFav-${Utils.random()}.xlsx`;
+    let xlsxFileId: string;
     const pdfFavorites = `pdfFav-${Utils.random()}.pdf`;
+    let pdfFileId: string;
+    let fileFavId: string;
+
     const fileForEditOffline = `file1-${Utils.random()}.docx`;
+    let fileForEditOfflineId: string;
     const fileForCancelEditing = `file2-${Utils.random()}.docx`;
+    let fileForCancelEditingId: string;
     const fileForUploadNewVersion = `file3-${Utils.random()}.docx`;
+    let fileForUploadNewVersionId: string;
 
     beforeAll(async () => {
       try {
         parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
         destinationId = (await apis.user.nodes.createFolder(destination)).entry.id;
-        const docxFileId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, docxFavorites)).entry.id;
+        docxFileId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, docxFavorites)).entry.id;
 
-        const xlsxFileId = (await apis.user.upload.uploadFileWithRename(xlsxFileForMove, parentId, xlsxFavorites)).entry.id;
-        const pdfFileId = (await apis.user.upload.uploadFileWithRename(pdfFileForDelete, parentId, pdfFavorites)).entry.id;
-        const fileFavId = (await apis.user.upload.uploadFile(docxFile2, parentId)).entry.id;
+        xlsxFileId = (await apis.user.upload.uploadFileWithRename(xlsxFileForMove, parentId, xlsxFavorites)).entry.id;
+        pdfFileId = (await apis.user.upload.uploadFileWithRename(pdfFileForDelete, parentId, pdfFavorites)).entry.id;
+        fileFavId = (await apis.user.upload.uploadFile(docxFile2, parentId)).entry.id;
 
-        const fileForEditOfflineId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForEditOffline)).entry.id;
-        const fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
-        const fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
+        fileForEditOfflineId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForEditOffline)).entry.id;
+        fileForCancelEditingId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForCancelEditing)).entry.id;
+        fileForUploadNewVersionId = (await apis.user.upload.uploadFileWithRename(docxFile, parentId, fileForUploadNewVersion)).entry.id;
 
-        await userActions.lockNodes([fileForCancelEditingId, fileForUploadNewVersionId]);
+        await apis.user.nodes.lockFile(fileForCancelEditingId);
+        await apis.user.nodes.lockFile(fileForUploadNewVersionId);
 
         await apis.user.favorites.addFavoritesByIds('file', [
           docxFileId,

--- a/e2e/suites/viewer/viewer-general.test.ts
+++ b/e2e/suites/viewer/viewer-general.test.ts
@@ -60,7 +60,7 @@ describe('Viewer general', () => {
   beforeAll(async () => {
     await adminApiActions.createUser({ username });
 
-    parentId = await apis.user.createFolder(parent);
+    parentId = (await apis.user.nodes.createFolder(parent)).entry.id;
     xlsxFileId = (await apis.user.upload.uploadFile(xlsxFile, parentId)).entry.id;
 
     await adminApiActions.sites.createSite(siteAdmin, SITE_VISIBILITY.PRIVATE);

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/favorites/favorites-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/favorites/favorites-api.ts
@@ -25,6 +25,7 @@
 
 import { RepoApi } from '../repo-api';
 import { Logger } from '@alfresco/adf-testing';
+import { RepoClient } from './../../repo-client';
 import { Utils } from '../../../../utilities/utils';
 import { FavoritesApi as AdfFavoritesApi, SitesApi as AdfSiteApi, FavoriteEntry } from '@alfresco/js-api';
 
@@ -34,6 +35,23 @@ export class FavoritesApi extends RepoApi {
 
   constructor(username?: string, password?: string) {
     super(username, password);
+  }
+
+  async addFavorite(api: RepoClient, nodeType: string, name: string, parentFolderId?: string) {
+    try {
+      const nodeId = (await api.nodes.getNodeByPath(name, parentFolderId)).entry.id;
+      const data = {
+        target: {
+          [nodeType]: {
+            guid: nodeId
+          }
+        }
+      };
+      return await this.favoritesApi.createFavorite('-me-', data);
+    } catch (error) {
+      this.handleError(`FavoritesApi addFavorite : catch : `, error);
+      return null;
+    }
   }
 
   async addFavoriteById(nodeType: 'file' | 'folder' | 'site', id: string): Promise<FavoriteEntry | null> {
@@ -74,7 +92,7 @@ export class FavoritesApi extends RepoApi {
     return favorites;
   }
 
-  private async getFavorites() {
+  async getFavorites() {
     try {
       await this.apiAuth();
       return await this.favoritesApi.listFavorites(this.username);
@@ -129,7 +147,7 @@ export class FavoritesApi extends RepoApi {
     return isFavorite;
   }
 
-  private async removeFavoriteById(nodeId: string) {
+  async removeFavoriteById(nodeId: string) {
     try {
       await this.apiAuth();
       return await this.favoritesApi.deleteFavorite('-me-', nodeId);

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/queries/queries-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/queries/queries-api.ts
@@ -35,20 +35,42 @@ export class QueriesApi extends RepoApi {
     super(username, password);
   }
 
-  private async findSitesTotalItems(searchTerm: string): Promise<number> {
+  async findSites(searchTerm: string) {
+    const data = {
+      term: searchTerm,
+      fields: ['title']
+    };
+
     try {
       await this.apiAuth();
+      return this.queriesApi.findSites(searchTerm, data);
+    } catch (error) {
+      this.handleError(`QueriesApi findSites : catch : `, error);
+      return null;
+    }
+  }
 
-      const opts = {
-        term: searchTerm,
-        fields: ['title']
-      };
-
-      const sites = await this.queriesApi.findSites(searchTerm, opts);
-      return sites.list.pagination.totalItems;
+  async findSitesTotalItems(searchTerm: string): Promise<number> {
+    try {
+      return (await this.findSites(searchTerm)).list.pagination.totalItems;
     } catch (error) {
       this.handleError(`QueriesApi findSitesTotalItems : catch :`, error);
       return -1;
+    }
+  }
+
+  async findNodes(searchTerm: string) {
+    const data = {
+      term: searchTerm,
+      fields: ['name']
+    };
+
+    try {
+      await this.apiAuth();
+      return this.queriesApi.findNodes(searchTerm, data);
+    } catch (error) {
+      this.handleError(`QueriesApi findNodes : catch : `, error);
+      return null;
     }
   }
 
@@ -66,6 +88,24 @@ export class QueriesApi extends RepoApi {
       return await Utils.retryCall(sites);
     } catch (error) {
       Logger.error(`QueriesApi waitForSites : catch : `);
+      Logger.error(`\tExpected: ${data.expect} items, but found ${error}`);
+    }
+  }
+
+  async waitForFilesAndFolders(searchTerm: string, data: { expect: number }) {
+    try {
+      const nodes = async () => {
+        const totalItems = (await this.findNodes(searchTerm)).list.pagination.totalItems;
+        if (totalItems !== data.expect) {
+          return Promise.reject(totalItems);
+        } else {
+          return Promise.resolve(totalItems);
+        }
+      };
+
+      return await Utils.retryCall(nodes);
+    } catch (error) {
+      Logger.error(`QueriesApi waitForFilesAndFolders : catch : `);
       Logger.error(`\tExpected: ${data.expect} items, but found ${error}`);
     }
   }

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/search/search-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/search/search-api.ts
@@ -35,7 +35,7 @@ export class SearchApi extends RepoApi {
     super(username, password);
   }
 
-  private async queryRecentFiles(username: string) {
+  async queryRecentFiles(username: string) {
     const data = {
       query: {
         query: '*',
@@ -66,7 +66,7 @@ export class SearchApi extends RepoApi {
     }
   }
 
-  private async queryNodesNames(searchTerm: string) {
+  async queryNodesNames(searchTerm: string) {
     const data = {
       query: {
         query: `cm:name:\"${searchTerm}*\"`,
@@ -80,6 +80,33 @@ export class SearchApi extends RepoApi {
       return this.searchApi.search(data);
     } catch (error) {
       this.handleError(`SearchApi queryNodesNames : catch : `, error);
+      return null;
+    }
+  }
+
+  async getSearchByTermTotalItems(searchTerm: string): Promise<number> {
+    try {
+      return (await this.queryNodesNames(searchTerm)).list.pagination.totalItems;
+    } catch (error) {
+      this.handleError(`SearchApi getSearchByTermTotalItems : catch : `, error);
+      return -1;
+    }
+  }
+
+  async queryNodesExactNames(searchTerm: string) {
+    const data = {
+      query: {
+        query: `cm:name:\"${searchTerm}\"`,
+        language: 'afts'
+      },
+      filterQueries: [{ query: `+TYPE:'cm:folder' OR +TYPE:'cm:content'` }]
+    };
+
+    try {
+      await this.apiAuth();
+      return this.searchApi.search(data);
+    } catch (error) {
+      this.handleError(`SearchApi queryNodesExactNames : catch : `, error);
       return null;
     }
   }
@@ -107,7 +134,7 @@ export class SearchApi extends RepoApi {
 
     const apiCall = async () => {
       try {
-        return (await this.queryNodesNames(searchTerm)).list.pagination.totalItems;
+        return await this.getSearchByTermTotalItems(searchTerm);
       } catch (error) {
         return 0;
       }

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/shared-links/shared-links-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/shared-links/shared-links-api.ts
@@ -64,7 +64,7 @@ export class SharedLinksApi extends RepoApi {
     return sharedLinks;
   }
 
-  private async getSharedIdOfNode(fileId: string): Promise<string> {
+  async getSharedIdOfNode(fileId: string): Promise<string> {
     try {
       const sharedLinksEntries = (await this.getSharedLinks())?.list.entries;
       const found = sharedLinksEntries.find((sharedLink) => sharedLink.entry.nodeId === fileId);
@@ -84,7 +84,7 @@ export class SharedLinksApi extends RepoApi {
     }
   }
 
-  private async getSharedLinks(maxItems: number = 250): Promise<SharedLinkPaging | null> {
+  async getSharedLinks(maxItems: number = 250): Promise<SharedLinkPaging | null> {
     try {
       await this.apiAuth();
       const opts = {
@@ -94,6 +94,38 @@ export class SharedLinksApi extends RepoApi {
     } catch (error) {
       this.handleError(`SharedLinksApi getSharedLinks : catch : `, error);
       return null;
+    }
+  }
+
+  async getSharedLinksTotalItems(): Promise<number> {
+    try {
+      await this.apiAuth();
+      const opts = {
+        maxItems: 250
+      };
+      const sharedList = await this.sharedlinksApi.listSharedLinks(opts);
+      return sharedList.list.entries.length;
+    } catch (error) {
+      this.handleError(`SharedLinksApi getSharedLinksTotalItems : catch : `, error);
+      return -1;
+    }
+  }
+
+  async waitForApi(data: { expect: number }): Promise<any> {
+    try {
+      const sharedFiles = async () => {
+        const totalItems = await this.getSharedLinksTotalItems();
+        if (totalItems !== data.expect) {
+          return Promise.reject(totalItems);
+        } else {
+          return Promise.resolve(totalItems);
+        }
+      };
+
+      return await Utils.retryCall(sharedFiles);
+    } catch (error) {
+      Logger.error(`SharedLinksApi waitForApi :  catch : `);
+      Logger.error(`\tExpected: ${data.expect} items, but found ${error}`);
     }
   }
 

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/upload/upload-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/upload/upload-api.ts
@@ -29,8 +29,8 @@ import { browser } from 'protractor';
 import * as fs from 'fs';
 
 export class UploadApi extends RepoApi {
-  private upload = new AdfUploadApi(this.alfrescoJsApi);
-  private e2eRootPath = browser.params.e2eRootPath;
+  upload = new AdfUploadApi(this.alfrescoJsApi);
+  e2eRootPath = browser.params.e2eRootPath;
 
   constructor(username?: string, password?: string) {
     super(username, password);

--- a/projects/aca-testing-shared/src/utilities/repo-client/repo-client.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/repo-client.ts
@@ -74,14 +74,4 @@ export class RepoClient {
     await this.apiAuth();
     return this.alfrescoApi.logout();
   }
-
-  async createFolder(name: string, parentId?: string): Promise<string> {
-    const response = await this.nodes.createFolder(name, parentId);
-    return response.entry.id;
-  }
-
-  async createFile(name: string, parentId?: string): Promise<string> {
-    const response = await this.nodes.createFile(name, parentId);
-    return response.entry.id;
-  }
 }

--- a/projects/aca-testing-shared/src/utilities/user-actions.ts
+++ b/projects/aca-testing-shared/src/utilities/user-actions.ts
@@ -24,9 +24,8 @@
  */
 
 import { Logger } from '@alfresco/adf-testing';
-import { AlfrescoApi, Comment, CommentsApi, NodesApi, TrashcanApi, SitesApi, SharedlinksApi, SiteEntry } from '@alfresco/js-api';
+import { AlfrescoApi, Comment, CommentsApi, NodesApi, TrashcanApi, SitesApi, SharedlinksApi } from '@alfresco/js-api';
 import { browser } from 'protractor';
-import { SITE_VISIBILITY } from '../configs';
 import { Utils } from './utils';
 
 export class UserActions {
@@ -159,16 +158,6 @@ export class UserActions {
     }
   }
 
-  async lockNodes(nodeIds: string[], lockType: string = 'ALLOW_OWNER_CHANGES') {
-    try {
-      for (const nodeId of nodeIds) {
-        await this.nodesApi.lockNode(nodeId, { type: lockType });
-      }
-    } catch (error) {
-      this.handleError('User Actions - lockNodes failed : ', error);
-    }
-  }
-
   /**
    * Unlock multiple nodes.
    * @param nodeIds The list of node IDs to unlock.
@@ -181,32 +170,6 @@ export class UserActions {
     } catch (error) {
       this.handleError('User Actions - unlockNodes failed : ', error);
     }
-  }
-
-  /**
-   * Create multiple sites
-   * @param siteNames The list of the site names
-   * @param visibility Default site visibility
-   * @returns List of site entries
-   */
-  async createSites(siteNames: string[], visibility?: string): Promise<SiteEntry[]> {
-    const sites: SiteEntry[] = [];
-
-    try {
-      if (siteNames && siteNames.length > 0) {
-        for (const siteName of siteNames) {
-          const site = await this.sitesApi.createSite({
-            title: siteName,
-            visibility: visibility || SITE_VISIBILITY.PUBLIC,
-            id: siteName
-          });
-          sites.push(site);
-        }
-      }
-    } catch (error) {
-      this.handleError(`User Actions - createSites failed : `, error);
-    }
-    return sites;
   }
 
   /**


### PR DESCRIPTION
Reverts Alfresco/alfresco-content-app#2951

this is a breaking change  Property 'getSharedLinks' is private and only accessible within class 'SharedLinksApi'.
70             totalSharedFiles = (await userApi.shared.getSharedLinks()).list.pagination.totalItems;