### PR TITLE
[ACA-4666] Make finalize fail if any previous check fails

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -208,6 +208,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
   finalize:
+    if: ${{ always() }}
     needs: [lint, build, unit-tests, e2es, e2es-playwright]
     name: 'Finalize'
     runs-on: ubuntu-latest
@@ -217,6 +218,14 @@ jobs:
         with:
           fetch-depth: 2
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-commit-message@v1.35.0
+
+      - name: Check previous jobs status
+        if: >-
+            ${{
+                contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+            }}
+        run: exit 1
 
       - name: Check ADF link
         shell: bash


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Finalize job is skipped when previous one fails. https://alfresco.atlassian.net/browse/ACA-4666

**What is the new behaviour?**

Finalize is run always and it checks previous job status.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
