### PR TITLE
[ACA-4604] Reset Password Functionality

### DIFF
--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -77,24 +77,27 @@
         "RESET_PASSWORD": {
             "RESET_PASSWORD": "Reset Password",
             "INFO_FILLER": "In order to protect your account, make sure your password:",
+            "USERNAME": "Username",
             "NEW_PASSWORD": "New password",
             "RE_ENTER_NEW_PASSWORD": "Re-enter your new password",
             "PLACEHOLDERS" : {
+                "ENTER_USERNAME": "Enter username",
                 "ENTER_PASSWORD": "Enter password",
                 "CONFIRM_PASSWORD": "Confirm password"
             },
             "CHANGE_PASSWORD": "Change Password",
-            "PASSWORD_RULES": {
-                "LENGTH": "is 8 characters or longer",
-                "UPPERCASE": "has at least 1 uppercase letter",
-                "LOWERCASE": "has at least 1 lowercase letter",
-                "NUMBER": "as at least 1 number",
-                "SPECIAL_CHARACTER": "if possible, has at least 1 special character"
-            },
+            "CLOSE": "Close",
             "ERRORS": {
-                "INVALID_PASSWORD_FORMAT": "Invalid password format",
                 "PASSWORD_MISMATCH_ERROR": "Passwords do not match"
+            },
+            "RESET_PASSWORD_STATUS": {
+                "RESET_PASSWORD_SUCCESSFUL": "Reset password successful",
+                "SUCCESS_MESSAGE":"You have successfully updated your password.",
+                "RESET_PASSWORD_UNSUCCESSFUL": "Reset password failed",
+                "FAILURE_MESSAGE": "Something went wrong. Plase try again."
             }
+            
+
         },
         "LOCKED_BY": "Locked by: ",
         "PREVIEW": {

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -74,6 +74,28 @@
             "POSTCODE": "Postcode",
             "INVALID_INPUT": "Invalid Input"
         },
