### PR TITLE
[MOBILEAPPS-1707] Open in App Dialog design changes as per new design and visibility of dialog enabled after the login and is shown in case of private files as well 

### DIFF
--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -11,7 +11,8 @@
     "iphoneUrl": "iosamw://",
     "androidUrlPart1": "intent:///",
     "androidUrlPart2": "#Intent;scheme=androidamw;package=com.alfresco.content.app;end",
-    "sessionTimeForOpenAppDialogDisplay": "${APP_CONFIG_SESSION_TIME_FOR_OPEN_APP_DIALOG_DISPLAY_IN_HOURS}"
+    "sessionTimeForOpenAppDialogDisplay": "${APP_CONFIG_SESSION_TIME_FOR_OPEN_APP_DIALOG_DISPLAY_IN_HOURS}",
+    "appStoreUrl": "https://apps.apple.com/us/app/alfresco-mobile-workspace/id1514434480"
   },
   "plugins": {
     "aosPlugin": ${APP_CONFIG_PLUGIN_AOS},

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -288,7 +288,7 @@
             },
             "MOBILE_APP": {
               "MOBILE_APP_BUTTON_LABEL": "Open in App",
-              "DOWNLOAD_APP_BUTTON_LABEL": "Don't have the app, Download App?",
+              "DOWNLOAD_APP_BUTTON_LABEL": "Don't have the app? Download app",
               "OPEN_ALFRESCO_MOBILE_APP": "Open using Alfresco Mobile application?"
             }
         },

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -287,7 +287,8 @@
                 "NO_LABEL": "Cancel"
             },
             "MOBILE_APP": {
-              "MOBILE_APP_BUTTON_LABEL": "Open in App"
+              "MOBILE_APP_BUTTON_LABEL": "Open in App",
+              "DOWNLOAD_APP_BUTTON_LABEL": "Download App"
             }
         },
         "DOCUMENT_LIST": {

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -288,7 +288,8 @@
             },
             "MOBILE_APP": {
               "MOBILE_APP_BUTTON_LABEL": "Open in App",
-              "DOWNLOAD_APP_BUTTON_LABEL": "Download App"
+              "DOWNLOAD_APP_BUTTON_LABEL": "Don't have the app, Download App?",
+              "OPEN_ALFRESCO_MOBILE_APP": "Open using Alfresco Mobile application?"
             }
         },
         "DOCUMENT_LIST": {

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -288,7 +288,7 @@
             },
             "MOBILE_APP": {
               "MOBILE_APP_BUTTON_LABEL": "Open in App",
-              "DOWNLOAD_APP_BUTTON_LABEL": "Don't have the app? Download app",
+              "DOWNLOAD_APP_BUTTON_LABEL": "Don't have the app? Download now.",
               "OPEN_ALFRESCO_MOBILE_APP": "Open using Alfresco Mobile application?"
             }
         },

