### PR TITLE
[ACS-4964] Color fix for primary button text

### DIFF
--- a/projects/aca-content/src/lib/components/header/header.component.scss
+++ b/projects/aca-content/src/lib/components/header/header.component.scss
@@ -2,6 +2,10 @@
   box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.02), 0 6px 10px 0 rgba(0, 0, 0, 0.014), 0 1px 18px 0 rgba(0, 0, 0, 0.012);
   z-index: 2;
 
+  adf-layout-header .mat-toolbar-single-row {
+    color: var(--theme-header-text-color) !important;
+  }
+
   .mat-toolbar {
     background-image: var(--header-background-image) !important;
     background-repeat: no-repeat !important;

--- a/projects/aca-content/src/lib/ui/colors.scss
+++ b/projects/aca-content/src/lib/ui/colors.scss
@@ -24,10 +24,10 @@ $aca-primary-blue: (
     700: white,
     800: $white-87-opacity,
     900: $white-87-opacity,
-    A100: $black-87-opacity,
+    A100: white,
     A200: white,
     A400: white,
-    A700: white,
+    A700: white
   )
 );
 $aca-accent-green: (
@@ -59,7 +59,7 @@ $aca-accent-green: (
     A100: $black-87-opacity,
     A200: white,
     A400: white,
-    A700: white,
+    A700: white
   )
 );
 $aca-warn: (
@@ -91,6 +91,6 @@ $aca-warn: (
     A100: $black-87-opacity,
     A200: white,
     A400: white,
-    A700: white,
+    A700: white
   )
 );

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -22,15 +22,15 @@ $adf-upload-dragging-level1-border: none;
 $grey-background: rgba(33, 33, 33, 0.12);
 $grey-text-background: rgba(33, 33, 33, 0.05);
 $grey-hover-background: rgba(33, 33, 33, 0.24);
-$blue-save-button-background: #1F74DB;
+$blue-save-button-background: #1f74db;
 $black-heading: #4e4c4c;
 $grey-dropdown-background: #eee;
-$grey-divider: rgba(0,0,0,.22);
+$grey-divider: rgba(0, 0, 0, 0.22);
 $pagination-background-color: #fff;
 $datetimepicker-font-color: rgba(black, 0.87);
 $datetimepicker-selected-date-background: #2254b2;
 $datetimepicker-cell-background-color: #fff;
-$datetimepicker-cell-focus-border-color: #1F74DB;
+$datetimepicker-cell-focus-border-color: #1f74db;
 $datetimepicker-cell-focus-background-color: rgba(33, 33, 33, 0.12);
 
 // CSS Variables
@@ -52,7 +52,7 @@ $defaults: (
   --theme-secondary-text-color: mat.get-color-from-palette($foreground, secondary-text),
   --theme-divider-color: mat.get-color-from-palette($foreground, divider, 0.07),
   --theme-dialog-background-color: mat.get-color-from-palette($background, dialog),
-
+  --theme-header-text-color: mat.get-color-from-palette($foreground, text, 0.87),
   --new-button-font-size: 0.9rem,
   --theme-grey-text-background-color: $grey-text-background,
   --theme-grey-background-color: $grey-background,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The ‘Primary’ mat-flat-button in ACA and alfresco-applications renders text in black color.

**What is the new behaviour?**
Primary’ mat-flat-button in ACA and alfresco-applications renders text in white.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-4964