### PR TITLE
[ACS-4448] Adding selectable options of mime types in folder rules add conditions

### DIFF
--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -840,7 +840,7 @@
     },
     {
       "value": "application/vnd.stardivision.chart",
-      "label": "StaChart 5.x"
+      "label": "StarChart 5.x"
     },
     {
       "value": "application/vnd.stardivision.calc",

--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -138,6 +138,811 @@
       "direction": "rtl"
     }
   ],
+  "mimeTypes": [
+    {
+      "value": "video/3gpp",
+      "label": "3G Video"
+    },
+    {
+      "value": "video/3gpp2",
+      "label": "3G2 Video"
+    },
+    {
+      "value": "application/vnd.alfresco.ai.features.v1+json",
+      "label": "AI-Features"
+    },
+    {
+      "value": "application/vnd.alfresco.ai.labels.v1+json",
+      "label": "AI-Labels"
+    },
+    {
+      "value": "application/vnd.alfresco.ai.pii.entities.v1+json",
+      "label": "AI-PII-Entities"
+    },
+    {
+      "value": "application/vnd.alfresco.ai.speech-to-text.v1+json",
+      "label": "AI-SpeechToText"
+    },
+    {
+      "value": "application/vnd.alfresco.ai.textract.v1+json",
+      "label": "AI-Textract"
+    },
+    {
+      "value": "audio/x-aiff",
+      "label": "AIFF Audio"
+    },
+    {
+      "value": "application/vnd.adobe.air-application-installer-package+zip",
+      "label": "Adobe AIR"
+    },
+    {
+      "value": "application/vnd.adobe.xdp+xml",
+      "label": "Adobe Acrobat XML Data Package"
+    },
+    {
+      "value": "application/vnd.adobe.aftereffects.project",
+      "label": "Adobe AfterEffects Project"
+    },
+    {
+      "value": "application/vnd.adobe.aftereffects.template",
+      "label": "Adobe AfterEffects Template"
+    },
+
+    {
+      "value": "image/x-raw-adobe",
+      "label": "Adobe Digital Negative Image"
+    },
+
+    {
+      "value": "application/x-zip",
+      "label": "Adobe Flex Project File"
+    },
+
+    {
+      "value": "application/framemaker",
+      "label": "Adobe FrameMaker"
+    },
+
+    {
+      "value": "application/illustrator",
+      "label": "Adobe Illustrator File"
+    },
+
+    {
+      "value": "application/x-indesign",
+      "label": "Adobe InDesign Document"
+    },
+
+    {
+      "value": "application/pdf",
+      "label": "Adobe PDF Document"
+    },
+
+    {
+      "value": "application/pagemaker",
+      "label": "Adobe PageMaker"
+    },
+
+    {
+      "value": "image/vnd.adobe.photoshop",
+      "label": "Adobe Photoshop"
+    },
+
+    {
+      "value": "image/vnd.adobe.premiere",
+      "label": "Adobe Premiere"
+    },
+
+    {
+      "value": "audio/vnd.adobe.soundbooth",
+      "label": "Adobe SoundBooth"
+    },
+
+    {
+      "value": "application/acp",
+      "label": "Alfresco Content Package"
+    },
+
+    {
+      "value": "application/vnd.android.package-archive",
+      "label": "Android Package"
+    },
+
+    {
+      "value": "image/x-portable-anymap",
+      "label": "Anymap Image"
+    },
+
+    {
+      "value": "image/icns",
+      "label": "Apple Icon"
+    },
+
+    {
+      "value": "application/vnd.apple.keynote",
+      "label": "Apple iWork Keynote"
+    },
+
+    {
+      "value": "application/vnd.apple.numbers",
+      "label": "Apple iWork Numbers"
+    },
+
+    {
+      "value": "application/vnd.apple.pages",
+      "label": "Apple iWork Pages"
+    },
+
+    {
+      "value": "image/vnd.dwg",
+      "label": "AutoCAD Drawing"
+    },
+
+    {
+      "value": "image/x-dwt",
+      "label": "AutoCAD Template"
+    },
+
+    {
+      "value": "audio/basic",
+      "label": "Basic Audio"
+    },
+
+    {
+      "value": "application/x-dosexec",
+      "label": "Binary File"
+    },
+
+    {
+      "value": "application/octet-stream",
+      "label": "Binary File (Octet Stream)"
+    },
+
+    {
+      "value": "image/bmp",
+      "label": "Bitmap Image"
+    },
+
+    {
+      "value": "image/cgm",
+      "label": "CGM Image"
+    },
+
+    {
+      "value": "image/x-raw-canon",
+      "label": "Canon RAW Image"
+    },
+
+    {
+      "value": "text/csv",
+      "label": "Comma Separated Values (CSV)"
+    },
+
+    {
+      "value": "application/dita+xml",
+      "label": "DITA"
+    },
+
+    {
+      "value": "message/rfc822",
+      "label": "EMail"
+    },
+
+    {
+      "value": "application/eps",
+      "label": "EPS Type PostScript"
+    },
+
+    {
+      "value": "audio/x-flac",
+      "label": "FLAC Audio"
+    },
+
+    {
+      "value": "application/x-fla",
+      "label": "Flash Source"
+    },
+
+    {
+      "value": "video/x-flv",
+      "label": "Flash Video"
+    },
+
+    {
+      "value": "image/x-raw-fuji",
+      "label": "Fuji RAW Image"
+    },
+
+    {
+      "value": "image/gif",
+      "label": "GIF Image"
+    },
+
+    {
+      "value": "application/x-gzip",
+      "label": "GZIP"
+    },
+
+    {
+      "value": "application/x-gtar",
+      "label": "GZIP Tarball"
+    },
+
+    {
+      "value": "image/x-portable-graymap",
+      "label": "Greymap Image"
+    },
+
+    {
+      "value": "text/html",
+      "label": "HTML"
+    },
+
+    {
+      "value": "application/vnd.oasis.opendocument.text-web",
+      "label": "HTML Document Template"
+    },
+
+    {
+      "value": "image/x-raw-hasselblad",
+      "label": "Hasselblad RAW Image"
+    },
+
+    {
+      "value": "image/ief",
+      "label": "IEF Image"
+    },
+
+    {
+      "value": "image/jp2",
+      "label": "JPEG 2000 Image"
+    },
+
+    {
+      "value": "image/jpeg",
+      "label": "JPEG Image"
+    },
+
+    {
+      "value": "application/json",
+      "label": "JSON"
+    },
+
+    {
+      "value": "application/java-archive",
+      "label": "Java Archive"
+    },
+
+    {
+      "value": "application/java",
+      "label": "Java Class"
+    },
+
+    {
+      "value": "text/x-jsp",
+      "label": "Java Server Page"
+    },
+
+    {
+      "value": "text/x-java-source",
+      "label": "Java Source File"
+    },
+
+    {
+      "value": "application/x-javascript",
+      "label": "JavaScript"
+    },
+
+    {
+      "value": "image/x-raw-kodak",
+      "label": "Kodak RAW Image"
+    },
+
+    {
+      "value": "application/x-latex",
+      "label": "LaTeX"
+    },
+
+    {
+      "value": "image/x-raw-leica",
+      "label": "Leica RAW Image"
+    },
+
+    {
+      "value": "audio/mpeg",
+      "label": "MPEG Audio"
+    },
+
+    {
+      "value": "video/mp2t",
+      "label": "MPEG Transport Stream"
+    },
+
+    {
+      "value": "video/mpeg",
+      "label": "MPEG Video"
+    },
+    {
+      "value": "video/mpeg2",
+      "label": "MPEG2 Video"
+    },
+    {
+      "value": "audio/mp4",
+      "label": "MPEG4 Audio"
+    },
+    {
+      "value": "video/mp4",
+      "label": "MPEG4 Video"
+    },
+    {
+      "value": "video/x-m4v",
+      "label": "MPEG4 Video (m4v)"
+    },
+    {
+      "value": "video/x-ms-asf",
+      "label": "MS ASF Streaming Video"
+    },
+    {
+      "value": "video/x-msvideo",
+      "label": "MS Video"
+    },
+    {
+      "value": "audio/x-ms-wma",
+      "label": "MS WMA Streaming Audio"
+    },
+    {
+      "value": "video/x-ms-wmv",
+      "label": "MS WMV Streaming Video"
+    },
+    {
+      "value": "application/x-troff-man",
+      "label": "Man Page"
+    },
+    {
+      "value": "text/x-markdown",
+      "label": "Markdown"
+    },
+    {
+      "value": "text/mediawiki",
+      "label": "MediaWiki Markup"
+    },
+    {
+      "value": "application/vnd.ms-excel",
+      "label": "Microsoft Excel"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "label": "Microsoft Excel 2007"
+    },
+    {
+      "value": "application/vnd.ms-excel.addin.macroenabled.12",
+      "label": "Microsoft Excel 2007 add-in"
+    },
+    {
+      "value": "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+      "label": "Microsoft Excel 2007 binary workbook"
+    },
+    {
+      "value": "application/vnd.ms-excel.sheet.macroenabled.12",
+      "label": "Microsoft Excel 2007 macro-enabled workbook"
+    },
+    {
+      "value": "application/vnd.ms-excel.template.macroenabled.12",
+      "label": "Microsoft Excel 2007 macro-enabled workbook template"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+      "label": "Microsoft Excel template 2007"
+    },
+    {
+      "value": "application/vnd.ms-outlook",
+      "label": "Microsoft Outlook Message"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint",
+      "label": "Microsoft PowerPoint"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "label": "Microsoft PowerPoint 2007"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint.addin.macroenabled.12",
+      "label": "Microsoft PowerPoint 2007 add-in"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+      "label": "Microsoft PowerPoint 2007 macro-enabled presentation"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint.template.macroenabled.12",
+      "label": "Microsoft PowerPoint 2007 macro-enabled presentation template"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint.slide.macroenabled.12",
+      "label": "Microsoft PowerPoint 2007 macro-enabled slide"
+    },
+    {
+      "value": "application/vnd.ms-powerpoint.slideshow.macroenabled.12",
+      "label": "Microsoft PowerPoint 2007 macro-enabled slide show"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.presentationml.slide",
+      "label": "Microsoft PowerPoint 2007 slide"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+      "label": "Microsoft PowerPoint 2007 slide show"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.presentationml.template",
+      "label": "Microsoft PowerPoint 2007 template"
+    },
+    {
+      "value": "application/vnd.ms-project",
+      "label": "Microsoft Project"
+    },
+    {
+      "value": "application/vnd.visio",
+      "label": "Microsoft Visio"
+    },
+    {
+      "value": "application/vnd.visio2013",
+      "label": "Microsoft Visio 2013"
+    },
+    {
+      "value": "application/vnd.ms-visio.drawing.macroenabled.main+xml",
+      "label": "Microsoft Visio macro-enabled drawing"
+    },
+    {
+      "value": "application/vnd.ms-visio.stencil.macroenabled.main+xml",
+      "label": "Microsoft Visio macro-enabled stencil"
+    },
+    {
+      "value": "application/vnd.ms-visio.template.macroenabled.main+xml",
+      "label": "Microsoft Visio macro-enabled template"
+    },
+    {
+      "value": "application/vnd.ms-visio.stencil.main+xml",
+      "label": "Microsoft Visio stencil"
+    },
+    {
+      "value": "application/vnd.ms-visio.template.main+xml",
+      "label": "Microsoft Visio template"
+    },
+    {
+      "value": "application/msword",
+      "label": "Microsoft Word"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "label": "Microsoft Word 2007"
+    },
+    {
+      "value": "application/vnd.ms-word.document.macroenabled.12",
+      "label": "Microsoft Word 2007 macro-enabled document"
+    },
+    {
+      "value": "application/vnd.ms-word.template.macroenabled.12",
+      "label": "Microsoft Word 2007 macro-enabled document template"
+    },
+    {
+      "value": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+      "label": "Microsoft Word 2007 template"
+    },
+    {
+      "value": "image/x-raw-minolta",
+      "label": "Minolta RAW Image"
+    },
+    {
+      "value": "image/x-raw-nikon",
+      "label": "Nikon RAW Image"
+    },
+    {
+      "value": "audio/ogg",
+      "label": "Ogg Audio"
+    },
+    {
+      "value": "application/ogg",
+      "label": "Ogg Multiplex"
+    },
+    {
+      "value": "video/ogg",
+      "label": "Ogg Video"
+    },
+    {
+      "value": "audio/vorbis",
+      "label": "Ogg Vorbis Audio"
+    },
+    {
+      "value": "image/x-raw-olympus",
+      "label": "Olympus RAW Image"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.chart",
+      "label": "OpenDocument Chart"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.database",
+      "label": "OpenDocument Database"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.graphics",
+      "label": "OpenDocument Drawing"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.graphics-template",
+      "label": "OpenDocument Drawing Template"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.formula",
+      "label": "OpenDocument Formula"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.image",
+      "label": "OpenDocument Image"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.text-master",
+      "label": "OpenDocument Master Document"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.presentation",
+      "label": "OpenDocument Presentation"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.presentation-template",
+      "label": "OpenDocument Presentation Template"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.spreadsheet",
+      "label": "OpenDocument Spreadsheet"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.spreadsheet-template",
+      "label": "OpenDocument Spreadsheet Template"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.text",
+      "label": "OpenDocument Text (OpenOffice 2.0)"
+    },
+    {
+      "value": "application/vnd.oasis.opendocument.text-template",
+      "label": "OpenDocument Text Template"
+    },
+    {
+      "value": "application/vnd.sun.xml.calc",
+      "label": "OpenOffice 1.0/StarOffice6.0 Calc 6.0"
+    },
+    {
+      "value": "application/vnd.sun.xml.calc.template",
+      "label": "OpenOffice 1.0/StarOffice6.0 Calc 6.0 Template"
+    },
+    {
+      "value": "application/vnd.sun.xml.draw",
+      "label": "OpenOffice 1.0/StarOffice6.0 Draw 6.0"
+    },
+    {
+      "value": "application/vnd.sun.xml.impress",
+      "label": "OpenOffice 1.0/StarOffice6.0 Impress 6.0"
+    },
+    {
+      "value": "application/vnd.sun.xml.impress.template",
+      "label": "OpenOffice 1.0/StarOffice6.0 Impress 6.0 Template"
+    },
+    {
+      "value": "application/vnd.sun.xml.writer",
+      "label": "OpenOffice 1.0/StarOffice6.0 Writer 6.0"
+    },
+    {
+      "value": "application/vnd.sun.xml.writer.template",
+      "label": "OpenOffice 1.0/StarOffice6.0 Writer 6.0 Template"
+    },
+    {
+      "value": "image/png",
+      "label": "PNG Image"
+    },
+    {
+      "value": "image/x-raw-panasonic",
+      "label": "Panasonic RAW Image"
+    },
+    {
+      "value": "image/x-raw-pentax",
+      "label": "Pentax RAW Image"
+    },
+    {
+      "value": "image/x-portable-pixmap",
+      "label": "Pixmap Image"
+    },
+    {
+      "value": "text/plain",
+      "label": "Plain Text"
+    },
+    {
+      "value": "image/x-portable-bitmap",
+      "label": "Portable Bitmap"
+    },
+    {
+      "value": "application/postscript",
+      "label": "PostScript"
+    },
+    {
+      "value": "application/remote-printing",
+      "label": "Printer Text File"
+    },
+    {
+      "value": "video/quicktime",
+      "label": "Quicktime Video"
+    },
+    {
+      "value": "video/x-rad-screenplay",
+      "label": "RAD Screen Display"
+    },
+    {
+      "value": "application/x-rar-compressed",
+      "label": "RAR Archive"
+    },
+    {
+      "value": "image/x-raw-red",
+      "label": "RED RAW Image"
+    },
+    {
+      "value": "image/x-rgb",
+      "label": "RGB Image"
+    },
+    {
+      "value": "application/rss+xml",
+      "label": "RSS"
+    },
+    {
+      "value": "image/x-cmu-raster",
+      "label": "Raster Image"
+    },
+    {
+      "value": "text/richtext",
+      "label": "Rich Text"
+    },
+    {
+      "value": "application/rtf",
+      "label": "Rich Text Format"
+    },
+    {
+      "value": "video/x-sgi-movie",
+      "label": "SGI Video"
+    },
+    {
+      "value": "text/sgml",
+      "label": "SGML (Human Readable)"
+    },
+    {
+      "value": "application/sgml",
+      "label": "SGML (Machine Readable)"
+    },
+    {
+      "value": "image/svg+xml",
+      "label": "Scalable Vector Graphics Image"
+    },
+    {
+      "value": "application/x-sh",
+      "label": "Shell Script"
+    },
+    {
+      "value": "application/x-shockwave-flash",
+      "label": "Shockwave Flash"
+    },
+    {
+      "value": "image/x-raw-sigma",
+      "label": "Sigma RAW Image"
+    },
+    {
+      "value": "image/x-raw-sony",
+      "label": "Sony RAW Image"
+    },
+    {
+      "value": "application/vnd.stardivision.chart",
+      "label": "StaChart 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.calc",
+      "label": "StarCalc 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.draw",
+      "label": "StarDraw 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.impress",
+      "label": "StarImpress 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.impress-packed",
+      "label": "StarImpress Packed 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.math",
+      "label": "StarMath 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.writer",
+      "label": "StarWriter 5.x"
+    },
+    {
+      "value": "application/vnd.stardivision.writer-global",
+      "label": "StarWriter 5.x global"
+    },
+    {
+      "value": "text/css",
+      "label": "Style Sheet"
+    },
+    {
+      "value": "image/tiff",
+      "label": "TIFF Image"
+    },
+    {
+      "value": "text/tab-separated-values",
+      "label": "Tab Separated Values"
+    },
+    {
+      "value": "application/x-tar",
+      "label": "Tarball"
+    },
+    {
+      "value": "application/x-tex",
+      "label": "Tex"
+    },
+    {
+      "value": "application/x-texinfo",
+      "label": "Tex Info"
+    },
+    {
+      "value": "x-world/x-vrml",
+      "label": "VRML"
+    },
+    {
+      "value": "audio/x-wav",
+      "label": "WAV Audio"
+    },
+    {
+      "value": "video/webm",
+      "label": "WebM Video"
+    },
+    {
+      "value": "application/wordperfect",
+      "label": "WordPerfect"
+    },
+    {
+      "value": "image/x-xbitmap",
+      "label": "XBitmap Image"
+    },
+    {
+      "value": "application/xhtml+xml",
+      "label": "XHTML"
+    },
+    {
+      "value": "text/xml",
+      "label": "XML"
+    },
+    {
+      "value": "image/x-xpixmap",
+      "label": "XPixmap Image"
+    },
+    {
+      "value": "image/x-xwindowdump",
+      "label": "XWindow Dump"
+    },
+    {
+      "value": "application/x-compress",
+      "label": "Z Compress"
+    },
+    {
+      "value": "application/zip",
+      "label": "ZIP"
+    },
+    {
+      "value": "text/calendar",
+      "label": "iCalendar File"
+    }
+  ],
   "content-metadata": {
     "presets": {
       "custom": [

--- a/projects/aca-folder-rules/src/lib/mock/conditions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/conditions.mock.ts
@@ -32,6 +32,12 @@ const simpleConditionMock: RuleSimpleCondition = {
   parameter: ''
 };
 
+export const mimeTypeMock: RuleSimpleCondition = {
+  field: 'mimetype',
+  comparator: 'equals',
+  parameter: ''
+};
+
 export const simpleConditionUnknownFieldMock: RuleSimpleCondition = {
   field: 'unknown-field',
   comparator: 'equals',

--- a/projects/aca-folder-rules/src/lib/mock/conditions.mock.ts
+++ b/projects/aca-folder-rules/src/lib/mock/conditions.mock.ts
@@ -38,6 +38,12 @@ export const mimeTypeMock: RuleSimpleCondition = {
   parameter: ''
 };
 
+export const categoryMock: RuleSimpleCondition = {
+  field: 'category',
+  comparator: 'equals',
+  parameter: ''
+};
+
 export const simpleConditionUnknownFieldMock: RuleSimpleCondition = {
   field: 'unknown-field',
   comparator: 'equals',

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-condition-fields.ts
@@ -23,13 +23,15 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special';
+export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special' | 'mimeType';
 
 export interface RuleConditionField {
   name: string;
   label: string;
   type: RuleConditionFieldType;
 }
+
+export const comparatorHiddenForConditionFieldType: string[] = ['special', 'mimeType'];
 
 export const ruleConditionFields: RuleConditionField[] = [
   {
@@ -45,7 +47,7 @@ export const ruleConditionFields: RuleConditionField[] = [
   {
     name: 'mimetype',
     label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.MIMETYPE',
-    type: 'special'
+    type: 'mimeType'
   },
   {
     name: 'encoding',

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types.ts
@@ -20,51 +20,10 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/,
+"label": ".
  */
-
-export type RuleConditionFieldType = 'string' | 'number' | 'date' | 'type' | 'special';
-
-export interface RuleConditionField {
-  name: string;
+export interface MimeType {
   label: string;
-  type: RuleConditionFieldType;
+  value: string;
 }
-
-export const ruleConditionFields: RuleConditionField[] = [
-  {
-    name: 'cm:name',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.NAME',
-    type: 'string'
-  },
-  {
-    name: 'size',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.SIZE',
-    type: 'number'
-  },
-  {
-    name: 'mimetype',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.MIMETYPE',
-    type: 'special'
-  },
-  {
-    name: 'encoding',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.ENCODING',
-    type: 'special'
-  },
-  {
-    name: 'category',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.HAS_CATEGORY',
-    type: 'special'
-  },
-  {
-    name: 'tag',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.HAS_TAG',
-    type: 'special'
-  },
-  {
-    name: 'aspect',
-    label: 'ACA_FOLDER_RULES.RULE_DETAILS.FIELDS.HAS_ASPECT',
-    type: 'special'
-  }
-];

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types.ts
@@ -20,9 +20,9 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Alfresco. If not, see <http://www.gnu.org/licenses/,
-"label": ".
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  */
+
 export interface MimeType {
   label: string;
   value: string;

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
@@ -22,6 +22,14 @@
   </mat-form-field>
 
   <mat-form-field class="aca-rule-simple-condition__form__parameter-input">
-    <input matInput placeholder="{{ 'ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.VALUE' | translate }}" type="text" formControlName="parameter" data-automation-id="value-input">
+    <mat-select formControlName="parameter" data-automation-id="value-select" *ngIf="selectedField?.name === 'mimetype'; else valueInput">
+      <mat-option *ngFor="let mimeType of mimeTypes"
+        [value]="mimeType.value">
+        {{ mimeType.label }}
+      </mat-option>
+    </mat-select>
+    <ng-template #valueInput>
+      <input matInput placeholder="{{ 'ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.VALUE' | translate }}" type="text" formControlName="parameter" data-automation-id="value-input">
+    </ng-template>
   </mat-form-field>
 </form>

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
@@ -22,7 +22,7 @@
   </mat-form-field>
 
   <mat-form-field class="aca-rule-simple-condition__form__parameter-input">
-    <mat-select formControlName="parameter" data-automation-id="value-select" *ngIf="selectedField?.name === 'mimetype'; else valueInput">
+    <mat-select formControlName="parameter" *ngIf="selectedField?.type === 'mimeType'; else valueInput">
       <mat-option *ngFor="let mimeType of mimeTypes"
         [value]="mimeType.value">
         {{ mimeType.label }}

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.html
@@ -22,7 +22,7 @@
   </mat-form-field>
 
   <mat-form-field class="aca-rule-simple-condition__form__parameter-input">
-    <mat-select formControlName="parameter" *ngIf="selectedField?.type === 'mimeType'; else valueInput">
+    <mat-select formControlName="parameter" data-automation-id="simple-condition-value-select" *ngIf="selectedField?.type === 'mimeType'; else valueInput">
       <mat-option *ngFor="let mimeType of mimeTypes"
         [value]="mimeType.value">
         {{ mimeType.label }}

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
@@ -29,6 +29,7 @@ import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { categoryMock, mimeTypeMock, simpleConditionUnknownFieldMock } from '../../mock/conditions.mock';
+import { MimeType } from './rule-mime-types';
 
 describe('RuleSimpleConditionUiComponent', () => {
   let fixture: ComponentFixture<RuleSimpleConditionUiComponent>;
@@ -131,11 +132,33 @@ describe('RuleSimpleConditionUiComponent', () => {
   });
 
   it('should provide select option when mimeType is selected and value filled', () => {
+    const mockMimeTypes: MimeType[] = [
+      {
+        value: 'video/3gpp',
+        label: '3G Video'
+      },
+      {
+        value: 'video/3gpp2',
+        label: '3G2 Video'
+      },
+      {
+        value: 'application/vnd.alfresco.ai.features.v1+json',
+        label: 'AI-Features'
+      },
+      {
+        value: 'application/vnd.alfresco.ai.labels.v1+json',
+        label: 'AI-Labels'
+      }
+    ];
+
     fixture.componentInstance.writeValue(mimeTypeMock);
+    fixture.componentInstance.mimeTypes = mockMimeTypes;
+
+    fixture.componentInstance.onChangeField();
     fixture.detectChanges();
 
     expect(getByDataAutomationId('simple-condition-value-select')).toBeTruthy();
-    expect(getByDataAutomationId('simple-condition-value-select').nativeElement.value).not.toBe('');
+    expect(fixture.componentInstance.form.get('parameter').value).toEqual(mockMimeTypes[0].value);
   });
 
   it('should set value to empty when any condition is selected after mimeType', () => {

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
@@ -28,7 +28,7 @@ import { RuleSimpleConditionUiComponent } from './rule-simple-condition.ui-compo
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { mimeTypeMock, simpleConditionUnknownFieldMock } from '../../mock/conditions.mock';
+import { categoryMock, mimeTypeMock, simpleConditionUnknownFieldMock } from '../../mock/conditions.mock';
 
 describe('RuleSimpleConditionUiComponent', () => {
   let fixture: ComponentFixture<RuleSimpleConditionUiComponent>;
@@ -130,10 +130,23 @@ describe('RuleSimpleConditionUiComponent', () => {
     expect(unknownOptionMatOption).toBeNull();
   });
 
-  it('should provide select option when mimeType is selected', () => {
+  it('should provide select option when mimeType is selected and value filled', () => {
     fixture.componentInstance.writeValue(mimeTypeMock);
     fixture.detectChanges();
 
     expect(getByDataAutomationId('simple-condition-value-select')).toBeTruthy();
+    expect(getByDataAutomationId('simple-condition-value-select').nativeElement.value).not.toBe('');
+  });
+
+  it('should set value to empty when any condition is selected after mimeType', () => {
+    fixture.componentInstance.writeValue(mimeTypeMock);
+    fixture.detectChanges();
+
+    expect(getByDataAutomationId('simple-condition-value-select')).toBeTruthy();
+
+    fixture.componentInstance.writeValue(categoryMock);
+    fixture.detectChanges();
+
+    expect(getByDataAutomationId('value-input').nativeElement.value).toBe('');
   });
 });

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
@@ -28,7 +28,7 @@ import { RuleSimpleConditionUiComponent } from './rule-simple-condition.ui-compo
 import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { simpleConditionUnknownFieldMock } from '../../mock/conditions.mock';
+import { mimeTypeMock, simpleConditionUnknownFieldMock } from '../../mock/conditions.mock';
 
 describe('RuleSimpleConditionUiComponent', () => {
   let fixture: ComponentFixture<RuleSimpleConditionUiComponent>;
@@ -75,6 +75,19 @@ describe('RuleSimpleConditionUiComponent', () => {
     expect(getComputedStyle(comparatorFormField).display).toBe('none');
   });
 
+  it('should hide the comparator select box if the type of the field is mimeType', () => {
+    fixture.detectChanges();
+    const comparatorFormField = getByDataAutomationId('comparator-form-field').nativeElement;
+
+    expect(fixture.componentInstance.isComparatorHidden).toBeFalsy();
+    expect(getComputedStyle(comparatorFormField).display).not.toBe('none');
+
+    changeMatSelectValue('field-select', 'mimetype');
+
+    expect(fixture.componentInstance.isComparatorHidden).toBeTruthy();
+    expect(getComputedStyle(comparatorFormField).display).toBe('none');
+  });
+
   it('should set the comparator to equals if the field is set to a type with different comparators', () => {
     const onChangeFieldSpy = spyOn(fixture.componentInstance, 'onChangeField').and.callThrough();
     fixture.detectChanges();
@@ -84,7 +97,7 @@ describe('RuleSimpleConditionUiComponent', () => {
     changeMatSelectValue('field-select', 'mimetype');
 
     expect(onChangeFieldSpy).toHaveBeenCalledTimes(1);
-    expect(getByDataAutomationId('comparator-select').componentInstance.value).toBe('contains');
+    expect(getByDataAutomationId('comparator-select').componentInstance.value).toBe('equals');
     changeMatSelectValue('field-select', 'size');
 
     expect(onChangeFieldSpy).toHaveBeenCalledTimes(2);
@@ -115,5 +128,12 @@ describe('RuleSimpleConditionUiComponent', () => {
 
     const unknownOptionMatOption = getByDataAutomationId('unknown-field-option');
     expect(unknownOptionMatOption).toBeNull();
+  });
+
+  it('should provide select option when mimeType is selected', () => {
+    fixture.componentInstance.writeValue(mimeTypeMock);
+    fixture.detectChanges();
+
+    expect(getByDataAutomationId('simple-condition-value-select')).toBeTruthy();
   });
 });

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -28,7 +28,7 @@ import { AbstractControl, ControlValueAccessor, FormControl, FormGroup, NG_VALUE
 import { RuleSimpleCondition } from '../../model/rule-simple-condition.model';
 import { RuleConditionField, ruleConditionFields } from './rule-condition-fields';
 import { RuleConditionComparator, ruleConditionComparators } from './rule-condition-comparators';
-import { AppService } from '@alfresco/aca-shared';
+import { AppConfigService } from '@alfresco/adf-core';
 import { MimeType } from './rule-mime-types';
 
 @Component({
@@ -65,8 +65,8 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     this.setDisabledState(isReadOnly);
   }
 
-  constructor(private appService: AppService) {
-    this.mimeTypes = this.appService.mimeTypes;
+  constructor(private config: AppConfigService) {
+    this.mimeTypes = this.config.get<Array<MimeType>>('mimeTypes');
   }
 
   private formSubscription = this.form.valueChanges.subscribe((value: any) => {

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -100,7 +100,7 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     return this.form.get('comparator');
   }
 
-  private get parameterControl(): AbstractControl {
+  private get parameterControl(): AbstractControl<string> {
     return this.form.get('parameter');
   }
 

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -26,7 +26,7 @@
 import { Component, forwardRef, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { RuleSimpleCondition } from '../../model/rule-simple-condition.model';
-import { RuleConditionField, ruleConditionFields } from './rule-condition-fields';
+import { comparatorHiddenForConditionFieldType, RuleConditionField, ruleConditionFields } from './rule-condition-fields';
 import { RuleConditionComparator, ruleConditionComparators } from './rule-condition-comparators';
 import { AppConfigService } from '@alfresco/adf-core';
 import { MimeType } from './rule-mime-types';
@@ -94,13 +94,13 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     return ruleConditionComparators.filter((comparator) => Object.keys(comparator.labels).includes(this.selectedField.type));
   }
   get isComparatorHidden(): boolean {
-    return this.selectedField?.type === 'special';
+    return comparatorHiddenForConditionFieldType.includes(this.selectedField?.type);
   }
   get comparatorControl(): AbstractControl {
     return this.form.get('comparator');
   }
 
-  get valueControl(): AbstractControl {
+  private get parameterControl(): AbstractControl {
     return this.form.get('parameter');
   }
 
@@ -133,10 +133,10 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     if (!this.selectedFieldComparators.find((comparator) => comparator.name === this.comparatorControl.value)) {
       this.comparatorControl.setValue('equals');
     }
-    if (!this.valueControl.value && this.selectedField?.name === 'mimetype') {
-      this.valueControl.setValue(this.mimeTypes[0]?.value);
-    } else if (this.valueControl.value) {
-      this.valueControl.setValue('');
+    if (!this.parameterControl.value && this.selectedField?.type === 'mimeType') {
+      this.parameterControl.setValue(this.mimeTypes[0]?.value);
+    } else if (this.parameterControl.value) {
+      this.parameterControl.setValue('');
     }
   }
 

--- a/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-folder-rules/src/lib/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -28,6 +28,8 @@ import { AbstractControl, ControlValueAccessor, FormControl, FormGroup, NG_VALUE
 import { RuleSimpleCondition } from '../../model/rule-simple-condition.model';
 import { RuleConditionField, ruleConditionFields } from './rule-condition-fields';
 import { RuleConditionComparator, ruleConditionComparators } from './rule-condition-comparators';
+import { AppService } from '@alfresco/aca-shared';
+import { MimeType } from './rule-mime-types';
 
 @Component({
   selector: 'aca-rule-simple-condition',
@@ -52,6 +54,8 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     parameter: new FormControl()
   });
 
+  mimeTypes: MimeType[] = [];
+
   private _readOnly = false;
   @Input()
   get readOnly(): boolean {
@@ -59,6 +63,10 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
   }
   set readOnly(isReadOnly: boolean) {
     this.setDisabledState(isReadOnly);
+  }
+
+  constructor(private appService: AppService) {
+    this.mimeTypes = this.appService.mimeTypes;
   }
 
   private formSubscription = this.form.valueChanges.subscribe((value: any) => {
@@ -92,6 +100,10 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
     return this.form.get('comparator');
   }
 
+  get valueControl(): AbstractControl {
+    return this.form.get('parameter');
+  }
+
   onChange: (condition: RuleSimpleCondition) => void = () => undefined;
   onTouch: () => void = () => undefined;
 
@@ -120,6 +132,11 @@ export class RuleSimpleConditionUiComponent implements ControlValueAccessor, OnD
   onChangeField() {
     if (!this.selectedFieldComparators.find((comparator) => comparator.name === this.comparatorControl.value)) {
       this.comparatorControl.setValue('equals');
+    }
+    if (!this.valueControl.value && this.selectedField?.name === 'mimetype') {
+      this.valueControl.setValue(this.mimeTypes[0]?.value);
+    } else if (this.valueControl.value) {
+      this.valueControl.setValue('');
     }
   }
 

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -49,6 +49,7 @@ import { RouterExtensionService } from './router.extension.service';
 import { Store } from '@ngrx/store';
 import { DiscoveryEntry, GroupEntry, Group } from '@alfresco/js-api';
 import { AcaMobileAppSwitcherService } from './aca-mobile-app-switcher.service';
+import { MimeType } from '../../../../aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types';
 
 @Injectable({
   providedIn: 'root'
@@ -69,6 +70,10 @@ export class AppService {
    */
   get withCredentials(): boolean {
     return this.config.get<boolean>('auth.withCredentials', false);
+  }
+
+  get mimeTypes(): MimeType[] {
+    return this.config.get<Array<MimeType>>('mimeTypes');
   }
 
   constructor(

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -49,7 +49,6 @@ import { RouterExtensionService } from './router.extension.service';
 import { Store } from '@ngrx/store';
 import { DiscoveryEntry, GroupEntry, Group } from '@alfresco/js-api';
 import { AcaMobileAppSwitcherService } from './aca-mobile-app-switcher.service';
-import { MimeType } from '../../../../aca-folder-rules/src/lib/rule-details/conditions/rule-mime-types';
 
 @Injectable({
   providedIn: 'root'
@@ -70,10 +69,6 @@ export class AppService {
    */
   get withCredentials(): boolean {
     return this.config.get<boolean>('auth.withCredentials', false);
-  }
-
-  get mimeTypes(): MimeType[] {
-    return this.config.get<Array<MimeType>>('mimeTypes');
   }
 
   constructor(


### PR DESCRIPTION
…nditions.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

You used to get a input field to input mime types in add condition while creating folder rules

**What is the new behaviour?**

You get an option select with options of mime types to chose a mime type.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