+        "RESET_PASSWORD": {
+            "RESET_PASSWORD": "Reset Password",
+            "INFO_FILLER": "In order to protect your account, make sure your password:",
+            "NEW_PASSWORD": "New password",
+            "RE_ENTER_NEW_PASSWORD": "Re-enter your new password",
+            "PLACEHOLDERS" : {
+                "ENTER_PASSWORD": "Enter password",
+                "CONFIRM_PASSWORD": "Confirm password"
+            },
+            "CHANGE_PASSWORD": "Change Password",
+            "PASSWORD_RULES": {
+                "LENGTH": "is 8 characters or longer",
+                "UPPERCASE": "has at least 1 uppercase letter",
+                "LOWERCASE": "has at least 1 lowercase letter",
+                "NUMBER": "as at least 1 number",
+                "SPECIAL_CHARACTER": "if possible, has at least 1 special character"
+            },
+            "ERRORS": {
+                "INVALID_PASSWORD_FORMAT": "Invalid password format",
+                "PASSWORD_MISMATCH_ERROR": "Passwords do not match"
+            }
+        },
         "LOCKED_BY": "Locked by: ",
         "PREVIEW": {
             "TITLE": "Preview"

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -118,6 +118,7 @@ import { UserInfoComponent } from './components/common/user-info/user-info.compo
 import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { ContentManagementService } from './services/content-management.service';
 import { ShellLayoutComponent, SHELL_NAVBAR_MIN_WIDTH } from '@alfresco/adf-core/shell';
+import { ResetPasswordModule } from './components/reset-password/reset-password.module';
 
 registerLocaleData(localeFr);
 registerLocaleData(localeDe);
@@ -149,6 +150,7 @@ registerLocaleData(localeSv);
     SharedModule,
     MaterialModule,
     AppStoreModule,
+    ResetPasswordModule,
     AppCommonModule,
     PageLayoutModule,
     DirectivesModule,

--- a/projects/aca-content/src/lib/aca-content.routes.ts
+++ b/projects/aca-content/src/lib/aca-content.routes.ts
@@ -40,6 +40,7 @@ import { Route } from '@angular/router';
 import { SharedLinkViewComponent } from './components/shared-link-view/shared-link-view.component';
 import { TrashcanComponent } from './components/trashcan/trashcan.component';
 import { ShellLayoutComponent } from '@alfresco/adf-core/shell';
+import { ResetPasswordComponent } from './components/reset-password/reset-password.component';
 
 export const CONTENT_ROUTES: ExtensionRoute[] = [
   {
@@ -53,6 +54,10 @@ export const CONTENT_ROUTES: ExtensionRoute[] = [
         }
       }
     ]
+  },
+  {
+    path: 'reset-password',
+    component: ResetPasswordComponent
   },
   {
     path: 'view',

--- a/projects/aca-content/src/lib/aca-content.routes.ts
+++ b/projects/aca-content/src/lib/aca-content.routes.ts
@@ -28,7 +28,7 @@ import { FavoriteLibrariesComponent } from './components/favorite-libraries/favo
 import { SearchResultsComponent } from './components/search/search-results/search-results.component';
 import { SearchLibrariesResultsComponent } from './components/search/search-libraries-results/search-libraries-results.component';
 import { AppSharedRuleGuard, GenericErrorComponent, ExtensionRoute, ExtensionsDataLoaderGuard } from '@alfresco/aca-shared';
-import { AuthGuard } from '@alfresco/adf-core';
+import { AuthGuard, ForgotPasswordComponent } from '@alfresco/adf-core';
 import { FavoritesComponent } from './components/favorites/favorites.component';
 import { RecentFilesComponent } from './components/recent-files/recent-files.component';
 import { SharedFilesComponent } from './components/shared-files/shared-files.component';
@@ -58,6 +58,10 @@ export const CONTENT_ROUTES: ExtensionRoute[] = [
   {
     path: 'reset-password',
     component: ResetPasswordComponent
+  },
+  {
+    path: 'forgot-password',
+    component: ForgotPasswordComponent
   },
   {
     path: 'view',

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
@@ -1,12 +1,10 @@
-<div class="reset-password-div">
-
+<div class="reset-password-div" *ngIf="!passwordChanged">
   <mat-card>
 
     <mat-card-header>
       <mat-card-title class="app-reset-password-title">
-        {{ 'RESET_PASSWORD.RESET-PASSWORD' | translate }}
+        {{ 'RESET_PASSWORD.RESET_PASSWORD' | translate }}
       </mat-card-title>
-
     </mat-card-header>
     <hr>
 
@@ -15,29 +13,44 @@
       <form [formGroup]="resetPasswordForm">
 
         <div class="reset-password-form-field">
-          <label for="new-passssword" class="app-reset-password-label">{{ 'RESET_PASSWORD.NEW_PASSWORD' | translate }}</label>
+          <label for="username" class="app-reset-password-label">{{ 'RESET_PASSWORD.USERNAME' | translate }}</label>
 
-          <div class="new-password-input-container">
-            <input id="new-passssword" class="app-reset-password-field" placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_PASSWORD' | translate }}" formControlName="password" required
-              [type]="passwordVisibility ? 'text' : 'password'">
-
-              <button matSuffix mat-icon-button type="button" (click)="togglePasswordVisibility()">
-                <mat-icon class="visibility-icon"> {{ passwordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
-              </button>
-            </div>
+          <div class="username-input-container">
+            <input id="username" class="app-reset-password-field"
+              placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_USERNAME' | translate }}" formControlName="username"
+              required type="text">
+          </div>
         </div>
 
         <div class="reset-password-form-field">
-          <label for="confirm-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.RE_ENTER_NEW_PASSWORD' | translate }}</label>
+          <label for="new-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.NEW_PASSWORD' | translate
+            }}</label>
+
+          <div class="new-password-input-container">
+            <input id="new-password" class="app-reset-password-field"
+              placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_PASSWORD' | translate }}" formControlName="password"
+              required [type]="passwordVisibility ? 'text' : 'password'">
+
+            <button matSuffix mat-icon-button type="button" (click)="togglePasswordVisibility()">
+              <mat-icon class="visibility-icon"> {{ passwordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <div class="reset-password-form-field">
+          <label for="confirm-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.RE_ENTER_NEW_PASSWORD' |
+            translate }}</label>
 
           <div class="confirm-password-input-container">
-            <input id="confirm-passssword" class="app-reset-password-field" placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.CONFIRM_PASSWORD' | translate }}" formControlName="confirmPassword"
-              required [type]="confirmPasswordVisibility ? 'text' : 'password'">
+            <input id="confirm-password" class="app-reset-password-field"
+              placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.CONFIRM_PASSWORD' | translate }}"
+              formControlName="confirmPassword" required [type]="confirmPasswordVisibility ? 'text' : 'password'">
 
-              <button matSuffix mat-icon-button type="button" (click)="toggleConfirmPasswordVisibility()">
-                <mat-icon class="visibility-icon"> {{ confirmPasswordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
-              </button> 
-            </div> 
+            <button matSuffix mat-icon-button type="button" (click)="toggleConfirmPasswordVisibility()">
+              <mat-icon class="visibility-icon"> {{ confirmPasswordVisibility ? 'visibility_off' : 'visibility' }}
+              </mat-icon>
+            </button>
+          </div>
         </div>
 
         <div class="password-mismatch-error" *ngIf="passwordMatchError()">
@@ -55,5 +68,54 @@
     </mat-card-content>
 
   </mat-card>
+</div>
 
+<div class="reset-password-div" *ngIf="passwordChangeSuccess">
+  <mat-card>
+
+    <mat-card-header>
+      <mat-card-title class="app-reset-password-title">
+        {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.RESET_PASSWORD_SUCCESSFUL' | translate }}
+      </mat-card-title>
+    </mat-card-header>
+    <hr>
+
+    <mat-card-content>
+      <div>
+        <p class="password-reset-message">
+          {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.SUCCESS_MESSAGE' | translate }}
+        </p>
+      </div>
+
+      <button mat-button class="close-button" (click)="close()">
+        {{ 'RESET_PASSWORD.CLOSE' | translate }}
+      </button>
+    </mat-card-content>
+
+  </mat-card>
+</div>
+
+<div class="reset-password-div" *ngIf="passwordChangeFailure">
+  <mat-card>
+
+    <mat-card-header>
+      <mat-card-title class="app-reset-password-title">
+        {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.RESET_PASSWORD_UNSUCCESSFUL' | translate }}
+      </mat-card-title>
+    </mat-card-header>
+    <hr>
+
+    <mat-card-content>
+      <div>
+        <p class="password-reset-message">
+          {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.FAILURE_MESSAGE' | translate }}
+        </p>
+      </div>
+
+      <button mat-button class="close-button" (click)="close()">
+        {{ 'RESET_PASSWORD.CLOSE' | translate }}
+      </button>
+    </mat-card-content>
+
+  </mat-card>
 </div>

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
@@ -1,0 +1,59 @@
+<div class="reset-password-div">
+
+  <mat-card>
+
+    <mat-card-header>
+      <mat-card-title class="app-reset-password-title">
+        {{ 'RESET_PASSWORD.RESET-PASSWORD' | translate }}
+      </mat-card-title>
+
+    </mat-card-header>
+    <hr>
+
+    <mat-card-content>
+
+      <form [formGroup]="resetPasswordForm">
+
+        <div class="reset-password-form-field">
+          <label for="new-passssword" class="app-reset-password-label">{{ 'RESET_PASSWORD.NEW_PASSWORD' | translate }}</label>
+
+          <div class="new-password-input-container">
+            <input id="new-passssword" class="app-reset-password-field" placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_PASSWORD' | translate }}" formControlName="password" required
+              [type]="passwordVisibility ? 'text' : 'password'">
+
+              <button matSuffix mat-icon-button type="button" (click)="togglePasswordVisibility()">
+                <mat-icon class="visibility-icon"> {{ passwordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
+              </button>
+            </div>
+        </div>
+
+        <div class="reset-password-form-field">
+          <label for="confirm-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.RE_ENTER_NEW_PASSWORD' | translate }}</label>
+
+          <div class="confirm-password-input-container">
+            <input id="confirm-passssword" class="app-reset-password-field" placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.CONFIRM_PASSWORD' | translate }}" formControlName="confirmPassword"
+              required [type]="confirmPasswordVisibility ? 'text' : 'password'">
+
+              <button matSuffix mat-icon-button type="button" (click)="toggleConfirmPasswordVisibility()">
+                <mat-icon class="visibility-icon"> {{ confirmPasswordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
+              </button> 
+            </div> 
+        </div>
+
+        <div class="password-mismatch-error" *ngIf="passwordMatchError()">
+          {{ 'RESET_PASSWORD.ERRORS.PASSWORD_MISMATCH_ERROR' | translate }}
+        </div>
+
+        <button type="button" (click)="changePassword()" [disabled]="isSubmitButtonDisabled()"
+          class="change-password-button" [attr.aria-label]="'PASSWORD.BUTTONS.SEND-INSTRUCTIONS' | translate"
+          mat-raised-button color="primary">
+          {{ 'RESET_PASSWORD.CHANGE_PASSWORD' | translate }}
+        </button>
+
+      </form>
+
+    </mat-card-content>
+
+  </mat-card>
+
+</div>

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
@@ -1,6 +1,5 @@
-<div class="reset-password-div" *ngIf="!passwordChanged">
+<div class="aca-reset-password" *ngIf="!passwordChanged">
   <mat-card>
-
     <mat-card-header>
       <mat-card-title class="app-reset-password-title">
         {{ 'RESET_PASSWORD.RESET_PASSWORD' | translate }}
@@ -9,13 +8,12 @@
     <hr>
 
     <mat-card-content>
-
       <form [formGroup]="resetPasswordForm">
 
         <div class="reset-password-form-field">
           <label for="username" class="app-reset-password-label">{{ 'RESET_PASSWORD.USERNAME' | translate }}</label>
 
-          <div class="username-input-container">
+          <div class="reset-password-input-container">
             <input id="username" class="app-reset-password-field"
               placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_USERNAME' | translate }}" formControlName="username"
               required type="text">
@@ -23,30 +21,28 @@
         </div>
 
         <div class="reset-password-form-field">
-          <label for="new-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.NEW_PASSWORD' | translate
-            }}</label>
+          <label for="new-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.NEW_PASSWORD' | translate }}</label>
 
-          <div class="new-password-input-container">
+          <div class="reset-password-input-container">
             <input id="new-password" class="app-reset-password-field"
               placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.ENTER_PASSWORD' | translate }}" formControlName="password"
               required [type]="passwordVisibility ? 'text' : 'password'">
 
-            <button matSuffix mat-icon-button type="button" (click)="togglePasswordVisibility()">
+            <button matSuffix mat-icon-button type="button" class="new-password-visibility-toggle" (click)="togglePasswordVisibility()">
               <mat-icon class="visibility-icon"> {{ passwordVisibility ? 'visibility_off' : 'visibility' }}</mat-icon>
             </button>
           </div>
         </div>
 
         <div class="reset-password-form-field">
-          <label for="confirm-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.RE_ENTER_NEW_PASSWORD' |
-            translate }}</label>
+          <label for="confirm-password" class="app-reset-password-label">{{ 'RESET_PASSWORD.RE_ENTER_NEW_PASSWORD' | translate }}</label>
 
-          <div class="confirm-password-input-container">
+          <div class="reset-password-input-container">
             <input id="confirm-password" class="app-reset-password-field"
               placeholder="{{'RESET_PASSWORD.PLACEHOLDERS.CONFIRM_PASSWORD' | translate }}"
               formControlName="confirmPassword" required [type]="confirmPasswordVisibility ? 'text' : 'password'">
 
-            <button matSuffix mat-icon-button type="button" (click)="toggleConfirmPasswordVisibility()">
+            <button matSuffix mat-icon-button type="button" class="confirm-password-visibility-toggle" (click)="toggleConfirmPasswordVisibility()">
               <mat-icon class="visibility-icon"> {{ confirmPasswordVisibility ? 'visibility_off' : 'visibility' }}
               </mat-icon>
             </button>
@@ -64,15 +60,12 @@
         </button>
 
       </form>
-
     </mat-card-content>
-
   </mat-card>
 </div>
 
-<div class="reset-password-div" *ngIf="passwordChangeSuccess">
+<div class="aca-reset-password" *ngIf="passwordChangeSuccess">
   <mat-card>
-
     <mat-card-header>
       <mat-card-title class="app-reset-password-title">
         {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.RESET_PASSWORD_SUCCESSFUL' | translate }}
@@ -91,13 +84,11 @@
         {{ 'RESET_PASSWORD.CLOSE' | translate }}
       </button>
     </mat-card-content>
-
   </mat-card>
 </div>
 
-<div class="reset-password-div" *ngIf="passwordChangeFailure">
+<div class="aca-reset-password" *ngIf="passwordChangeFailure">
   <mat-card>
-
     <mat-card-header>
       <mat-card-title class="app-reset-password-title">
         {{ 'RESET_PASSWORD.RESET_PASSWORD_STATUS.RESET_PASSWORD_UNSUCCESSFUL' | translate }}
@@ -116,6 +107,5 @@
         {{ 'RESET_PASSWORD.CLOSE' | translate }}
       </button>
     </mat-card-content>
-
   </mat-card>
 </div>

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.html
@@ -1,9 +1,11 @@
 <div class="aca-reset-password" *ngIf="!passwordChanged">
   <mat-card>
     <mat-card-header>
-      <mat-card-title class="app-reset-password-title">
-        {{ 'RESET_PASSWORD.RESET_PASSWORD' | translate }}
-      </mat-card-title>
+      <div class="custom-card-header mat-card-header-text">
+        <mat-card-title class="app-reset-password-title">
+          {{ 'RESET_PASSWORD.RESET_PASSWORD' | translate }}
+        </mat-card-title>
+      </div>
     </mat-card-header>
     <hr>
 

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
@@ -1,0 +1,139 @@
+.reset-password-div {
+  width: 371px;
+  height: 100vh;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  transform: translate(calc(50vw - 50%));
+  border-radius: 12px;
+}
+
+mat-card {
+  padding: 24px 24px;
+}
+
+::ng-deep .mat-card-header-text {
+  margin: 0 !important;
+}
+
+.app-reset-password-title {
+  font-style: normal;
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 28px;
+  letter-spacing: 0.15px;
+  color: var(--theme-reset-password-title-color);
+  padding: 2px 0;
+  margin: 0 !important;
+}
+
+hr {
+  margin: 12px 0;
+}
+
+.password-rules {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 8px 0px;
+  height: 16px;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.5px;
+  color: var(--theme-reset-password-label-color);
+  margin: 0 0 8px 0;
+}
+
+ul {
+  padding: 0 20px;
+  //height: 16px;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.5px;
+  color: var(--theme-reset-password-label-color);
+  margin: 0 0 8px 0;
+}
+
+.reset-password-form-field {
+  height: 64px;
+  margin-top: 24px;
+}
+
+.app-reset-password-label {
+  height: 32px;
+  padding: 6px 0;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0.15px;
+  color: var(--theme-reset-password-title-color);
+}
+
+.app-reset-password-field {
+  text-decoration: none;
+  background: none;
+  width: 100%;
+  border: none !important;
+  outline: none;
+}
+
+.new-password-input-container {
+  height: 32px;
+  line-height: 32px;
+  display: flex;
+  background: var(--theme-reset-password-input-background-color);
+  border-radius: 6px;
+  width: 100%;
+  border: none !important;
+  outline: none;
+  margin: 10px 0 24px 0;
+}
+
+.confirm-password-input-container {
+  height: 32px;
+  line-height: 32px;
+  display: flex;
+  background: var(--theme-reset-password-input-background-color);
+  border-radius: 6px;
+  width: 100%;
+  border: none !important;
+  outline: none;
+  margin: 10px 0 24px 0;
+}
+
+.visibility-icon {
+  width: 24px;
+  height: 24px;
+  padding: 0 0 8px 0;
+}
+
+.change-password-button {
+  width: 100% !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 12px;
+  height: 32px;
+  background: var(--theme-reset-password-button-background-color);
+  border-radius: 6px;
+  margin: 24px 0 0 0 !important;
+}
+
+.password-mismatch-error {
+  color: var(--theme-reset-password-error-color);
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.5px;
+}

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
@@ -1,5 +1,5 @@
 .reset-password-div {
-  width: 371px;
+  width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: row;
@@ -10,6 +10,7 @@
   left: 0;
   transform: translate(calc(50vw - 50%));
   border-radius: 12px;
+  background-color: var(--theme-reset-password-background);
 }
 
 mat-card {
@@ -86,6 +87,18 @@ ul {
   outline: none;
 }
 
+.username-input-container {
+  height: 32px;
+  line-height: 32px;
+  display: flex;
+  background: var(--theme-reset-password-input-background-color);
+  border-radius: 6px;
+  width: 100%;
+  border: none !important;
+  outline: none;
+  margin: 10px 0 24px 0;
+}
+
 .new-password-input-container {
   height: 32px;
   line-height: 32px;
@@ -136,4 +149,30 @@ ul {
   font-size: 12px;
   line-height: 16px;
   letter-spacing: 0.5px;
+}
+
+.password-reset-message {
+  height: 32px;
+  padding: 6px 0;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0.25px;
+  color: var( --theme-reset-password-title-color);
+  margin-bottom: 0;
+}
+
+.close-button {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--theme-grey-text-background-color);
+  color: var( --theme-reset-password-title-color);
+  margin-top: 8px;
+  padding: 4px 12px;
+  height: 32px;
+  border-radius: 6px;
 }

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
@@ -1,178 +1,122 @@
-.reset-password-div {
-  width: 100%;
-  height: 100vh;
+.aca-reset-password {
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  transform: translate(calc(50vw - 50%));
+  min-height: 100vh;
   border-radius: 12px;
   background-color: var(--theme-reset-password-background);
-}
 
-mat-card {
-  padding: 24px 24px;
-}
+  mat-card {
+    padding: 24px;
+  }
 
-::ng-deep .mat-card-header-text {
-  margin: 0 !important;
-}
+  ::ng-deep .mat-card-header-text {
+    margin: 0 !important;
+  }
 
-.app-reset-password-title {
-  font-style: normal;
-  font-weight: 400;
-  font-size: 20px;
-  line-height: 28px;
-  letter-spacing: 0.15px;
-  color: var(--theme-reset-password-title-color);
-  padding: 2px 0;
-  margin: 0 !important;
-}
+  .app-reset-password-title {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 20px;
+    line-height: 28px;
+    letter-spacing: 0.15px;
+    color: var(--theme-reset-password-title-color);
+    padding: 2px 0;
+    margin: 0;
+  }
 
-hr {
-  margin: 12px 0;
-}
+  hr {
+    margin: 12px 0;
+  }
 
-.password-rules {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 8px 0px;
-  height: 16px;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 16px;
-  letter-spacing: 0.5px;
-  color: var(--theme-reset-password-label-color);
-  margin: 0 0 8px 0;
-}
+  .reset-password-form-field {
+    height: 64px;
+    margin-top: 24px;
+  }
 
-ul {
-  padding: 0 20px;
-  //height: 16px;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 16px;
-  letter-spacing: 0.5px;
-  color: var(--theme-reset-password-label-color);
-  margin: 0 0 8px 0;
-}
+  .app-reset-password-label {
+    height: 32px;
+    padding: 6px 0;
+    font-style: normal;
+    font-weight: 700;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.15px;
+    color: var(--theme-reset-password-title-color);
+  }
 
-.reset-password-form-field {
-  height: 64px;
-  margin-top: 24px;
-}
+  .app-reset-password-field {
+    text-decoration: none;
+    background: none;
+    width: 100%;
+    padding: 0 6px;
+    border: none;
+    outline: none;
+  }
 
-.app-reset-password-label {
-  height: 32px;
-  padding: 6px 0;
-  font-style: normal;
-  font-weight: 700;
-  font-size: 14px;
-  line-height: 20px;
-  letter-spacing: 0.15px;
-  color: var(--theme-reset-password-title-color);
-}
+   .reset-password-input-container {
+    height: 32px;
+    line-height: 32px;
+    display: flex;
+    background: var(--theme-reset-password-input-background-color);
+    border-radius: 6px;
+    width: 100%;
+    border: none;
+    outline: none;
+    margin: 10px 0 24px 0;
+  }
 
-.app-reset-password-field {
-  text-decoration: none;
-  background: none;
-  width: 100%;
-  border: none !important;
-  outline: none;
-}
+  .visibility-icon {
+    width: 24px;
+    height: 24px;
+    padding: 0 0 8px;
+  }
 
-.username-input-container {
-  height: 32px;
-  line-height: 32px;
-  display: flex;
-  background: var(--theme-reset-password-input-background-color);
-  border-radius: 6px;
-  width: 100%;
-  border: none !important;
-  outline: none;
-  margin: 10px 0 24px 0;
-}
+  .change-password-button {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 12px;
+    height: 32px;
+    background: var(--theme-reset-password-button-background-color);
+    border-radius: 6px;
+    margin: 24px 0 0;
+  }
 
-.new-password-input-container {
-  height: 32px;
-  line-height: 32px;
-  display: flex;
-  background: var(--theme-reset-password-input-background-color);
-  border-radius: 6px;
-  width: 100%;
-  border: none !important;
-  outline: none;
-  margin: 10px 0 24px 0;
-}
+  .password-mismatch-error {
+    color: var(--theme-reset-password-error-color);
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: 0.5px;
+  }
 
-.confirm-password-input-container {
-  height: 32px;
-  line-height: 32px;
-  display: flex;
-  background: var(--theme-reset-password-input-background-color);
-  border-radius: 6px;
-  width: 100%;
-  border: none !important;
-  outline: none;
-  margin: 10px 0 24px 0;
-}
+  .password-reset-message {
+    height: 32px;
+    padding: 6px 0;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.25px;
+    color: var(--theme-reset-password-title-color);
+    margin-bottom: 0;
+  }
 
-.visibility-icon {
-  width: 24px;
-  height: 24px;
-  padding: 0 0 8px 0;
-}
-
-.change-password-button {
-  width: 100% !important;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 4px 12px;
-  height: 32px;
-  background: var(--theme-reset-password-button-background-color);
-  border-radius: 6px;
-  margin: 24px 0 0 0 !important;
-}
-
-.password-mismatch-error {
-  color: var(--theme-reset-password-error-color);
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 16px;
-  letter-spacing: 0.5px;
-}
-
-.password-reset-message {
-  height: 32px;
-  padding: 6px 0;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 20px;
-  letter-spacing: 0.25px;
-  color: var( --theme-reset-password-title-color);
-  margin-bottom: 0;
-}
-
-.close-button {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--theme-grey-text-background-color);
-  color: var( --theme-reset-password-title-color);
-  margin-top: 8px;
-  padding: 4px 12px;
-  height: 32px;
-  border-radius: 6px;
+  .close-button {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--theme-grey-text-background-color);
+    color: var(--theme-reset-password-title-color);
+    margin-top: 8px;
+    padding: 4px 12px;
+    height: 32px;
+    border-radius: 6px;
+  }
 }

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.scss
@@ -10,7 +10,7 @@
     padding: 24px;
   }
 
-  ::ng-deep .mat-card-header-text {
+  .custom-card-header {
     margin: 0 !important;
   }
 
@@ -54,7 +54,7 @@
     outline: none;
   }
 
-   .reset-password-input-container {
+  .reset-password-input-container {
     height: 32px;
     line-height: 32px;
     display: flex;
@@ -63,7 +63,7 @@
     width: 100%;
     border: none;
     outline: none;
-    margin: 10px 0 24px 0;
+    margin: 10px 0 24px;
   }
 
   .visibility-icon {

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,163 @@
+/*!
+ * @license
+ * Alfresco Example Content Application
+ *
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CoreModule } from '@alfresco/adf-core';
+import { ResetPasswordComponent } from './reset-password.component';
+import { AppTestingModule } from '../../testing/app-testing.module';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule, CoreModule.forChild()],
+      declarations: [ResetPasswordComponent],
+      providers: []
+    });
+
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('change password button should be disabled by default', async () => {
+    component.ngOnInit();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toBeTruthy();
+  });
+
+  it('change password button should be disabled if new password field is empty', async () => {
+    component.ngOnInit();
+    component.resetPasswordForm.controls['password'].setValue('');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('password');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toBeTruthy();
+  });
+
+  it('change password button should be disabled if confirm password field is empty', async () => {
+    component.ngOnInit();
+    component.resetPasswordForm.controls['password'].setValue('password');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toBeTruthy();
+  });
+
+  it('change password button should be disabled if new password and confirm password field values do not match', async () => {
+    component.ngOnInit();
+    component.resetPasswordForm.controls['password'].setValue('password1');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('password2');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toBeTruthy();
+  });
+
+  it('change password button should be enabled when new password and confirm password field values match', async () => {
+    component.ngOnInit();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.resetPasswordForm.controls['password'].setValue('password');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('password');
+
+    spyOn(component, 'isSubmitButtonDisabled').and.callThrough();
+    const changePasswordBtn = fixture.debugElement.nativeElement.querySelector('.change-password-button');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toHaveBeenCalled();
+    expect(changePasswordBtn.disabled).toBeFalsy();
+  });
+
+  it('should toggle new password field value visibility when visibility icon is clicked', async () => {
+    component.ngOnInit();
+    component.passwordVisibility = false;
+    spyOn(component, 'togglePasswordVisibility').and.callThrough();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.new-password-input-container > button');
+    eyeIcon.click();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.togglePasswordVisibility).toHaveBeenCalled();
+    expect(component.passwordVisibility).toEqual(true);
+  });
+
+  it('should toggle confirm password field value visibility when visibility icon is clicked', async () => {
+    component.ngOnInit();
+    component.confirmPasswordVisibility = false;
+    spyOn(component, 'toggleConfirmPasswordVisibility').and.callThrough();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.confirm-password-input-container > button');
+    eyeIcon.click();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.toggleConfirmPasswordVisibility).toHaveBeenCalled();
+    expect(component.confirmPasswordVisibility).toEqual(true);
+  });
+
+  it('should change password when the change password button is clicked', async () => {
+    component.ngOnInit();
+    component.resetPasswordForm.controls['password'].setValue('password');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('password');
+    spyOn(component, 'changePassword').and.callThrough();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const changePasswordBtn = fixture.debugElement.nativeElement.querySelector('.change-password-button');
+    changePasswordBtn.dispatchEvent(new Event('click'));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.changePassword).toHaveBeenCalled();
+  });
+});

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -56,8 +56,21 @@ describe('ResetPasswordComponent', () => {
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
+  it('change password button should be disabled if username field is empty', async () => {
+    component.ngOnInit();
+    component.resetPasswordForm.controls['username'].setValue('');
+    component.resetPasswordForm.controls['password'].setValue('password');
+    component.resetPasswordForm.controls['confirmPassword'].setValue('password');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isSubmitButtonDisabled).toBeTruthy();
+  });
+
   it('change password button should be disabled if new password field is empty', async () => {
     component.ngOnInit();
+    component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
 
@@ -69,6 +82,7 @@ describe('ResetPasswordComponent', () => {
 
   it('change password button should be disabled if confirm password field is empty', async () => {
     component.ngOnInit();
+    component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('');
 
@@ -80,6 +94,7 @@ describe('ResetPasswordComponent', () => {
 
   it('change password button should be disabled if new password and confirm password field values do not match', async () => {
     component.ngOnInit();
+    component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password1');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password2');
 
@@ -89,11 +104,12 @@ describe('ResetPasswordComponent', () => {
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
-  it('change password button should be enabled when new password and confirm password field values match', async () => {
+  it('change password button should be enabled when new password and confirm password field values match and username field is not empty', async () => {
     component.ngOnInit();
     fixture.detectChanges();
     await fixture.whenStable();
 
+    component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
 
@@ -145,6 +161,7 @@ describe('ResetPasswordComponent', () => {
 
   it('should change password when the change password button is clicked', async () => {
     component.ngOnInit();
+    component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
     spyOn(component, 'changePassword').and.callThrough();

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -1,12 +1,11 @@
 /*!
- * @license
- * Alfresco Example Content Application
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Alfresco Example Content Application
  *
  * This file is part of the Alfresco Example Content Application.
  * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * the paid license agreement will prevail. Otherwise, the software is
  * provided under the following open source license terms:
  *
  * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
@@ -16,11 +15,11 @@
  *
  * The Alfresco Example Content Application is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -24,28 +24,52 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiService, AlfrescoApiServiceMock, CoreModule } from '@alfresco/adf-core';
 import { ResetPasswordComponent } from './reset-password.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
+  const router: any = {
+    url: '',
+    navigate: jasmine.createSpy('navigate')
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [AppTestingModule, CoreModule.forChild()],
-      declarations: [ResetPasswordComponent]
+      declarations: [ResetPasswordComponent],
+      providers: [
+        {
+          provide: Router,
+          useValue: router
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { data: { preferencePrefix: 'prefix' }, paramMap: convertToParamMap({ folderId: undefined }) },
+            params: of({ folderId: 'someId' }),
+            queryParamMap: of({})
+          }
+        },
+        {
+          provide: AlfrescoApiService,
+          useClass: AlfrescoApiServiceMock
+        }
+      ]
     });
 
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
-    component.ngOnInit();
+    fixture.detectChanges();
   });
 
-  // afterEach(() => {
-  //   fixture.destroy();
-  // });
+  afterEach(() => {
+    fixture.destroy();
+  });
 
   it('change password button should be disabled by default', async () => {
     expect(component.isSubmitButtonDisabled).toBeTruthy();
@@ -56,9 +80,6 @@ describe('ResetPasswordComponent', () => {
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
@@ -66,9 +87,6 @@ describe('ResetPasswordComponent', () => {
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
-
-    fixture.detectChanges();
-    await fixture.whenStable();
 
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
@@ -78,9 +96,6 @@ describe('ResetPasswordComponent', () => {
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('');
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
@@ -89,16 +104,10 @@ describe('ResetPasswordComponent', () => {
     component.resetPasswordForm.controls['password'].setValue('password1');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password2');
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
   it('change password button should be enabled when new password and confirm password field values match and username field is not empty', async () => {
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
@@ -117,14 +126,8 @@ describe('ResetPasswordComponent', () => {
     component.passwordVisibility = false;
     spyOn(component, 'togglePasswordVisibility').and.callThrough();
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     const eyeIcon = fixture.debugElement.nativeElement.querySelector('.new-password-visibility-toggle');
     eyeIcon.click();
-
-    fixture.detectChanges();
-    await fixture.whenStable();
 
     expect(component.togglePasswordVisibility).toHaveBeenCalled();
     expect(component.passwordVisibility).toEqual(true);
@@ -134,14 +137,8 @@ describe('ResetPasswordComponent', () => {
     component.confirmPasswordVisibility = false;
     spyOn(component, 'toggleConfirmPasswordVisibility').and.callThrough();
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     const eyeIcon = fixture.debugElement.nativeElement.querySelector('.confirm-password-visibility-toggle');
     eyeIcon.click();
-
-    fixture.detectChanges();
-    await fixture.whenStable();
 
     expect(component.toggleConfirmPasswordVisibility).toHaveBeenCalled();
     expect(component.confirmPasswordVisibility).toEqual(true);
@@ -153,14 +150,8 @@ describe('ResetPasswordComponent', () => {
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
     spyOn(component, 'changePassword').and.callThrough();
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     const changePasswordBtn = fixture.debugElement.nativeElement.querySelector('.change-password-button');
     changePasswordBtn.dispatchEvent(new Event('click'));
-
-    fixture.detectChanges();
-    await fixture.whenStable();
 
     expect(component.changePassword).toHaveBeenCalled();
   });

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -28,14 +28,14 @@ import { CoreModule } from '@alfresco/adf-core';
 import { ResetPasswordComponent } from './reset-password.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
-fdescribe('ResetPasswordComponent', () => {
+describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [AppTestingModule, CoreModule.forChild()],
-      declarations: [ResetPasswordComponent],
+      declarations: [ResetPasswordComponent]
     });
 
     fixture = TestBed.createComponent(ResetPasswordComponent);

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.spec.ts
@@ -28,7 +28,7 @@ import { CoreModule } from '@alfresco/adf-core';
 import { ResetPasswordComponent } from './reset-password.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
-describe('ResetPasswordComponent', () => {
+fdescribe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
 
@@ -36,28 +36,22 @@ describe('ResetPasswordComponent', () => {
     TestBed.configureTestingModule({
       imports: [AppTestingModule, CoreModule.forChild()],
       declarations: [ResetPasswordComponent],
-      providers: []
     });
 
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
+    component.ngOnInit();
   });
 
-  it('should be created', () => {
-    expect(component).toBeTruthy();
-  });
+  // afterEach(() => {
+  //   fixture.destroy();
+  // });
 
   it('change password button should be disabled by default', async () => {
-    component.ngOnInit();
-
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.isSubmitButtonDisabled).toBeTruthy();
   });
 
   it('change password button should be disabled if username field is empty', async () => {
-    component.ngOnInit();
     component.resetPasswordForm.controls['username'].setValue('');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
@@ -69,7 +63,6 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('change password button should be disabled if new password field is empty', async () => {
-    component.ngOnInit();
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');
@@ -81,7 +74,6 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('change password button should be disabled if confirm password field is empty', async () => {
-    component.ngOnInit();
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('');
@@ -93,7 +85,6 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('change password button should be disabled if new password and confirm password field values do not match', async () => {
-    component.ngOnInit();
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password1');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password2');
@@ -105,7 +96,6 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('change password button should be enabled when new password and confirm password field values match and username field is not empty', async () => {
-    component.ngOnInit();
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -124,14 +114,13 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('should toggle new password field value visibility when visibility icon is clicked', async () => {
-    component.ngOnInit();
     component.passwordVisibility = false;
     spyOn(component, 'togglePasswordVisibility').and.callThrough();
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.new-password-input-container > button');
+    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.new-password-visibility-toggle');
     eyeIcon.click();
 
     fixture.detectChanges();
@@ -142,14 +131,13 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('should toggle confirm password field value visibility when visibility icon is clicked', async () => {
-    component.ngOnInit();
     component.confirmPasswordVisibility = false;
     spyOn(component, 'toggleConfirmPasswordVisibility').and.callThrough();
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.confirm-password-input-container > button');
+    const eyeIcon = fixture.debugElement.nativeElement.querySelector('.confirm-password-visibility-toggle');
     eyeIcon.click();
 
     fixture.detectChanges();
@@ -160,7 +148,6 @@ describe('ResetPasswordComponent', () => {
   });
 
   it('should change password when the change password button is clicked', async () => {
-    component.ngOnInit();
     component.resetPasswordForm.controls['username'].setValue('user');
     component.resetPasswordForm.controls['password'].setValue('password');
     component.resetPasswordForm.controls['confirmPassword'].setValue('password');

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2005 - 2021 Alfresco Software, Ltd. All rights reserved.
+ *
+ * License rights for this program may be obtained from Alfresco Software, Ltd.
+ * pursuant to a written agreement and any use of this program without such an
+ * agreement is prohibited.
+ */
+
+import { AlfrescoApiService } from '@alfresco/adf-core';
+import { PasswordResetBody, PeopleApi } from '@alfresco/js-api';
+import { Component, OnInit } from '@angular/core';
+import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-reset-password',
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.scss']
+})
+export class ResetPasswordComponent implements OnInit {
+  private peopleApi: PeopleApi;
+  resetPasswordForm: FormGroup;
+  passwordVisibility: boolean;
+  confirmPasswordVisibility: boolean;
+
+  constructor(private activatedRoute: ActivatedRoute, private apiService: AlfrescoApiService) {}
+
+  get peopleApiInstance() {
+    return this.peopleApi || (this.peopleApi = new PeopleApi(this.apiService.getInstance()));
+  }
+
+  ngOnInit(): void {
+    this.resetPasswordForm = new FormGroup(
+      {
+        password: new FormControl('', [Validators.required]),
+        confirmPassword: new FormControl('', [Validators.required])
+      },
+      [this.matchValidator('password', 'confirmPassword')]
+    );
+    this.passwordVisibility = false;
+    this.confirmPasswordVisibility = false;
+  }
+
+  togglePasswordVisibility() {
+    this.passwordVisibility = !this.passwordVisibility;
+  }
+
+  toggleConfirmPasswordVisibility() {
+    this.confirmPasswordVisibility = !this.confirmPasswordVisibility;
+  }
+
+  changePassword() {
+    let key = '';
+    let id = '';
+    let userName = '';
+
+    this.activatedRoute.queryParams.subscribe((data) => {
+      key = data.key;
+      id = data.id;
+      userName = data.userName;
+    });
+
+    this.peopleApiInstance.resetPassword(userName, {
+      password: this.resetPasswordForm.controls.password.value,
+      id,
+      key
+    } as PasswordResetBody);
+  }
+
+  isSubmitButtonDisabled(): boolean {
+    if (this.resetPasswordForm.invalid || this.passwordMatchError()) {
+      return this.resetPasswordForm.invalid || this.passwordMatchError();
+    } else {
+      return false;
+    }
+  }
+
+  passwordMatchError(): boolean {
+    return this.resetPasswordForm.getError('mismatch') && this.resetPasswordForm.get('confirmPassword')?.dirty;
+  }
+
+  matchValidator(source: string, target: string): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const sourceCtrl = control.get(source);
+      const targetCtrl = control.get(target);
+
+      return sourceCtrl && targetCtrl && sourceCtrl.value !== targetCtrl.value ? { mismatch: true } : null;
+    };
+  }
+}

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -22,6 +22,9 @@ export class ResetPasswordComponent implements OnInit {
   resetPasswordForm: FormGroup;
   passwordVisibility: boolean;
   confirmPasswordVisibility: boolean;
+  passwordChanged: boolean;
+  passwordChangeSuccess: boolean;
+  passwordChangeFailure: boolean;
 
   constructor(private activatedRoute: ActivatedRoute, private apiService: AlfrescoApiService, private router: Router) {}
 
@@ -32,11 +35,15 @@ export class ResetPasswordComponent implements OnInit {
   ngOnInit(): void {
     this.resetPasswordForm = new FormGroup(
       {
+        username: new FormControl('', [Validators.required]),
         password: new FormControl('', [Validators.required]),
         confirmPassword: new FormControl('', [Validators.required])
       },
       [this.matchValidator('password', 'confirmPassword')]
     );
+    this.passwordChanged = false;
+    this.passwordChangeSuccess = false;
+    this.passwordChangeFailure = false;
     this.passwordVisibility = false;
     this.confirmPasswordVisibility = false;
   }
@@ -50,6 +57,8 @@ export class ResetPasswordComponent implements OnInit {
   }
 
   changePassword() {
+    //this.passwordChangeSuccess = true;
+    //this.passwordChangeFailure = true;
     let key = '';
     let id = '';
     let userName = '';
@@ -57,15 +66,24 @@ export class ResetPasswordComponent implements OnInit {
     this.activatedRoute.queryParams.subscribe((data) => {
       key = data.key;
       id = data.id;
-      userName = data.userName;
+      // userName = data.userName;
+      userName = this.resetPasswordForm.controls.username.value;
     });
 
-    this.peopleApiInstance.resetPassword(userName, {
+    let resetPassword = this.peopleApi.resetPassword(userName, {
       password: this.resetPasswordForm.controls.password.value,
       id,
       key
     } as PasswordResetBody);
-    this.router.navigate(['./login']);
+
+    resetPassword.then((value) => {
+      console.log('resolved', value);
+      this.passwordChangeSuccess = true;
+    });
+    resetPassword.catch((error) => {
+      console.log('rejected', error);
+      this.passwordChangeFailure = true;
+    });
   }
 
   isSubmitButtonDisabled(): boolean {
@@ -87,5 +105,9 @@ export class ResetPasswordComponent implements OnInit {
 
       return sourceCtrl && targetCtrl && sourceCtrl.value !== targetCtrl.value ? { mismatch: true } : null;
     };
+  }
+
+  close() {
+    this.router.navigate(['./login']);
   }
 }

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -10,7 +10,7 @@ import { AlfrescoApiService } from '@alfresco/adf-core';
 import { PasswordResetBody, PeopleApi } from '@alfresco/js-api';
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-reset-password',
@@ -23,7 +23,7 @@ export class ResetPasswordComponent implements OnInit {
   passwordVisibility: boolean;
   confirmPasswordVisibility: boolean;
 
-  constructor(private activatedRoute: ActivatedRoute, private apiService: AlfrescoApiService) {}
+  constructor(private activatedRoute: ActivatedRoute, private apiService: AlfrescoApiService, private router: Router) {}
 
   get peopleApiInstance() {
     return this.peopleApi || (this.peopleApi = new PeopleApi(this.apiService.getInstance()));
@@ -65,6 +65,7 @@ export class ResetPasswordComponent implements OnInit {
       id,
       key
     } as PasswordResetBody);
+    this.router.navigate(['./login']);
   }
 
   isSubmitButtonDisabled(): boolean {

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -1,9 +1,25 @@
-/*
- * Copyright © 2005 - 2021 Alfresco Software, Ltd. All rights reserved.
+/*!
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
- * License rights for this program may be obtained from Alfresco Software, Ltd.
- * pursuant to a written agreement and any use of this program without such an
- * agreement is prohibited.
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
 import { AlfrescoApiService } from '@alfresco/adf-core';
@@ -25,6 +41,7 @@ export class ResetPasswordComponent implements OnInit {
   passwordChanged: boolean;
   passwordChangeSuccess: boolean;
   passwordChangeFailure: boolean;
+  passwordResetStatus: any;
 
   constructor(private activatedRoute: ActivatedRoute, private apiService: AlfrescoApiService, private router: Router) {}
 
@@ -74,11 +91,11 @@ export class ResetPasswordComponent implements OnInit {
     } as PasswordResetBody);
 
     resetPassword.then((value) => {
-      console.log('resolved', value);
+      this.passwordResetStatus = value;
       this.passwordChangeSuccess = true;
     });
     resetPassword.catch((error) => {
-      console.log('rejected', error);
+      this.passwordResetStatus = error;
       this.passwordChangeFailure = true;
     });
   }

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -57,8 +57,6 @@ export class ResetPasswordComponent implements OnInit {
   }
 
   changePassword() {
-    //this.passwordChangeSuccess = true;
-    //this.passwordChangeFailure = true;
     let key = '';
     let id = '';
     let userName = '';
@@ -69,7 +67,7 @@ export class ResetPasswordComponent implements OnInit {
       userName = this.resetPasswordForm.controls.username.value;
     });
 
-    let resetPassword = this.peopleApi.resetPassword(userName, {
+    const resetPassword = this.peopleApiInstance.resetPassword(userName, {
       password: this.resetPasswordForm.controls.password.value,
       id,
       key

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.component.ts
@@ -66,7 +66,6 @@ export class ResetPasswordComponent implements OnInit {
     this.activatedRoute.queryParams.subscribe((data) => {
       key = data.key;
       id = data.id;
-      // userName = data.userName;
       userName = this.resetPasswordForm.controls.username.value;
     });
 

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.module.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.module.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2005 - 2021 Alfresco Software, Ltd. All rights reserved.
+ *
+ * License rights for this program may be obtained from Alfresco Software, Ltd.
+ * pursuant to a written agreement and any use of this program without such an
+ * agreement is prohibited.
+ */
+
+import { MaterialModule } from '@alfresco/adf-core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { ResetPasswordComponent } from './reset-password.component';
+
+@NgModule({
+  imports: [RouterModule, FormsModule, ReactiveFormsModule, CommonModule, TranslateModule, HttpClientModule, MaterialModule],
+  declarations: [ResetPasswordComponent],
+  exports: [ResetPasswordComponent]
+})
+export class ResetPasswordModule {}

--- a/projects/aca-content/src/lib/components/reset-password/reset-password.module.ts
+++ b/projects/aca-content/src/lib/components/reset-password/reset-password.module.ts
@@ -1,9 +1,25 @@
-/*
- * Copyright © 2005 - 2021 Alfresco Software, Ltd. All rights reserved.
+/*!
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
- * License rights for this program may be obtained from Alfresco Software, Ltd.
- * pursuant to a written agreement and any use of this program without such an
- * agreement is prohibited.
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
 import { MaterialModule } from '@alfresco/adf-core';

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -82,6 +82,7 @@ $defaults: (
   --theme-header-border-color: $grey-background,
   --theme-page-layout-header-background-color: $page-layout-header-background-color,
   --theme-app-toolbar-button-background-color: $aca-toolbar-button-background-color,
+  --theme-reset-password-background: #E5E5E5,
   --theme-reset-password-title-color: #212121,
   --theme-reset-password-label-color: rgba(33, 35, 40, 0.7),
   --theme-reset-password-input-background-color: $grey-text-background,

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -31,12 +31,6 @@ $datetimepicker-selected-date-background: #2254b2;
 $datetimepicker-cell-background-color: #fff;
 $datetimepicker-cell-focus-border-color: #1f74db;
 $datetimepicker-cell-focus-background-color: rgba(33, 33, 33, 0.12);
-$sidenav-background-color: #f8f8f8;
-$selected-text-color: #212121;
-$selected-background-color: rgba(31, 116, 219, 0.24);
-$action-button-text-color: rgba(33, 35, 40, 0.7);
-$page-layout-header-background-color: #fff;
-$aca-toolbar-button-background-color: rgba(33, 33, 33, 0.05);
 
 // CSS Variables
 $defaults: (
@@ -74,14 +68,6 @@ $defaults: (
   --theme-datetimepicker-cell-background: $datetimepicker-cell-background-color,
   --theme-datetimepicker-cell-focus-border: $datetimepicker-cell-focus-border-color,
   --theme-datetimepicker-cell-focus-background: $datetimepicker-cell-focus-background-color,
-  --theme-sidenav-background-color: $sidenav-background-color,
-  --theme-selected-text-color: $selected-text-color,
-  --theme-selected-background-color: $selected-background-color,
-  --theme-hover-background-color: $grey-text-background,
-  --theme-action-button-text-color: $action-button-text-color,
-  --theme-header-border-color: $grey-background,
-  --theme-page-layout-header-background-color: $page-layout-header-background-color,
-  --theme-app-toolbar-button-background-color: $aca-toolbar-button-background-color,
   --theme-reset-password-background: #E5E5E5,
   --theme-reset-password-title-color: #212121,
   --theme-reset-password-label-color: rgba(33, 35, 40, 0.7),

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -81,7 +81,14 @@ $defaults: (
   --theme-action-button-text-color: $action-button-text-color,
   --theme-header-border-color: $grey-background,
   --theme-page-layout-header-background-color: $page-layout-header-background-color,
-  --theme-app-toolbar-button-background-color: $aca-toolbar-button-background-color
+  --theme-app-toolbar-button-background-color: $aca-toolbar-button-background-color,
+  --theme-reset-password-title-color: #212121,
+  --theme-reset-password-label-color: rgba(33, 35, 40, 0.7),
+  --theme-reset-password-input-background-color: $grey-text-background,
+  --theme-reset-password-button-background-color: $blue-save-button-background,
+  --theme-reset-password-dialog-border-color: $grey-background,
+  --theme-reset-password-dialog-shadow-color: rgba(33, 35, 40, 0.06),
+  --theme-reset-password-error-color: red,
 );
 
 // propagates SCSS variables into the CSS variables scope


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There's no password reset functionality if the user forgets the password


**What is the new behaviour?**
This PR includes **Reset Password functionality** for ECM users. 
Once the ECM user has clicked on _forgot password link_ (https://github.com/Alfresco/alfresco-ng2-components/pull/8529), and received the Reset Password email on the registered mail ID, the user can click on the link in the email to get redirected to the Reset Password screen and change the Password.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4643
This PR depends on https://github.com/Alfresco/alfresco-ng2-components/pull/8529