### PR TITLE
[ACS-5564] Bugfix: Expand navigation menu icon is visible even when navigation menu is expanded

### DIFF
--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
@@ -47,10 +47,7 @@ describe('SidenavComponent', () => {
             toggleAppNavBar$: new Subject()
           }
         },
-        {
-          provide: SidenavLayoutComponent,
-          useClass: SidenavLayoutComponent
-        }
+        SidenavLayoutComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
@@ -28,11 +28,13 @@ import { SidenavComponent } from './sidenav.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { AppExtensionService, AppService } from '@alfresco/aca-shared';
 import { BehaviorSubject, Subject } from 'rxjs';
+import { SidenavLayoutComponent } from '@alfresco/adf-core';
 
 describe('SidenavComponent', () => {
   let fixture: ComponentFixture<SidenavComponent>;
   let component: SidenavComponent;
   let extensionService: AppExtensionService;
+  let sidenavLayoutComponent: SidenavLayoutComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,6 +46,10 @@ describe('SidenavComponent', () => {
             appNavNarMode$: new BehaviorSubject('expanded'),
             toggleAppNavBar$: new Subject()
           }
+        },
+        {
+          provide: SidenavLayoutComponent,
+          useClass: SidenavLayoutComponent
         }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -51,6 +57,7 @@ describe('SidenavComponent', () => {
 
     fixture = TestBed.createComponent(SidenavComponent);
     component = fixture.componentInstance;
+    sidenavLayoutComponent = TestBed.inject(SidenavLayoutComponent);
     extensionService = TestBed.inject(AppExtensionService);
     extensionService.navbar = [
       {
@@ -65,6 +72,9 @@ describe('SidenavComponent', () => {
         ]
       }
     ];
+    component.data = {
+      layout: sidenavLayoutComponent
+    };
   });
 
   it('should set the sidenav data', async () => {

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.ts
@@ -66,6 +66,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
 
     this.appService.appNavNarMode$.next(this.data.mode);
     this.appService.toggleAppNavBar$.pipe(takeUntil(this.onDestroy$)).subscribe(() => this.toggleNavBar());
+    this.data.layout.expanded.pipe(takeUntil(this.onDestroy$)).subscribe(() => this.setNavBarMode());
   }
 
   trackByGroupId(_: number, obj: NavBarGroupRef): string {
@@ -80,9 +81,13 @@ export class SidenavComponent implements OnInit, OnDestroy {
     this.toggleNavBar();
   }
 
+  private setNavBarMode() {
+    this.appService.appNavNarMode$.next(this.data.layout.isMenuMinimized || this.data.layout.isHeaderInside ? 'collapsed' : 'expanded');
+  }
+
   private toggleNavBar() {
     this.data.layout.toggleMenu();
-    this.appService.appNavNarMode$.next(this.data.layout.isMenuMinimized ? 'collapsed' : 'expanded');
+    this.setNavBarMode();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

In some cases, the 'expand navigation' icon was missing when it was needed, and vice versa.
https://alfresco.atlassian.net/browse/ACS-5564

**What is the new behaviour?**

Bug fixed, the "expand navigation" icon is displayed correctly when needed.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
