### PR TITLE
failing e2e coorect due to date-picker component changes

### DIFF
--- a/e2e/protractor/suites/info-drawer/file-folder-properties.test.ts
+++ b/e2e/protractor/suites/info-drawer/file-folder-properties.test.ts
@@ -22,17 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  AdminActions,
-  LoginPage,
-  BrowsingPage,
-  RepoClient,
-  InfoDrawer,
-  Utils,
-  FILES,
-  DATE_TIME_FORMAT,
-  DATE_FORMAT
-} from '@alfresco/aca-testing-shared';
+import { AdminActions, LoginPage, BrowsingPage, RepoClient, InfoDrawer, Utils, FILES, DATE_FORMAT } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
 
 const moment = require('moment');
@@ -220,7 +210,7 @@ describe('File / Folder properties', () => {
       const expectedPropValues = [
         properties['exif:pixelXDimension']?.toString(),
         properties['exif:pixelYDimension']?.toString(),
-        moment(properties['exif:dateTimeOriginal']).format(DATE_TIME_FORMAT),
+        moment(properties['exif:dateTimeOriginal']).format(DATE_FORMAT),
         properties['exif:exposureTime']?.toString(),
         properties['exif:fNumber']?.toString(),
         properties['exif:flash'],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
While change from old mat-datetimepicker component to new mat-datepicker component in ADF CardViewDateItemComponent some e2e tests were failed


**What is the new behaviour?**
Failing e2e test correction for [C269007] Image properties in file-folder-properties.test.ts file


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Jira id - https://alfresco.atlassian.net/browse/ACS-5557
