### PR TITLE
[ACS-4270] [ACS-4301] Content or functionality was lost due to overlapping content when the page is adjusted to an equivalent width of 320px or 400% zoom 

### DIFF
--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
@@ -53,3 +53,13 @@
     border-right: 1px solid var(--theme-border-color, rgba(0, 0, 0, 0.07));
   }
 }
+
+@media screen and (max-width: 380px) {
+  .aca-page-layout-header {
+    max-height: 16%;
+  }
+
+  .main-content {
+    max-height: 92%;
+  }
+}

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.scss
@@ -40,6 +40,16 @@
     max-width: 350px;
     width: 350px;
   }
+
+  @media screen and (max-width: 380px) {
+    .aca-page-layout-header {
+      max-height: 16%;
+    }
+
+    .main-content {
+      max-height: 92%;
+    }
+  }
 }
 
 [dir='rtl'] .aca-page-layout {
@@ -51,15 +61,5 @@
 [dir='ltr'] .aca-page-layout {
   .main-content {
     border-right: 1px solid var(--theme-border-color, rgba(0, 0, 0, 0.07));
-  }
-}
-
-@media screen and (max-width: 380px) {
-  .aca-page-layout-header {
-    max-height: 16%;
-  }
-
-  .main-content {
-    max-height: 92%;
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Content or functionality is lost due to overlapping content when the page is adjusted to an equivalent width of 320px or 400% zoom 


**What is the new behaviour?**
adjusted the libraries section, content and pagination section at 400% zoom to fit in the view port.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

before-

![Screenshot from 2023-02-14 16-20-37](https://user-images.githubusercontent.com/105338943/218714716-d092fa23-51a8-47f8-a149-f82750838745.png)

after -

![Screenshot from 2023-02-14 16-06-12](https://user-images.githubusercontent.com/105338943/218714772-aa3688f6-643e-4457-b565-de8e33441561.png)


