### PR TITLE
[ACS-4259] Updated CSS rules for DateTimePicker

### DIFF
--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -162,7 +162,7 @@
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content:not(.mat-datetimepicker-calendar-body-selected) {
-    background-color: white !important;
+    background-color: var(--theme-datetimepicker-cell-background); !important;
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -167,7 +167,7 @@
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {
     background-color: var(--theme-grey-background-color);
-    color: var(--theme-font-color-black-87-alpha);
+    color: var(--theme-datetimepicker-font-color);
   }
 
   .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -158,7 +158,7 @@
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content {
-    outline: 2px solid var(--theme-blue-button-color);
+    outline: 2px solid var(--theme-datetimepicker-cell-focus-border);
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content:not(.mat-datetimepicker-calendar-body-selected) {
@@ -166,7 +166,7 @@
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {
-    background-color: var(--theme-grey-background-color);
+    background-color: var(--theme-datetimepicker-cell-focus-background);
     color: var(--theme-datetimepicker-font-color);
   }
 

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -162,7 +162,7 @@
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content:not(.mat-datetimepicker-calendar-body-selected) {
-    background-color: var(--theme-datetimepicker-cell-background); !important;
+    background-color: var(--theme-datetimepicker-cell-background) !important;
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -166,12 +166,12 @@
   }
 
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {
-    background-color: rgba(black, 0.12);
-    color: rgba(black, 0.87);
+    background-color: var(--theme-grey-background-color);
+    color: var(--theme-font-color-black-87-alpha);
   }
 
   .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {
-    background-color: #2254b2;
+    background-color: var(--theme-datetimepicker-selected-date-background);
   }
 
   .mat-expansion-panel .mat-expansion-panel-header {

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -157,9 +157,17 @@
     }
   }
 
+  .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content {
+    outline: 2px solid var(--theme-blue-button-color);
+  }
+
   .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content:not(.mat-datetimepicker-calendar-body-selected) {
     background-color: white !important;
-    outline: 2px solid var(--theme-blue-button-color);
+  }
+
+  .mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {
+    background-color: rgba(black, 0.12);
+    color: rgba(black, 0.87);
   }
 
   .mat-datetimepicker-calendar-body-cell-content.mat-datetimepicker-calendar-body-selected {

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -41,8 +41,8 @@ $black-heading: #4e4c4c;
 $grey-dropdown-background: #eee;
 $grey-divider: rgba(0,0,0,.22);
 $pagination-background-color: #ffffff;
-$black-87-alpha: rgba(black, 0.87);
-$blue-datetimepicker-background: #2254b2;
+$datetimepicker-font-color: rgba(black, 0.87);
+$datetimepicker-selected-date-background: #2254b2;
 
 $defaults: (
   --theme-primary-color: mat.get-color-from-palette($primary),
@@ -75,8 +75,8 @@ $defaults: (
   --theme-about-panel-border-color: $grey-background,
   --theme-about-panel-background-color: #ffffff,
   --theme-about-panel-title-color: #212121,
-  --theme-font-color-black-87-alpha: $black-87-alpha,
-  --theme-datetimepicker-selected-date-background: $blue-datetimepicker-background
+  --theme-datetimepicker-font-color: $datetimepicker-font-color,
+  --theme-datetimepicker-selected-date-background: $datetimepicker-selected-date-background
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -44,6 +44,8 @@ $pagination-background-color: #ffffff;
 $datetimepicker-font-color: rgba(black, 0.87);
 $datetimepicker-selected-date-background: #2254b2;
 $datetimepicker-cell-background-color: #ffffff;
+$datetimepicker-cell-focus-border-color: #1F74DB;
+$datetimepicker-cell-focus-background-color: rgba(33, 33, 33, 0.12);
 
 $defaults: (
   --theme-primary-color: mat.get-color-from-palette($primary),
@@ -78,7 +80,9 @@ $defaults: (
   --theme-about-panel-title-color: #212121,
   --theme-datetimepicker-font-color: $datetimepicker-font-color,
   --theme-datetimepicker-selected-date-background: $datetimepicker-selected-date-background,
-  --theme-datetimepicker-cell-background: $datetimepicker-cell-background-color
+  --theme-datetimepicker-cell-background: $datetimepicker-cell-background-color,
+  --theme-datetimepicker-cell-focus-border: $datetimepicker-cell-focus-border-color,
+  --theme-datetimepicker-cell-focus-background: $datetimepicker-cell-focus-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -43,6 +43,7 @@ $grey-divider: rgba(0,0,0,.22);
 $pagination-background-color: #ffffff;
 $datetimepicker-font-color: rgba(black, 0.87);
 $datetimepicker-selected-date-background: #2254b2;
+$datetimepicker-cell-background-color: #ffffff;
 
 $defaults: (
   --theme-primary-color: mat.get-color-from-palette($primary),
@@ -76,7 +77,8 @@ $defaults: (
   --theme-about-panel-background-color: #ffffff,
   --theme-about-panel-title-color: #212121,
   --theme-datetimepicker-font-color: $datetimepicker-font-color,
-  --theme-datetimepicker-selected-date-background: $datetimepicker-selected-date-background
+  --theme-datetimepicker-selected-date-background: $datetimepicker-selected-date-background,
+  --theme-datetimepicker-cell-background: $datetimepicker-cell-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -41,6 +41,8 @@ $black-heading: #4e4c4c;
 $grey-dropdown-background: #eee;
 $grey-divider: rgba(0,0,0,.22);
 $pagination-background-color: #ffffff;
+$black-87-alpha: rgba(black, 0.87);
+$blue-datetimepicker-background: #2254b2;
 
 $defaults: (
   --theme-primary-color: mat.get-color-from-palette($primary),
@@ -73,6 +75,8 @@ $defaults: (
   --theme-about-panel-border-color: $grey-background,
   --theme-about-panel-background-color: #ffffff,
   --theme-about-panel-title-color: #212121,
+  --theme-font-color-black-87-alpha: $black-87-alpha,
+  --theme-datetimepicker-selected-date-background: $blue-datetimepicker-background
 );
 
 // propagates SCSS variables into the CSS variables scope


### PR DESCRIPTION
Updated CSS rules for DateTimePicker  to show which date is currently focused on when navigating using the keyboard.

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When using the keyboard to navigate between different dates inside a datetimepicker, if the focus was set to a previously selected date, then there was no visual indicator.


**What is the new behaviour?**
When navigating to a previously selected date, there is significant change in the style of the date element, to give a visual indicator of focus change - 

- Background color changes from BLUE to GREY
- A BLUE border is added to the date element


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
