### PR TITLE
[ACS-4436] comparator options set as Equals only when Encoding is selected in condition in Create/Edit a rule in Manage rules same as Share application

### DIFF
--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
@@ -91,11 +91,5 @@ export const ruleConditionComparators: RuleConditionComparator[] = [
     labels: {
       type: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.INSTANCE_OF'
     }
-  },
-  {
-    name: 'equals',
-    labels: {
-      equals_comparator: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.EQUALS'
-    }
   }
 ];

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-comparators.ts
@@ -91,5 +91,11 @@ export const ruleConditionComparators: RuleConditionComparator[] = [
     labels: {
       type: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.INSTANCE_OF'
     }
+  },
+  {
+    name: 'equals',
+    labels: {
+      equals_comparator: 'ACA_FOLDER_RULES.RULE_DETAILS.COMPARATORS.EQUALS'
+    }
   }
 ];

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special' | 'equals_comparator';
+export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special';
 
 export interface RuleConditionField {
   name: string;
@@ -50,7 +50,7 @@ export const ruleConditionFields: RuleConditionField[] = [
   {
     name: 'encoding',
     label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.ENCODING',
-    type: 'equals_comparator'
+    type: 'special'
   },
   {
     name: 'category',

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special';
+export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special' | 'equals_comparator';
 
 export interface RuleConditionField {
   name: string;
@@ -50,7 +50,7 @@ export const ruleConditionFields: RuleConditionField[] = [
   {
     name: 'encoding',
     label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.ENCODING',
-    type: 'string'
+    type: 'equals_comparator'
   },
   {
     name: 'category',


### PR DESCRIPTION
…as Share application which was earlier “Equals, Contains, Starts with and Ends with”

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
we have comparator values “Equals, Contains, Starts with and Ends with” when Encoding is selected in Condition but on Share app we can see only “Equals” for Encoding. 

**What is the new behaviour?**
comparator options set as Equals only when Encoding is selected in condition in Create/Edit a rule in Manage rules same as Share application.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
