### PR TITLE
[PRODSEC-6575] used date instead of datetime for datePicker implementation in Shared link dialog component in ADF

### DIFF
--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -39,7 +39,7 @@
     "copyright": "APP.COPYRIGHT"
   },
   "viewer.maxRetries": 1,
-  "sharedLinkDateTimePickerType": "datetime",
+  "sharedLinkDateTimePickerType": "date",
   "customCssPath": "",
   "webFontPath": "",
   "pagination": {

--- a/app/src/app.config.json.tpl
+++ b/app/src/app.config.json.tpl
@@ -39,7 +39,6 @@
     "copyright": "APP.COPYRIGHT"
   },
   "viewer.maxRetries": 1,
-  "sharedLinkDateTimePickerType": "date",
   "customCssPath": "",
   "webFontPath": "",
   "pagination": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Earlier matDateTimePicker was used in ADF so type was 'datetime' which needs to be changed.


**What is the new behaviour?**
I have used datePicker in ADF for Shared Link Dialog component so needed to change the type of sharedLinkDateTimePickerType as 'date' instead of 'datetime'.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
