### PR TITLE
[ACS-5152] Fix for File type filter getting applied before clicking apply button

### DIFF
--- a/app/src/app.config.json
+++ b/app/src/app.config.json
@@ -977,6 +977,7 @@
         "component": {
           "selector": "check-list",
           "settings": {
+            "allowUpdateOnChange": false,
             "pageSize": 5,
             "operator": "OR",
             "options": [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
'File type' filter gets applied without clicking on 'Apply' button. https://alfresco.atlassian.net/browse/ACS-5152



**What is the new behaviour?**
The filter gets applied only after clicking the apply button.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Suggestion - The id for file type filter is checkList, which is very generic and can be changed to something more specific like fileType