### PR TITLE
[ACS-4632] Add GH workflow to trigger ACA upstream

### DIFF
--- a/.github/workflows/aca-upstream.yml
+++ b/.github/workflows/aca-upstream.yml
@@ -30,8 +30,8 @@ jobs:
         - name: install NPM
           uses: actions/setup-node@v3
           with:
-            node-version: 14
-            cache-dependency-path: package-lock.json
+            node-version: 16
+            cache: 'npm'
         - name: Trigger upstream
           shell: bash
           run: |

--- a/.github/workflows/aca-upstream.yml
+++ b/.github/workflows/aca-upstream.yml
@@ -1,0 +1,39 @@
+name: "ACA upstream"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      repo_to_update:
+        description: Repository to update
+        type: choice
+        required: true
+        options:
+          - alfresco-applications
+          - alfresco-apps
+        default: alfresco-applications
+env:
+  GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+  TRAVIS_COMMIT: ${{ github.sha }}
+  TRAVIS_BUILD_NUMBER: ${{ github.run_id }}
+  NODE_OPTIONS: "--max-old-space-size=5120"
+
+jobs:
+  trigger_aca_upstream:
+    name: Trigger ACA upstream
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: install NPM
+          uses: actions/setup-node@v3
+          with:
+            node-version: 14
+            cache-dependency-path: package-lock.json
+        - name: Trigger upstream
+          shell: bash
+          run: |
+            npm install github-api
+            ./scripts/travis/update/update-project.sh -p $TRAVIS_BUILD_NUMBER -t $GH_TOKEN -v alpha -c $TRAVIS_COMMIT -r ${{ inputs.repo_to_update }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,8 +206,8 @@ jobs:
 
     - stage: Trigger DW
       script:
-        - ./scripts/trigger-travis.sh --branch $TRAVIS_BRANCH Alfresco alfresco-apps $TRAVIS_API_TOKEN
-        - ./scripts/travis/update/update-project.sh -p $TRAVIS_BUILD_NUMBER -t $GITHUB_TOKEN -v alpha -c $TRAVIS_COMMIT
+        - ./scripts/trigger-travis.sh --branch $TRAVIS_BRANCH Alfresco alfresco-applications $TRAVIS_API_TOKEN
+        - ./scripts/travis/update/update-project.sh -p $TRAVIS_BUILD_NUMBER -t $GITHUB_TOKEN -v alpha -c $TRAVIS_COMMIT -r alfresco-applications
 
 
 notifications:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

There is no way to trigger ACA upstream manually. ACA upstream is not created for applications repo. https://alfresco.atlassian.net/browse/ACS-4632

**What is the new behaviour?**

New GH workflow to manually trigger ACA upstream has been added. Upstream is automatically created for applications repo only.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
