### PR TITLE
[ACS-5156] Bug fixes for search Input

### DIFF
--- a/e2e/suites/search/search-results-libraries.test.ts
+++ b/e2e/suites/search/search-results-libraries.test.ts
@@ -174,16 +174,6 @@ describe('Search results - libraries', () => {
     expect(await dataTable.isItemPresent(site4.name)).toBe(true, `${site4.name} not displayed`);
   });
 
-  it('[C290015] Results page title', async () => {
-    await toolbar.clickSearchIconButton();
-    await searchInput.clickSearchButton();
-    await searchInput.checkLibraries();
-    await searchInput.searchForLibrary(random);
-    await dataTable.waitForBody();
-
-    expect(await page.breadcrumb.currentItem.getText()).toEqual('Libraries found...');
-  });
-
   it('[C290016] Results page columns', async () => {
     await toolbar.clickSearchIconButton();
     await searchInput.clickSearchButton();

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -237,7 +237,6 @@
                 }
             },
             "SEARCH_LIBRARIES": {
-              "TITLE": "Libraries found...",
               "FOUND_RESULTS": "{{ number }} results",
               "FOUND_ONE_RESULT": "{{ number }} result"
             }

--- a/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.html
+++ b/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.html
@@ -19,6 +19,7 @@
       (ngModelChange)="inputChange($event)"
       (keyup.enter)="searchSubmit($event)"
       [placeholder]="'SEARCH.INPUT.PLACEHOLDER' | translate"
+      autocomplete="off"
     />
     <div matSuffix class="app-suffix-search-icon-wrapper">
       <mat-icon *ngIf="searchTerm.length" (click)="clear()" class="app-clear-icon">clear</mat-icon>

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.html
@@ -1,6 +1,7 @@
 <aca-page-layout>
   <aca-page-layout-header>
-    <adf-breadcrumb root="APP.BROWSE.SEARCH_LIBRARIES.TITLE"> </adf-breadcrumb>
+    <aca-search-input></aca-search-input>
+    <adf-breadcrumb root="APP.BROWSE.SEARCH_LIBRARIES.TITLE"> </adf-breadcrumb> 
     <adf-toolbar class="adf-toolbar--inline">
       <ng-container *ngFor="let entry of actions; trackBy: trackByActionId">
         <aca-toolbar-action [actionRef]="entry"></aca-toolbar-action>

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.html
@@ -1,7 +1,7 @@
 <aca-page-layout>
   <aca-page-layout-header>
     <aca-search-input></aca-search-input>
-    <adf-breadcrumb root="APP.BROWSE.SEARCH_LIBRARIES.TITLE"> </adf-breadcrumb> 
+    <div class="adf-toolbar--spacer adf-toolbar-divider"></div>
     <adf-toolbar class="adf-toolbar--inline">
       <ng-container *ngFor="let entry of actions; trackBy: trackByActionId">
         <aca-toolbar-action [actionRef]="entry"></aca-toolbar-action>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
1.After searching something in libraries, the search input should be visible but instead of that it disappears actually.
2.There is also issue with some hints menu which overlaps popup with content type. That hints menu shows last used searched values. 


**What is the new behaviour?**
1.After searching something and selecting libraries, the search input is visible Now.
2.The Search hints menu shows last used searched values. Should be disable Now


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5156
![Search-Library](https://github.com/Alfresco/alfresco-content-app/assets/88775344/e2209eae-dafb-418d-9de3-3764510d619f)
![Search-hint](https://github.com/Alfresco/alfresco-content-app/assets/88775344/28aab1f2-b855-4d54-a73d-9468d2fdfb49)
