### PR TITLE
Added missing DirectiveModule import in standalone LogoutComponent

### DIFF
--- a/projects/aca-content/src/lib/components/common/logout/logout.component.ts
+++ b/projects/aca-content/src/lib/components/common/logout/logout.component.ts
@@ -28,10 +28,11 @@ import { SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
+import { DirectiveModule } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
-  imports: [TranslateModule, MatIconModule, MatMenuModule],
+  imports: [TranslateModule, MatIconModule, MatMenuModule, DirectiveModule],
   selector: 'aca-logout',
   template: `
     <button mat-menu-item (click)="onLogoutEvent()" adf-logout>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Standalone logout component was missing import for DirectiveModule (required for adf-logout directive)


**What is the new behaviour?**
Added missing DirectiveModule import


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
