### PR TITLE
[ACA-4692] fixed focus for create and upload modals

### DIFF
--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -85,7 +85,7 @@ interface RestoredNode {
   providedIn: 'root'
 })
 export class ContentManagementService {
-  private readonly createMenuButtonSelector = 'app-create-menu button';
+  private readonly createMenuButtonSelector = 'app-toolbar-menu button[title="Create content"]';
 
   constructor(
     private nodesApiService: NodesApiService,

--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -85,7 +85,7 @@ interface RestoredNode {
   providedIn: 'root'
 })
 export class ContentManagementService {
-  private readonly createMenuButtonSelector = 'app-toolbar-menu button[title="Create content"]';
+  private readonly createMenuButtonSelector = 'app-toolbar-menu button[id="app.toolbar.create"]';
 
   constructor(
     private nodesApiService: NodesApiService,

--- a/projects/aca-content/src/lib/services/node-template.service.ts
+++ b/projects/aca-content/src/lib/services/node-template.service.ts
@@ -166,6 +166,6 @@ export class NodeTemplateService {
   }
 
   private static focusCreateMenuButton(): void {
-    document.querySelector<HTMLElement>('app-create-menu button').focus();
+    document.querySelector<HTMLElement>('app-toolbar-menu button[title="Create content"]').focus();
   }
 }

--- a/projects/aca-content/src/lib/services/node-template.service.ts
+++ b/projects/aca-content/src/lib/services/node-template.service.ts
@@ -166,6 +166,6 @@ export class NodeTemplateService {
   }
 
   private static focusCreateMenuButton(): void {
-    document.querySelector<HTMLElement>('app-toolbar-menu button[title="Create content"]').focus();
+    document.querySelector<HTMLElement>('app-toolbar-menu button[id="app.toolbar.create"]').focus();
   }
 }

--- a/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
@@ -59,76 +59,76 @@ describe('UploadEffects', () => {
   });
 
   describe('uploadFiles$', () => {
-    let createMenuButton: HTMLButtonElement;
+    let uploadMenuButton: HTMLButtonElement;
     const focusedClass = 'cdk-program-focused';
 
     beforeEach(() => {
-      createMenuButton = document.createElement('button');
-      document.body.appendChild(createMenuButton);
+      uploadMenuButton = document.createElement('button');
+      document.body.appendChild(uploadMenuButton);
       store.dispatch(new UploadFilesAction({}));
-      spyOn(document, 'querySelector').withArgs('app-create-menu button').and.returnValue(createMenuButton);
+      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[title="Upload content"]').and.returnValue(uploadMenuButton);
     });
 
-    it('should call focus function on create menu button', () => {
-      spyOn(createMenuButton, 'focus');
+    it('should call focus function on upload menu button', () => {
+      spyOn(uploadMenuButton, 'focus');
       window.dispatchEvent(new FocusEvent('focus'));
-      expect(createMenuButton.focus).toHaveBeenCalledWith();
+      expect(uploadMenuButton.focus).toHaveBeenCalledWith();
     });
 
-    it('should not call focus function on create menu button if handler for focus of window is not fired', () => {
-      spyOn(createMenuButton, 'focus');
-      expect(createMenuButton.focus).not.toHaveBeenCalled();
+    it('should not call focus function on upload menu button if handler for focus of window is not fired', () => {
+      spyOn(uploadMenuButton, 'focus');
+      expect(uploadMenuButton.focus).not.toHaveBeenCalled();
     });
 
-    it('should add cdk-program-focused class to create menu button', () => {
+    it('should add cdk-program-focused class to upload menu button', () => {
       window.dispatchEvent(new FocusEvent('focus'));
-      createMenuButton.dispatchEvent(new FocusEvent('focus'));
-      expect(createMenuButton).toHaveClass(focusedClass);
+      uploadMenuButton.dispatchEvent(new FocusEvent('focus'));
+      expect(uploadMenuButton).toHaveClass(focusedClass);
     });
 
-    it('should not add cdk-program-focused class to create menu button if handler for focus of window is not fired', () => {
-      expect(createMenuButton).not.toHaveClass(focusedClass);
+    it('should not add cdk-program-focused class to upload menu button if handler for focus of window is not fired', () => {
+      expect(uploadMenuButton).not.toHaveClass(focusedClass);
     });
 
     afterEach(() => {
-      createMenuButton.remove();
+      uploadMenuButton.remove();
     });
   });
 
   describe('uploadFolder$', () => {
-    let createMenuButton: HTMLButtonElement;
+    let uploadMenuButton: HTMLButtonElement;
     const focusedClass = 'cdk-program-focused';
 
     beforeEach(() => {
-      createMenuButton = document.createElement('button');
-      document.body.appendChild(createMenuButton);
+      uploadMenuButton = document.createElement('button');
+      document.body.appendChild(uploadMenuButton);
       store.dispatch(new UploadFolderAction({}));
-      spyOn(document, 'querySelector').withArgs('app-create-menu button').and.returnValue(createMenuButton);
+      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[title="Upload content"]').and.returnValue(uploadMenuButton);
     });
 
-    it('should call focus function on create menu button', () => {
-      spyOn(createMenuButton, 'focus');
+    it('should call focus function on upload menu button', () => {
+      spyOn(uploadMenuButton, 'focus');
       window.dispatchEvent(new FocusEvent('focus'));
-      expect(createMenuButton.focus).toHaveBeenCalledWith();
+      expect(uploadMenuButton.focus).toHaveBeenCalledWith();
     });
 
-    it('should not call focus function on create menu button if handler for focus of window is not fired', () => {
-      spyOn(createMenuButton, 'focus');
-      expect(createMenuButton.focus).not.toHaveBeenCalled();
+    it('should not call focus function on upload menu button if handler for focus of window is not fired', () => {
+      spyOn(uploadMenuButton, 'focus');
+      expect(uploadMenuButton.focus).not.toHaveBeenCalled();
     });
 
-    it('should add cdk-program-focused class to create menu button', () => {
+    it('should add cdk-program-focused class to upload menu button', () => {
       window.dispatchEvent(new FocusEvent('focus'));
-      createMenuButton.dispatchEvent(new FocusEvent('focus'));
-      expect(createMenuButton).toHaveClass(focusedClass);
+      uploadMenuButton.dispatchEvent(new FocusEvent('focus'));
+      expect(uploadMenuButton).toHaveClass(focusedClass);
     });
 
-    it('should not add cdk-program-focused class to create menu button if handler for focus of window is not fired', () => {
-      expect(createMenuButton).not.toHaveClass(focusedClass);
+    it('should not add cdk-program-focused class to upload menu button if handler for focus of window is not fired', () => {
+      expect(uploadMenuButton).not.toHaveClass(focusedClass);
     });
 
     afterEach(() => {
-      createMenuButton.remove();
+      uploadMenuButton.remove();
     });
   });
 

--- a/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
@@ -66,7 +66,7 @@ describe('UploadEffects', () => {
       uploadMenuButton = document.createElement('button');
       document.body.appendChild(uploadMenuButton);
       store.dispatch(new UploadFilesAction({}));
-      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[title="Upload content"]').and.returnValue(uploadMenuButton);
+      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[id="app.toolbar.upload"]').and.returnValue(uploadMenuButton);
     });
 
     it('should call focus function on upload menu button', () => {
@@ -103,7 +103,7 @@ describe('UploadEffects', () => {
       uploadMenuButton = document.createElement('button');
       document.body.appendChild(uploadMenuButton);
       store.dispatch(new UploadFolderAction({}));
-      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[title="Upload content"]').and.returnValue(uploadMenuButton);
+      spyOn(document, 'querySelector').withArgs('app-toolbar-menu button[id="app.toolbar.upload"]').and.returnValue(uploadMenuButton);
     });
 
     it('should call focus function on upload menu button', () => {

--- a/projects/aca-content/src/lib/store/effects/upload.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.ts
@@ -47,7 +47,7 @@ export class UploadEffects {
   private fileInput: HTMLInputElement;
   private folderInput: HTMLInputElement;
   private fileVersionInput: HTMLInputElement;
-  private readonly createMenuButtonSelector = 'app-create-menu button';
+  private readonly uploadMenuButtonSelector = 'app-toolbar-menu button[title="Upload content"]';
 
   constructor(
     private store: Store<AppStore>,
@@ -91,7 +91,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFilesAction>(UploadActionTypes.UploadFiles),
         map(() => {
-          this.registerFocusingElementAfterModalClose(this.fileInput, this.createMenuButtonSelector);
+          this.registerFocusingElementAfterModalClose(this.fileInput, this.uploadMenuButtonSelector);
           this.fileInput.click();
         })
       ),
@@ -103,7 +103,7 @@ export class UploadEffects {
       this.actions$.pipe(
         ofType<UploadFolderAction>(UploadActionTypes.UploadFolder),
         map(() => {
-          this.registerFocusingElementAfterModalClose(this.folderInput, this.createMenuButtonSelector);
+          this.registerFocusingElementAfterModalClose(this.folderInput, this.uploadMenuButtonSelector);
           this.folderInput.click();
         })
       ),

--- a/projects/aca-content/src/lib/store/effects/upload.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.ts
@@ -47,7 +47,7 @@ export class UploadEffects {
   private fileInput: HTMLInputElement;
   private folderInput: HTMLInputElement;
   private fileVersionInput: HTMLInputElement;
-  private readonly uploadMenuButtonSelector = 'app-toolbar-menu button[title="Upload content"]';
+  private readonly uploadMenuButtonSelector = 'app-toolbar-menu button[id="app.toolbar.upload"]';
 
   constructor(
     private store: Store<AppStore>,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After closing create and upload dialogs, the focus was not returning back to the menu/button

https://user-images.githubusercontent.com/110394264/234065328-ea362646-e8b0-477d-a1d7-66149ac532c2.mp4



**What is the new behaviour?**
After closing create and upload dialogs, the focus is now returning back to the menu/button

https://user-images.githubusercontent.com/110394264/234065433-00131b7a-47b7-457e-a662-5385a270f951.mp4



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4692