### PR TITLE
[ACS-5638] hide checkboxes in file lists

### DIFF
--- a/e2e/playwright/viewer/src/tests/viewer.spec.ts
+++ b/e2e/playwright/viewer/src/tests/viewer.spec.ts
@@ -54,7 +54,7 @@ test.describe('viewer file', () => {
   });
 
   test('[C279270] Viewer opens when clicking the View action for a file', async ({ personalFiles }) => {
-    await personalFiles.dataTable.selectItem(randomDocxName);
+    await personalFiles.dataTable.getRowByName(randomDocxName).click();
     await personalFiles.acaHeader.viewButton.click();
     await personalFiles.dataTable.spinnerWaitForReload();
     expect(await personalFiles.viewer.isViewerOpened(), 'Viewer is not opened').toBe(true);

--- a/projects/aca-content/src/lib/components/files/files.component.html
+++ b/projects/aca-content/src/lib/components/files/files.component.html
@@ -22,7 +22,7 @@
           acaContextActions
           [display]="documentDisplayMode$ | async"
           [selectionMode]="'multiple'"
-          [multiselect]="true"
+          [multiselect]="false"
           [currentFolderId]="node?.id"
           [loading]="true"
           [showHeader]="showHeader"

--- a/projects/aca-content/src/lib/components/trashcan/trashcan.component.html
+++ b/projects/aca-content/src/lib/components/trashcan/trashcan.component.html
@@ -18,7 +18,7 @@
         [display]="documentDisplayMode$ | async"
         [currentFolderId]="'-trashcan-'"
         [selectionMode]="'multiple'"
-        [multiselect]="true"
+        [multiselect]="false"
         [navigate]="false"
         [sortingMode]="'client'"
         [imageResolver]="imageResolver"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Checkboxes were implemented to handle bulk edit, which was removed from the scope of 23.1 version.
https://alfresco.atlassian.net/browse/ACS-5638


**What is the new behaviour?**
Checkboxes are disabled in Personal Files and Trash.
![image](https://github.com/Alfresco/alfresco-content-app/assets/138671284/d34c6c4d-44fa-4c7a-8e89-427f0ead9db3)
![image](https://github.com/Alfresco/alfresco-content-app/assets/138671284/e112ff90-9177-4768-b1fc-b1b2f0449a47)




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
