### PR TITLE
[AAE-12511] Fix oidc breaking changes

### DIFF
--- a/tsconfig.adf.json
+++ b/tsconfig.adf.json
@@ -27,6 +27,7 @@
       "@alfresco/adf-core/*": ["../alfresco-ng2-components/lib/core/*/public-api.ts"],
       "@alfresco/adf-core/shell": ["../alfresco-ng2-components/lib/core/shell/src/index.ts"],
       "@alfresco/adf-core/auth": ["../alfresco-ng2-components/lib/core/auth/src/index.ts"],
+      "@alfresco/adf-core/api": ["../alfresco-ng2-components/lib/core/api/src/index.ts"],
       "@alfresco/adf-extensions": ["../alfresco-ng2-components/lib/extensions"],
       "@alfresco/adf-content-services": ["../alfresco-ng2-components/lib/content-services"],
       "@alfresco/adf-process-services-cloud": ["../alfresco-ng2-components/lib/process-services-cloud"],


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)
Merging this [PR](https://github.com/Alfresco/alfresco-ng2-components/pull/7856) on ADF, a new module `@alfresco/adf-core/api` has been created. To run the application with the adf configuration, that module has to be mapped with the adf path.


**What is the new behaviour?**
Map the module path in the tsconfig.adf.json.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
