### PR TITLE
[ACS-5374] Fixed lost styles for library details after refreshing page

### DIFF
--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.scss
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.scss
@@ -1,0 +1,20 @@
+app-library-metadata-form {
+  .mat-form-field-infix {
+    position: relative;
+    width: 180px;
+
+    .mat-form-field-label-wrapper {
+      position: absolute;
+      width: 100%;
+      pointer-events: none;
+
+      .mat-form-field-label {
+        position: absolute;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        transform-origin: 0 0;
+      }
+    }
+  }
+}

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -64,6 +64,7 @@ export class InstantErrorStateMatcher implements ErrorStateMatcher {
   ],
   selector: 'app-library-metadata-form',
   templateUrl: './library-metadata-form.component.html',
+  styleUrls: ['./library-metadata-form.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
 export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestroy {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5374


**What is the new behaviour?**
When we refresh page, styles for library details are not lost now. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
