### PR TITLE
[ACS-4441] Destination folder ids are now properly visible on View Rule Screen in Folder Rules

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -62,6 +62,7 @@
     "submenus",
     "succes",
     "superadmin",
+    "textitem",
     "thumbnailed",
     "titlecase",
     "tooltip",

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.scss
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.scss
@@ -3,5 +3,9 @@
     display: flex;
     flex-direction: row;
     gap: 20px;
+
+    adf-card-view .adf-property-list .adf-property adf-card-view-item-dispatcher adf-card-view-textitem .mat-form-field .mat-form-field-infix {
+      width: 280px;
+    }
   }
 }


### PR DESCRIPTION
…n Folder Rules

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Destination Folder ids are truncated on View Rule screen in Folder Rules


**What is the new behaviour?**
Destination folder ids are now properly visible on View Rule Screen in Folder Rules


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

before - 

![Screenshot from 2023-03-10 13-39-08](https://user-images.githubusercontent.com/105338943/224665064-6f473fd2-1d34-4ef0-a371-7688a63095bd.png)

After - 

![Screenshot from 2023-03-10 13-38-27](https://user-images.githubusercontent.com/105338943/224665149-f1069171-bf1f-4492-a47b-0c71c94ed722.png)



