### PR TITLE
[ACS-4276] Header section content does not reflow to fit horizontally within the viewpoint when the page is adjusted to an equivalent width of 320px or 400% zoom

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
@@ -153,3 +153,9 @@ mat-checkbox {
     max-width: 180px;
   }
 }
+
+@media screen and (max-width: 380px) {
+  .aca-search-input {
+    max-width: 148px;
+  }
+}


### PR DESCRIPTION
… viewpoint when the page is adjusted to an equivalent width of 320px or 400% zoom

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Header section content does not reflow to fit horizontally within the viewpoint when the page is adjusted to an equivalent width of 320px or 400% zoom


**What is the new behaviour?**
Adjusted Header section content to fit horizontally within the viewpoint when the page is adjusted to an equivalent width of 320px or 400% zoom


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
