### PR TITLE
[MOBILEAPPS-1707] Custom URL schema new issues from Frontend - dark squared shade for Open in App button, Banner is disappearing for the PDF files in ios and android

### DIFF
--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.scss
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.scss
@@ -2,6 +2,12 @@
   width: 100%;
   height: 100%;
 
+  .adf-alfresco-viewer {
+    .adf-viewer {
+      position: relative;
+    }
+  }
+
   .adf-viewer-toolbar .adf-toolbar-divider {
     display: none;
   }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -16,6 +16,6 @@
   overflow-x: hidden;
 }
 
-.open-in-app .cdk-program-focused .mat-button-focus-overlay {
+.open-in-app.cdk-program-focused .mat-button-focus-overlay {
   opacity: 0 !important;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -16,6 +16,6 @@
   overflow-x: hidden;
 }
 
-.open-in-app.cdk-program-focused .mat-button-focus-overlay {
+.open-in-app .cdk-program-focused .mat-button-focus-overlay {
   opacity: 0 !important;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -15,3 +15,7 @@
 .open-in-app.mat-button {
   overflow-x: hidden;
 }
+
+.open-in-app.cdk-program-focused .mat-button-focus-overlay {
+  opacity: 0 !important;
+}

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -16,6 +16,6 @@
   overflow-x: hidden;
 }
 
-.open-in-app.cdk-program-focused .mat-button-focus-overlay {
-  opacity: 0 !important;
+.open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
+  opacity: 0;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
1. The dark squared shade is showing on the backside “Open in app” text when the user clicks on the URL. 
2.The Banner is disappearing for the PDF files, so adding the PDF URLs 
URL 1: [Alfresco Content App](https://mobileapps.envalfresco.com/aca/#/preview/s/VO7a8j1UQ7iTU8PRJM5CJg)  
URL 2: [Alfresco Content App](https://mobileapps.envalfresco.com/aca/#/preview/s/jTFA2WL3R3GgH_9WEIwuLQ)

**What is the new behaviour?**
1. The dark squared shade will now show on the backside “Open in app” text when the user clicks on the URL. 
2. The banner will not disappear for the PDF files when shown in preview mode for android as well as for ios.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
