### PR TITLE
re-enable protractor test due to unstable playwright test

### DIFF
--- a/e2e/playwright/viewer/exclude.tests.json
+++ b/e2e/playwright/viewer/exclude.tests.json
@@ -1,1 +1,6 @@
-{}
+{
+  "C284636" : "https://alfresco.atlassian.net/browse/ACS-5639",
+  "C284635" : "https://alfresco.atlassian.net/browse/ACS-5639",
+  "C279175" : "https://alfresco.atlassian.net/browse/ACS-5639",
+  "C284634" : "https://alfresco.atlassian.net/browse/ACS-5639"
+}

--- a/e2e/protractor/suites/viewer/viewer-general.test.ts
+++ b/e2e/protractor/suites/viewer/viewer-general.test.ts
@@ -48,8 +48,9 @@ describe('Viewer general', () => {
 
   const loginPage = new LoginPage();
   const page = new BrowsingPage();
-  const { dataTable } = page;
+  const { dataTable, toolbar } = page;
   const viewer = new Viewer();
+  const { searchInput } = page.pageLayoutHeader;
 
   const adminApiActions = new AdminActions();
   const userActions = new UserActions();
@@ -107,6 +108,47 @@ describe('Viewer general', () => {
     await dataTable.doubleClickOnRowByName(siteUser);
     await dataTable.waitForHeader();
     await dataTable.doubleClickOnRowByName(fileInSite);
+    expect(await viewer.isViewerOpened()).toBe(true, 'Viewer is not opened');
+    expect(await viewer.isViewerToolbarDisplayed()).toBe(true, 'Toolbar not displayed');
+    expect(await viewer.isCloseButtonDisplayed()).toBe(true, 'Close button is not displayed');
+    expect(await viewer.isFileTitleDisplayed()).toBe(true, 'File title is not displayed');
+  });
+
+  it('[C284636] Viewer opens for a file from Recent Files', async () => {
+    await page.clickRecentFilesAndWait();
+    await dataTable.doubleClickOnRowByName(xlsxFile);
+    expect(await viewer.isViewerOpened()).toBe(true, 'Viewer is not opened');
+    expect(await viewer.isViewerToolbarDisplayed()).toBe(true, 'Toolbar not displayed');
+    expect(await viewer.isCloseButtonDisplayed()).toBe(true, 'Close button is not displayed');
+    expect(await viewer.isFileTitleDisplayed()).toBe(true, 'File title is not displayed');
+  });
+
+  it('[C284635] Viewer opens for a file from Shared Files', async () => {
+    await page.clickSharedFilesAndWait();
+    await dataTable.doubleClickOnRowByName(xlsxFile);
+    expect(await viewer.isViewerOpened()).toBe(true, 'Viewer is not opened');
+    expect(await viewer.isViewerToolbarDisplayed()).toBe(true, 'Toolbar not displayed');
+    expect(await viewer.isCloseButtonDisplayed()).toBe(true, 'Close button is not displayed');
+    expect(await viewer.isFileTitleDisplayed()).toBe(true, 'File title is not displayed');
+  });
+
+  it('[C284634] Viewer opens for a file from Favorites', async () => {
+    await page.clickFavoritesAndWait();
+    await dataTable.doubleClickOnRowByName(xlsxFile);
+    expect(await viewer.isViewerOpened()).toBe(true, 'Viewer is not opened');
+    expect(await viewer.isViewerToolbarDisplayed()).toBe(true, 'Toolbar not displayed');
+    expect(await viewer.isCloseButtonDisplayed()).toBe(true, 'Close button is not displayed');
+    expect(await viewer.isFileTitleDisplayed()).toBe(true, 'File title is not displayed');
+  });
+
+  it('[C279175] Viewer opens for a file from Search Results', async () => {
+    await toolbar.clickSearchIconButton();
+    await searchInput.clickSearchButton();
+    await searchInput.checkFilesAndFolders();
+    await searchInput.searchFor(xlsxFile);
+    await dataTable.waitForBody();
+
+    await dataTable.doubleClickOnRowByName(xlsxFile);
     expect(await viewer.isViewerOpened()).toBe(true, 'Viewer is not opened');
     expect(await viewer.isViewerToolbarDisplayed()).toBe(true, 'Toolbar not displayed');
     expect(await viewer.isCloseButtonDisplayed()).toBe(true, 'Close button is not displayed');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: exclude flaky playwright test


**What is the current behaviour?** (You can also link to an open issue here)
we have flaky playwright tests


**What is the new behaviour?**
re enable protractor tests


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: https://alfresco.atlassian.net/browse/ACS-5639
