### PR TITLE
[ACS-5330] Added clearSelection() in afterEach so that tests unslect rows after test case execution

### DIFF
--- a/e2e/suites/actions/copy-move/destination-picker-dialog.test.ts
+++ b/e2e/suites/actions/copy-move/destination-picker-dialog.test.ts
@@ -136,6 +136,7 @@ describe('Destination picker dialog : ', () => {
 
   afterEach(async () => {
     await page.closeOpenDialogs();
+    await page.dataTable.clearSelection();
   });
 
   describe('general', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Fixing e2e test case

**What is the current behaviour?** (You can also link to an open issue here)
Some of the test cases were not unselecting the rows in the datatable. This was causing issues for the next test case, which would then click the row, unselecting it, while trying to 'select' the row


**What is the new behaviour?**
Added a datatable.clearSelection() method call after each test, to clear any rows that the test case might have selected.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
