### PR TITLE
fix publishing upon PR merge

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: "Pull request"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [master, develop]
 
 concurrency:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,6 @@
 name: "Pull request"
 
 on:
-  push:
-    branches: [master, develop]
   pull_request:
     branches: [master, develop]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,10 @@ on:
         required: false
         type: boolean
         default: true
-  pull_request:
-    types: [closed]
-    branches:
-      - develop
-      - master
-      - develop-patch*
-      - master-patch*
   push:
     branches:
       - master
+      - develop
 
 env:
   APP_CONFIG_ECM_HOST: ${{ secrets.PIPELINE_ENV_URL }}
@@ -61,7 +55,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-image
         with:
-          branch_name: ${{ github.base_ref }}
+          branch_name: ${{ env.BRANCH_NAME }}
           domain: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
@@ -84,7 +78,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-image
         with:
-          branch_name: ${{ github.base_ref }}
+          branch_name: ${{ env.BRANCH_NAME }}
           domain: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -113,7 +107,7 @@ jobs:
         uses: ./.github/actions/git-tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_name: ${{ github.base_ref }}
+          branch_name: ${{ env.BRANCH_NAME }}
           dry-run: ${{ inputs.dry-run-release }}
 
   publish-libs:
@@ -135,7 +129,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-libs
         with:
-          branch_name: ${{ github.base_ref }}
+          branch_name: ${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           npm_registry_address: ${{ vars.NPM_REGISTRY_ADDRESS }}
           npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-image
         with:
-          branch_name: ${{ env.BRANCH_NAME }}
+          branch_name: ${{ github.base_ref }}
           domain: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-image
         with:
-          branch_name: ${{ env.BRANCH_NAME }}
+          branch_name: ${{ github.base_ref }}
           domain: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -113,7 +113,7 @@ jobs:
         uses: ./.github/actions/git-tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_name: ${{ env.BRANCH_NAME }}
+          branch_name: ${{ github.base_ref }}
           dry-run: ${{ inputs.dry-run-release }}
 
   publish-libs:
@@ -135,7 +135,7 @@ jobs:
       - name: publish
         uses: ./.github/actions/publish-libs
         with:
-          branch_name: ${{ env.BRANCH_NAME }}
+          branch_name: ${{ github.base_ref }}
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           npm_registry_address: ${{ vars.NPM_REGISTRY_ADDRESS }}
           npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

upon merge, it takes the name of the source branch, not the target one
https://github.com/Alfresco/alfresco-content-app/actions/runs/4392942322/jobs/7693019234

**What is the new behaviour?**

fix publishing upon PR merge to `develop` (use target (`develop`) branch instead of the closed branch name)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