--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.spec.ts
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.spec.ts
@@ -30,7 +30,7 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { AppExtensionService } from '@alfresco/aca-shared';
+import { AppExtensionService, AppService } from '@alfresco/aca-shared';
 
 describe('SharedLinkViewComponent', () => {
   let component: SharedLinkViewComponent;
@@ -40,6 +40,9 @@ describe('SharedLinkViewComponent', () => {
   const storeMock = {
     dispatch: jasmine.createSpy('dispatch'),
     select: () => of({})
+  };
+  const appServiceMock = {
+    openMobileAppDialog: () => {}
   };
 
   beforeEach(() => {
@@ -55,6 +58,10 @@ describe('SharedLinkViewComponent', () => {
             snapshot: { data: { preferencePrefix: 'prefix' } },
             params: of({ id: '123' })
           }
+        },
+        {
+          provide: AppService,
+          useValue: appServiceMock
         }
       ],
       schemas: [NO_ERRORS_SCHEMA]

--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
@@ -31,7 +31,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { forkJoin, from, of, Subject } from 'rxjs';
 import { catchError, mergeMap, takeUntil } from 'rxjs/operators';
-import { AppExtensionService } from '@alfresco/aca-shared';
+import { AppExtensionService, AppService } from '@alfresco/aca-shared';
 
 @Component({
   selector: 'app-shared-link-view',
@@ -50,7 +50,8 @@ export class SharedLinkViewComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private store: Store<AppStore>,
     private extensions: AppExtensionService,
-    private alfrescoApiService: AlfrescoApiService
+    private alfrescoApiService: AlfrescoApiService,
+    private appService: AppService
   ) {
     this.sharedLinksApi = new SharedlinksApi(this.alfrescoApiService.getInstance());
   }
@@ -65,6 +66,7 @@ export class SharedLinkViewComponent implements OnInit, OnDestroy {
       .subscribe(([sharedEntry, sharedId]: [SharedLinkEntry, string]) => {
         if (sharedEntry) {
           this.store.dispatch(new SetSelectedNodesAction([sharedEntry as any]));
+          this.appService.getMobileAppDialog();
         }
         this.sharedLinkId = sharedId;
       });

--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
@@ -66,7 +66,7 @@ export class SharedLinkViewComponent implements OnInit, OnDestroy {
       .subscribe(([sharedEntry, sharedId]: [SharedLinkEntry, string]) => {
         if (sharedEntry) {
           this.store.dispatch(new SetSelectedNodesAction([sharedEntry as any]));
-          this.appService.getMobileAppDialog();
+          this.appService.openMobileAppDialog();
         }
         this.sharedLinkId = sharedId;
       });

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -1,9 +1,13 @@
+<div class="alfresco-mobile-application-container">
+    <span>{{ 'APP.DIALOGS.MOBILE_APP.OPEN_ALFRESCO_MOBILE_APP' | translate }}</span>
+    <button mat-button class="cross-button" (click)="onCloseDialog()">
+      <mat-icon>close</mat-icon>
+    </button>
+</div>
+
 <div class="open-in-app-container">
   <button mat-button (click)="openInApp()" data-automation-id="open-in-app-button" class="open-in-app">
     <span>{{ 'APP.DIALOGS.MOBILE_APP.MOBILE_APP_BUTTON_LABEL' | translate }}</span>
-  </button>
-  <button mat-button (click)="onCloseDialog()">
-    <mat-icon>close</mat-icon>
   </button>
 </div>
 

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -1,7 +1,7 @@
 <div class="alfresco-mobile-application-container">
     <span>{{ 'APP.DIALOGS.MOBILE_APP.OPEN_ALFRESCO_MOBILE_APP' | translate }}</span>
     <button mat-button class="cross-button" (click)="onCloseDialog()">
-      <mat-icon>close</mat-icon>
+      <mat-icon class="cross-icon">close</mat-icon>
     </button>
 </div>
 

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="open-in-app-container">
-  <button mat-button (click)="openInApp()" data-automation-id="open-in-app-button" class="open-in-app">
+  <button mat-button (click)="openInApp()" data-automation-id="open-in-app-button" class="open-in-app" cdkFocusInitial>
     <span>{{ 'APP.DIALOGS.MOBILE_APP.MOBILE_APP_BUTTON_LABEL' | translate }}</span>
   </button>
 </div>

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -1,8 +1,14 @@
-<div class="container">
+<div class="open-in-app-container">
   <button mat-button (click)="openInApp()" data-automation-id="open-in-app-button" class="open-in-app">
     <span>{{ 'APP.DIALOGS.MOBILE_APP.MOBILE_APP_BUTTON_LABEL' | translate }}</span>
   </button>
   <button mat-button (click)="onCloseDialog()">
     <mat-icon>close</mat-icon>
+  </button>
+</div>
+
+<div class="download-app-container" *ngIf="appStoreUrl">
+  <button mat-button class="download-app-button" (click)="downloadIosApp()">
+    <span>{{ 'APP.DIALOGS.MOBILE_APP.DOWNLOAD_APP_BUTTON_LABEL' | translate }}</span>
   </button>
 </div>

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -1,8 +1,8 @@
 <div class="alfresco-mobile-application-container">
-    <span>{{ 'APP.DIALOGS.MOBILE_APP.OPEN_ALFRESCO_MOBILE_APP' | translate }}</span>
-    <button mat-button class="cross-button" (click)="onCloseDialog()">
-      <mat-icon class="cross-icon">close</mat-icon>
-    </button>
+  <span>{{ 'APP.DIALOGS.MOBILE_APP.OPEN_ALFRESCO_MOBILE_APP' | translate }}</span>
+  <button mat-button class="cross-button" (click)="onCloseDialog()">
+    <mat-icon class="cross-icon">close</mat-icon>
+  </button>
 </div>
 
 <div class="open-in-app-container">

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.html
@@ -12,7 +12,7 @@
 </div>
 
 <div class="download-app-container" *ngIf="appStoreUrl">
-  <button mat-button class="download-app-button" (click)="downloadIosApp()">
+  <button mat-button data-automation-id="download-app-button" class="download-app-button" (click)="downloadIosApp()">
     <span>{{ 'APP.DIALOGS.MOBILE_APP.DOWNLOAD_APP_BUTTON_LABEL' | translate }}</span>
   </button>
 </div>

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -1,16 +1,11 @@
 .open-in-app-container {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 5px;
-  border-radius: 22px;
+  place-content: center;
+  padding: 8px 24px;
+  border-radius: 8px;
   background-color: var(--theme-blue-button-color);
   color: var(--theme-about-panel-background-color);
-}
-
-.mat-dialog-container {
-  box-shadow: none;
+  margin-top: 12px;
 }
 
 .open-in-app.mat-button {
@@ -23,12 +18,27 @@
 }
 
 .download-app-container {
-  margin-top: 16px;
+  display: flex;
+  place-content: center;
+  margin-top: 12px;
+}
+
+.alfresco-mobile-application-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  padding: 6px 0;
+}
+
+.mat-button.cross-button {
+  padding-right: 0;
 }
 
 .mat-button.download-app-button {
   background: var(--theme-dialog-background-color);
   color: var(--theme-blue-button-color);
-  font-size: 16px;
+  font-size: 14px;
   padding-left: 40px;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -11,10 +11,15 @@
 .open-in-app.mat-button {
   overflow-x: hidden;
   font-size: 16px;
+  width: 100%;
 }
 
 .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
   opacity: 0;
+}
+
+.open-in-app.mat-button.cdk-touch-focused {
+  background-color: var(--theme-primary-color);
 }
 
 .cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -1,7 +1,7 @@
 .open-in-app-container {
   display: flex;
   place-content: center;
-  padding: 8px 24px;
+  padding: 0;
   border-radius: 8px;
   background-color: var(--theme-primary-color);
   color: var(--theme-about-panel-background-color);
@@ -12,6 +12,8 @@
   overflow-x: hidden;
   font-size: 16px;
   width: 100%;
+  padding: 0;
+  height: 48px;
 }
 
 .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -3,7 +3,7 @@
   place-content: center;
   padding: 8px 24px;
   border-radius: 8px;
-  background-color: #0055b8;
+  background-color: var(--theme-primary-color);
   color: var(--theme-about-panel-background-color);
   margin-top: 12px;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -9,24 +9,17 @@ aca-open-in-app {
     margin-top: 12px;
   }
 
-  .open-in-app.mat-button {
+  .open-in-app {
     overflow-x: hidden;
     font-size: 16px;
     width: 100%;
     padding: 0;
     height: 48px;
-  }
 
-  .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
-    opacity: 0;
-  }
-
-  .open-in-app.cdk-touch-focused {
-    background-color: var(--theme-primary-color);
-  }
-
-  .cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {
-    opacity: 0;
+    &:focus-visible {
+      outline: none;
+      border-radius: unset;
+    }
   }
 
   .download-app-container {
@@ -44,7 +37,7 @@ aca-open-in-app {
     padding: 6px 0;
   }
 
-  .mat-button.cross-button {
+  .cross-button {
     padding-right: 0;
 
     &:focus-visible {
@@ -53,7 +46,7 @@ aca-open-in-app {
     }
   }
 
-  .mat-icon.cross-icon {
+  .cross-icon {
     font-weight: bold;
     font-size: 21px;
     height: 21px;

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -1,69 +1,71 @@
-.open-in-app-container {
-  display: flex;
-  place-content: center;
-  padding: 0;
-  border-radius: 8px;
-  background-color: var(--theme-primary-color);
-  color: var(--theme-about-panel-background-color);
-  margin-top: 12px;
-}
-
-.open-in-app.mat-button {
-  overflow-x: hidden;
-  font-size: 16px;
-  width: 100%;
-  padding: 0;
-  height: 48px;
-}
-
-.open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
-  opacity: 0;
-}
-
-.open-in-app.cdk-touch-focused {
-  background-color: var(--theme-primary-color);
-}
-
-.cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {
-  opacity: 0;
-}
-
-.download-app-container {
-  display: flex;
-  place-content: center;
-  margin-top: 12px;
-}
-
-.alfresco-mobile-application-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 14px;
-  padding: 6px 0;
-}
-
-.mat-button.cross-button {
-  padding-right: 0;
-
-  &:focus-visible {
-    outline: none;
-    border-radius: unset;
+aca-open-in-app {
+  .open-in-app-container {
+    display: flex;
+    place-content: center;
+    padding: 0;
+    border-radius: 8px;
+    background-color: var(--theme-primary-color);
+    color: var(--theme-about-panel-background-color);
+    margin-top: 12px;
   }
-}
 
-.mat-icon.cross-icon {
-  font-weight: bold;
-  font-size: 21px;
-  height: 21px;
-}
+  .open-in-app.mat-button {
+    overflow-x: hidden;
+    font-size: 16px;
+    width: 100%;
+    padding: 0;
+    height: 48px;
+  }
 
-.download-app-button {
-  background: var(--theme-dialog-background-color);
-  color: var(--theme-primary-color);
-  font-size: 14px;
-}
+  .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
+    opacity: 0;
+  }
 
-.mat-dialog-container {
-  padding: 8px 24px 24px;
+  .open-in-app.cdk-touch-focused {
+    background-color: var(--theme-primary-color);
+  }
+
+  .cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {
+    opacity: 0;
+  }
+
+  .download-app-container {
+    display: flex;
+    place-content: center;
+    margin-top: 12px;
+  }
+
+  .alfresco-mobile-application-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+    padding: 6px 0;
+  }
+
+  .mat-button.cross-button {
+    padding-right: 0;
+
+    &:focus-visible {
+      outline: none;
+      border-radius: unset;
+    }
+  }
+
+  .mat-icon.cross-icon {
+    font-weight: bold;
+    font-size: 21px;
+    height: 21px;
+  }
+
+  .download-app-button {
+    background: var(--theme-dialog-background-color);
+    color: var(--theme-primary-color);
+    font-size: 14px;
+  }
+
+  .mat-dialog-container {
+    padding: 8px 24px 24px;
+  }
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -1,21 +1,34 @@
-.container{
+.open-in-app-container {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-}
-
-.mat-dialog-container{
   padding: 5px;
-  border-radius: 36px;
+  border-radius: 22px;
   background-color: var(--theme-blue-button-color);
   color: var(--theme-about-panel-background-color);
 }
 
+.mat-dialog-container {
+  box-shadow: none;
+}
+
 .open-in-app.mat-button {
   overflow-x: hidden;
+  font-size: 16px;
 }
 
 .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
   opacity: 0;
+}
+
+.download-app-container {
+  margin-top: 16px;
+}
+
+.mat-button.download-app-button {
+  background: var(--theme-dialog-background-color);
+  color: var(--theme-blue-button-color);
+  font-size: 16px;
+  padding-left: 40px;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -60,7 +60,7 @@
 
 .mat-button.download-app-button {
   background: var(--theme-dialog-background-color);
-  color: var(--theme-blue-button-color);
+  color: var(--theme-primary-color);
   font-size: 14px;
 }
 

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -3,7 +3,7 @@
   place-content: center;
   padding: 8px 24px;
   border-radius: 8px;
-  background-color: var(--theme-blue-button-color);
+  background-color: #0055b8;
   color: var(--theme-about-panel-background-color);
   margin-top: 12px;
 }
@@ -15,6 +15,15 @@
 
 .open-in-app.mat-button.cdk-program-focused .mat-button-focus-overlay {
   opacity: 0;
+}
+
+.cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {
+  opacity: 0;
+}
+
+.cross-button.mat-button:focus-visible {
+  outline: none;
+  border-radius: unset;
 }
 
 .download-app-container {
@@ -36,9 +45,18 @@
   padding-right: 0;
 }
 
+.mat-icon.cross-icon {
+  font-weight: bold;
+  font-size: 21px;
+  height: 21px;
+}
+
 .mat-button.download-app-button {
   background: var(--theme-dialog-background-color);
   color: var(--theme-blue-button-color);
   font-size: 14px;
-  padding-left: 40px;
+}
+
+.mat-dialog-container {
+  padding: 8px 24px 24px;
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -20,17 +20,12 @@
   opacity: 0;
 }
 
-.open-in-app.mat-button.cdk-touch-focused {
+.open-in-app.cdk-touch-focused {
   background-color: var(--theme-primary-color);
 }
 
 .cross-button.mat-button.cdk-program-focused .mat-button-focus-overlay {
   opacity: 0;
-}
-
-.cross-button.mat-button:focus-visible {
-  outline: none;
-  border-radius: unset;
 }
 
 .download-app-container {
@@ -50,6 +45,11 @@
 
 .mat-button.cross-button {
   padding-right: 0;
+
+  &:focus-visible {
+    outline: none;
+    border-radius: unset;
+  }
 }
 
 .mat-icon.cross-icon {
@@ -58,7 +58,7 @@
   height: 21px;
 }
 
-.mat-button.download-app-button {
+.download-app-button {
   background: var(--theme-dialog-background-color);
   color: var(--theme-primary-color);
   font-size: 14px;

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.spec.ts
@@ -45,7 +45,7 @@ describe('OpenInAppComponent', () => {
       imports: [LibTestingModule, SharedModule.forRoot(), MatIconTestingModule],
       providers: [
         provideMockStore({ initialState }),
-        { provide: MAT_DIALOG_DATA, useValue: { redirectUrl: 'mockRedirectUrl' } },
+        { provide: MAT_DIALOG_DATA, useValue: { redirectUrl: 'mockRedirectUrl', appStoreUrl: 'mockAppStoreUrl' } },
         { provide: MatDialogRef, useValue: mockDialogRef }
       ]
     });
@@ -77,5 +77,23 @@ describe('OpenInAppComponent', () => {
     component.onCloseDialog();
     expect(sessionStorage.getItem('mobile_notification_expires_in')).not.toBeNull();
     expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should redirect to App Store for downloading the app in case of Ios device', async () => {
+    let currentLocation: string | string[];
+    const windowStub: Window & typeof globalThis = {
+      location: {
+        set href(value: string | string[]) {
+          currentLocation = value;
+        }
+      }
+    } as Window & typeof globalThis;
+    component.window = windowStub;
+    const downloadAppButton = fixture.debugElement.query(By.css('[data-automation-id="download-app-button"]')).nativeElement;
+    downloadAppButton.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(currentLocation).toBe('mockAppStoreUrl');
   });
 });

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -47,9 +47,7 @@ export class OpenInAppComponent {
   ) {
     if (data) {
       this.redirectUrl = data.redirectUrl;
-      if (data.appStoreUrl) {
-        this.appStoreUrl = data.appStoreUrl;
-      }
+      this.appStoreUrl = data.appStoreUrl;
     }
   }
 

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -27,6 +27,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 export interface OpenInAppDialogOptions {
   redirectUrl: string;
+  appStoreUrl: string;
 }
 @Component({
   selector: 'aca-open-in-app',
@@ -35,7 +36,8 @@ export interface OpenInAppDialogOptions {
   encapsulation: ViewEncapsulation.None
 })
 export class OpenInAppComponent {
-  private readonly redirectUrl: string;
+  private redirectUrl: string;
+  public appStoreUrl: string;
   public window: Window & typeof globalThis = window;
 
   constructor(
@@ -45,11 +47,18 @@ export class OpenInAppComponent {
   ) {
     if (data) {
       this.redirectUrl = data.redirectUrl;
+      if (data.appStoreUrl) {
+        this.appStoreUrl = data.appStoreUrl;
+      }
     }
   }
 
   openInApp(): void {
     this.window.location.href = this.redirectUrl;
+  }
+
+  downloadIosApp(): void {
+    this.window.location.href = this.appStoreUrl;
   }
 
   onCloseDialog(): void {

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -24,6 +24,7 @@
 
 import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { AcaMobileAppSwitcherService } from '../../services/aca-mobile-app-switcher.service';
 
 export interface OpenInAppDialogOptions {
   redirectUrl: string;
@@ -43,7 +44,8 @@ export class OpenInAppComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public data: OpenInAppDialogOptions,
-    private dialog: MatDialogRef<OpenInAppComponent>
+    private dialog: MatDialogRef<OpenInAppComponent>,
+    private acaMobileAppSwitcherService: AcaMobileAppSwitcherService
   ) {
     if (data) {
       this.redirectUrl = data.redirectUrl;
@@ -65,5 +67,6 @@ export class OpenInAppComponent {
     const time: number = new Date().getTime();
     sessionStorage.setItem('mobile_notification_expires_in', time.toString());
     this.dialog.close();
+    this.acaMobileAppSwitcherService.isDialogEnable = false;
   }
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -24,7 +24,6 @@
 
 import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { AcaMobileAppSwitcherService } from '../../services/aca-mobile-app-switcher.service';
 
 export interface OpenInAppDialogOptions {
   redirectUrl: string;
@@ -44,8 +43,7 @@ export class OpenInAppComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public data: OpenInAppDialogOptions,
-    private dialog: MatDialogRef<OpenInAppComponent>,
-    private acaMobileAppSwitcherService: AcaMobileAppSwitcherService
+    private dialog: MatDialogRef<OpenInAppComponent>
   ) {
     if (data) {
       this.redirectUrl = data.redirectUrl;
@@ -67,6 +65,5 @@ export class OpenInAppComponent {
     const time: number = new Date().getTime();
     sessionStorage.setItem('mobile_notification_expires_in', time.toString());
     this.dialog.close();
-    this.acaMobileAppSwitcherService.isDialogEnable = false;
   }
 }

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.module.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.module.ts
@@ -22,26 +22,17 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ModuleWithProviders, NgModule } from '@angular/core';
-import { ContentApiService } from './services/content-api.service';
-import { NodePermissionService } from './services/node-permission.service';
-import { AppService } from './services/app.service';
-import { ContextActionsModule } from './directives/contextmenu/contextmenu.module';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatDialogModule } from '@angular/material/dialog';
+import { BrowserModule } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
-import { OpenInAppModule } from './components/open-in-app/open-in-app.module';
+import { OpenInAppComponent } from './open-in-app.component';
 
 @NgModule({
-  imports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, OpenInAppModule],
-  exports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, OpenInAppModule]
+  imports: [CommonModule, MatIconModule, TranslateModule, MatButtonModule, BrowserModule],
+  declarations: [OpenInAppComponent],
+  exports: [OpenInAppComponent]
 })
-export class SharedModule {
-  static forRoot(): ModuleWithProviders<SharedModule> {
-    return {
-      ngModule: SharedModule,
-      providers: [ContentApiService, NodePermissionService, AppService]
-    };
-  }
-}
+export class OpenInAppModule {}

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -82,7 +82,8 @@ export class AcaMobileAppSwitcherService {
   identifyBrowserAndSetRedirectURL(): void {
     const ua: string = navigator.userAgent.toLowerCase();
     const isAndroid: boolean = ua.indexOf('android') > -1;
-    const isIOS: boolean = ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1;
+    const iPadInSafari = /Macintosh/i.test(ua) && navigator.maxTouchPoints && navigator.maxTouchPoints > 1;
+    const isIOS: boolean = ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1 || iPadInSafari;
     const currentUrl: string = this.getCurrentUrl();
 
     if (isIOS === true) {

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -43,6 +43,7 @@ export class AcaMobileAppSwitcherService {
   public redirectUrl: string;
   public appStoreUrl: string;
   dialogRef: MatDialogRef<OpenInAppComponent>;
+  isDialogEnable = false;
 
   constructor(private config: AppConfigService, private dialog: MatDialog) {
     this.mobileAppSwitchConfig = this.config.get<MobileAppSwitchConfigurationOptions>('mobileAppSwitch');
@@ -98,16 +99,19 @@ export class AcaMobileAppSwitcherService {
   }
 
   openDialog(redirectUrl: string, appStoreUrl?: string): void {
-    this.dialogRef = this.dialog.open(OpenInAppComponent, {
-      data: {
-        redirectUrl,
-        appStoreUrl
-      },
-      hasBackdrop: false,
-      width: '100%',
-      role: 'dialog',
-      position: { bottom: '0' }
-    });
+    if (!this.isDialogEnable) {
+      this.dialogRef = this.dialog.open(OpenInAppComponent, {
+        data: {
+          redirectUrl,
+          appStoreUrl
+        },
+        hasBackdrop: false,
+        width: '100%',
+        role: 'dialog',
+        position: { bottom: '0' }
+      });
+      this.isDialogEnable = true;
+    }
   }
 
   clearSessionExpireTime(): void {
@@ -120,5 +124,6 @@ export class AcaMobileAppSwitcherService {
 
   closeDialog(): void {
     this.dialog.closeAll();
+    this.isDialogEnable = false;
   }
 }

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -103,9 +103,9 @@ export class AcaMobileAppSwitcherService {
         appStoreUrl
       },
       hasBackdrop: false,
-      width: 'auto',
+      width: '100%',
       role: 'dialog',
-      position: { bottom: '20px' }
+      position: { bottom: '0' }
     });
   }
 

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -24,7 +24,7 @@
 
 import { AppConfigService } from '@alfresco/adf-core';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { OpenInAppComponent } from '../components/open-in-app/open-in-app.component';
 
 export interface MobileAppSwitchConfigurationOptions {
@@ -42,6 +42,7 @@ export class AcaMobileAppSwitcherService {
   private mobileAppSwitchConfig: MobileAppSwitchConfigurationOptions;
   public redirectUrl: string;
   public appStoreUrl: string;
+  dialogRef: MatDialogRef<OpenInAppComponent>;
 
   constructor(private config: AppConfigService, private dialog: MatDialog) {
     this.mobileAppSwitchConfig = this.config.get<MobileAppSwitchConfigurationOptions>('mobileAppSwitch');
@@ -97,7 +98,7 @@ export class AcaMobileAppSwitcherService {
   }
 
   openDialog(redirectUrl: string, appStoreUrl?: string): void {
-    this.dialog.open(OpenInAppComponent, {
+    this.dialogRef = this.dialog.open(OpenInAppComponent, {
       data: {
         redirectUrl,
         appStoreUrl
@@ -115,5 +116,9 @@ export class AcaMobileAppSwitcherService {
 
   getCurrentUrl(): string {
     return window.location.href;
+  }
+
+  closeDialog(): void {
+    this.dialog.closeAll();
   }
 }

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -43,7 +43,6 @@ export class AcaMobileAppSwitcherService {
   public redirectUrl: string;
   public appStoreUrl: string;
   dialogRef: MatDialogRef<OpenInAppComponent>;
-  isDialogEnable = false;
 
   constructor(private config: AppConfigService, private dialog: MatDialog) {
     this.mobileAppSwitchConfig = this.config.get<MobileAppSwitchConfigurationOptions>('mobileAppSwitch');
@@ -99,7 +98,7 @@ export class AcaMobileAppSwitcherService {
   }
 
   openDialog(redirectUrl: string, appStoreUrl?: string): void {
-    if (!this.isDialogEnable) {
+    if (this.dialogRef === null || this.dialogRef === undefined) {
       this.dialogRef = this.dialog.open(OpenInAppComponent, {
         data: {
           redirectUrl,
@@ -110,7 +109,6 @@ export class AcaMobileAppSwitcherService {
         role: 'dialog',
         position: { bottom: '0' }
       });
-      this.isDialogEnable = true;
     }
   }
 
@@ -124,6 +122,6 @@ export class AcaMobileAppSwitcherService {
 
   closeDialog(): void {
     this.dialog.closeAll();
-    this.isDialogEnable = false;
+    this.dialogRef = null;
   }
 }

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -99,7 +99,7 @@ export class AcaMobileAppSwitcherService {
   }
 
   openDialog(redirectUrl: string, appStoreUrl?: string): void {
-    if (this.dialogRef === null || this.dialogRef === undefined) {
+    if (!this.dialogRef) {
       this.dialogRef = this.dialog.open(OpenInAppComponent, {
         data: {
           redirectUrl,
@@ -122,7 +122,7 @@ export class AcaMobileAppSwitcherService {
   }
 
   closeDialog(): void {
-    if (this.dialogRef !== null && this.dialogRef !== undefined) {
+    if (this.dialogRef) {
       this.dialog.closeAll();
       this.dialogRef = null;
     }

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -82,8 +82,8 @@ export class AcaMobileAppSwitcherService {
   identifyBrowserAndSetRedirectURL(): void {
     const ua: string = navigator.userAgent.toLowerCase();
     const isAndroid: boolean = ua.indexOf('android') > -1;
-    const iPadInSafari = /Macintosh/i.test(ua) && navigator.maxTouchPoints && navigator.maxTouchPoints > 1;
-    const isIOS: boolean = ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1 || iPadInSafari;
+    const isIPadInSafari = /Macintosh/i.test(ua) && navigator.maxTouchPoints && navigator.maxTouchPoints > 1;
+    const isIOS: boolean = ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1 || isIPadInSafari;
     const currentUrl: string = this.getCurrentUrl();
 
     if (isIOS === true) {

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -33,6 +33,7 @@ export interface MobileAppSwitchConfigurationOptions {
   androidUrlPart1: string;
   androidUrlPart2: string;
   sessionTimeForOpenAppDialogDisplay: string;
+  appStoreUrl: string;
 }
 @Injectable({
   providedIn: 'root'
@@ -40,6 +41,7 @@ export interface MobileAppSwitchConfigurationOptions {
 export class AcaMobileAppSwitcherService {
   private mobileAppSwitchConfig: MobileAppSwitchConfigurationOptions;
   public redirectUrl: string;
+  public appStoreUrl: string;
 
   constructor(private config: AppConfigService, private dialog: MatDialog) {
     this.mobileAppSwitchConfig = this.config.get<MobileAppSwitchConfigurationOptions>('mobileAppSwitch');
@@ -84,19 +86,21 @@ export class AcaMobileAppSwitcherService {
 
     if (isIOS === true) {
       this.redirectUrl = this.mobileAppSwitchConfig.iphoneUrl + currentUrl;
+      this.appStoreUrl = this.mobileAppSwitchConfig.appStoreUrl;
     } else if (isAndroid === true) {
       this.redirectUrl = this.mobileAppSwitchConfig.androidUrlPart1 + currentUrl + this.mobileAppSwitchConfig.androidUrlPart2;
     }
 
     if (this.redirectUrl !== undefined && this.redirectUrl !== null) {
-      this.openDialog(this.redirectUrl);
+      this.openDialog(this.redirectUrl, this.appStoreUrl);
     }
   }
 
-  openDialog(redirectUrl: string): void {
+  openDialog(redirectUrl: string, appStoreUrl?: string): void {
     this.dialog.open(OpenInAppComponent, {
       data: {
-        redirectUrl
+        redirectUrl,
+        appStoreUrl
       },
       hasBackdrop: false,
       width: 'auto',

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -42,7 +42,7 @@ export class AcaMobileAppSwitcherService {
   private mobileAppSwitchConfig: MobileAppSwitchConfigurationOptions;
   public redirectUrl: string;
   public appStoreUrl: string;
-  dialogRef: MatDialogRef<OpenInAppComponent>;
+  private dialogRef: MatDialogRef<OpenInAppComponent>;
 
   constructor(private config: AppConfigService, private dialog: MatDialog) {
     this.mobileAppSwitchConfig = this.config.get<MobileAppSwitchConfigurationOptions>('mobileAppSwitch');
@@ -122,7 +122,9 @@ export class AcaMobileAppSwitcherService {
   }
 
   closeDialog(): void {
-    this.dialog.closeAll();
-    this.dialogRef = null;
+    if (this.dialogRef !== null && this.dialogRef !== undefined) {
+      this.dialog.closeAll();
+      this.dialogRef = null;
+    }
   }
 }

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -104,9 +104,7 @@ export class AppService implements OnDestroy {
     this.authenticationService.onLogout.subscribe(() => {
       searchQueryBuilderService.resetToDefaults();
       acaMobileAppSwitcherService.clearSessionExpireTime();
-      if (acaMobileAppSwitcherService.dialogRef !== null && acaMobileAppSwitcherService.dialogRef !== undefined) {
-        acaMobileAppSwitcherService.closeDialog();
-      }
+      acaMobileAppSwitcherService.closeDialog();
     });
 
     this.pageHeading$ = this.router.events.pipe(

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -168,7 +168,7 @@ export class AppService implements OnDestroy {
       if (isReady) {
         this.loadRepositoryStatus();
         this.loadUserProfile();
-        this.getMobileAppDialog();
+        this.openMobileAppDialog();
       }
     });
 
@@ -265,7 +265,7 @@ export class AppService implements OnDestroy {
     document.head.appendChild(cssLinkElement);
   }
 
-  public getMobileAppDialog(): void {
+  public openMobileAppDialog(): void {
     const isMobileSwitchEnabled: boolean = this.config.get<boolean>('mobileAppSwitch.enabled', false);
     if (isMobileSwitchEnabled) {
       this.acaMobileAppSwitcherService.resolveExistenceOfDialog();

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -103,6 +103,10 @@ export class AppService implements OnDestroy {
 
     this.authenticationService.onLogout.subscribe(() => {
       searchQueryBuilderService.resetToDefaults();
+      acaMobileAppSwitcherService.clearSessionExpireTime();
+      if (acaMobileAppSwitcherService.dialogRef !== null && acaMobileAppSwitcherService.dialogRef !== undefined) {
+        acaMobileAppSwitcherService.closeDialog();
+      }
     });
 
     this.pageHeading$ = this.router.events.pipe(
@@ -164,17 +168,11 @@ export class AppService implements OnDestroy {
       if (isReady) {
         this.loadRepositoryStatus();
         this.loadUserProfile();
+        this.getMobileAppDialog();
       }
     });
 
     this.overlayContainer.getContainerElement().setAttribute('role', 'region');
-
-    const isMobileSwitchEnabled: boolean = this.config.get<boolean>('mobileAppSwitch.enabled', false);
-    if (isMobileSwitchEnabled) {
-      this.acaMobileAppSwitcherService.resolveExistenceOfDialog();
-    } else {
-      this.acaMobileAppSwitcherService.clearSessionExpireTime();
-    }
   }
 
   private loadRepositoryStatus() {
@@ -265,5 +263,14 @@ export class AppService implements OnDestroy {
     cssLinkElement.setAttribute('type', 'text/css');
     cssLinkElement.setAttribute('href', url);
     document.head.appendChild(cssLinkElement);
+  }
+
+  public getMobileAppDialog(): void {
+    const isMobileSwitchEnabled: boolean = this.config.get<boolean>('mobileAppSwitch.enabled', false);
+    if (isMobileSwitchEnabled) {
+      this.acaMobileAppSwitcherService.resolveExistenceOfDialog();
+    } else {
+      this.acaMobileAppSwitcherService.clearSessionExpireTime();
+    }
   }
 }

--- a/projects/aca-shared/src/lib/shared.module.ts
+++ b/projects/aca-shared/src/lib/shared.module.ts
@@ -32,10 +32,11 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
+import { BrowserModule } from '@angular/platform-browser';
 
 @NgModule({
-  imports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule],
-  exports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule],
+  imports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, BrowserModule],
+  exports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, BrowserModule],
   declarations: [OpenInAppComponent]
 })
 export class SharedModule {

--- a/projects/aca-shared/src/lib/shared.module.ts
+++ b/projects/aca-shared/src/lib/shared.module.ts
@@ -31,11 +31,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
-import { OpenInAppModule } from './components/open-in-app/open-in-app.module';
 
 @NgModule({
-  imports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, OpenInAppModule],
-  exports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule, OpenInAppModule]
+  imports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule],
+  exports: [ContextActionsModule, MatButtonModule, MatIconModule, MatDialogModule, TranslateModule]
 })
 export class SharedModule {
   static forRoot(): ModuleWithProviders<SharedModule> {

--- a/projects/aca-shared/src/public-api.ts
+++ b/projects/aca-shared/src/public-api.ts
@@ -41,6 +41,8 @@ export * from './lib/components/info-drawer/info-drawer.component';
 export * from './lib/components/info-drawer/shared-info-drawer.module';
 export * from './lib/components/document-base-page/document-base-page.component';
 export * from './lib/components/document-base-page/document-base-page.service';
+export * from './lib/components/open-in-app/open-in-app.component';
+export * from './lib/components/open-in-app/open-in-app.module';
 
 export * from './lib/directives/contextmenu/contextmenu.directive';
 export * from './lib/directives/contextmenu/contextmenu.module';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
1. Open in App dialog was showing only after refresh the application.
2. Open in App dialog was not showing for private files.
3. Open in App dialog was not having button to Dowload App in case of IOS devices.
4. Design was not as per the expectations.


**What is the new behaviour?**
1. New design changes for Open In App diaog as per new design shared by Mobile Apps team.
5. Now Open In App dialog will appear after login into the application.
6. Now dialog Open In App dialog will appear without refreshing the page.
7. Earlier user was not able to see Open In App diaog for private files after login which is fixed now.
8. Now user will have the option to Download the app in case of IOS devices which was earlier not present.
9. Test cases added for Open In app pop up component for new code changes and in Shared Link view component as well and failed test cases modified.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
1. Open in App Dialog in case of IOS device

![Screenshot from 2023-05-24 11-52-28](https://github.com/Alfresco/alfresco-content-app/assets/105338943/82c821fb-d58d-49e6-93df-f2457fda98ea)

2. Open in App Dialog in case of Android device

![Screenshot from 2023-05-24 11-52-49](https://github.com/Alfresco/alfresco-content-app/assets/105338943/d714e031-893a-499b-9423-9d8c4504f1b1)

