### PR TITLE
[ACS-4106] Removed default text for file upload placeholder

### DIFF
--- a/projects/aca-folder-rules/assets/i18n/en.json
+++ b/projects/aca-folder-rules/assets/i18n/en.json
@@ -22,8 +22,7 @@
         "NAME": "Enter rule name",
         "DESCRIPTION": "Enter rule description",
         "NO_DESCRIPTION": "No description",
-        "VALUE": "Value",
-        "CHOOSE_FOLDER": "Choose destination folder"
+        "VALUE": "Value"
       },
       "ERROR": {
         "REQUIRED": "This field is required",

--- a/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/actions/rule-action.ui-component.ts
@@ -194,7 +194,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnDe
             return new CardViewTextItemModel({
               ...cardViewPropertiesModel,
               icon: 'folder',
-              default: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
+              default: '',
               clickable: true,
               clickCallBack: this.openSelectorDialog.bind(this, paramDef.name),
               value: this.parameters[paramDef.name]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If upload file is not selected, the 'create' buttons remains in enabled state.


**What is the new behaviour?**
'Create' button remains disabled until user doesn't select upload file


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
