### PR TITLE
[AC-4313] - Add missing sorting in list component on init

### DIFF
--- a/projects/aca-content/src/lib/directives/document-list.directive.ts
+++ b/projects/aca-content/src/lib/directives/document-list.directive.ts
@@ -68,7 +68,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
     if (this.sortingPreferenceKey) {
       const current = this.documentList.sorting;
 
-      const key = this.preferences.get(`${this.sortingPreferenceKey}.sorting.key`, current[0]);
+      const key = this.preferences.get(`${this.sortingPreferenceKey}.sorting.sortingKey`, current[0]);
       const direction = this.preferences.get(`${this.sortingPreferenceKey}.sorting.direction`, current[1]);
 
       this.documentList.sorting = [key, direction];
@@ -101,6 +101,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
   onSortingChanged(event: CustomEvent) {
     if (this.sortingPreferenceKey) {
       this.preferences.set(`${this.sortingPreferenceKey}.sorting.key`, event.detail.key);
+      this.preferences.set(`${this.sortingPreferenceKey}.sorting.sortingKey`, event.detail.sortingKey);
       this.preferences.set(`${this.sortingPreferenceKey}.sorting.direction`, event.detail.direction);
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When entering a document list with server side sorting, icon in column header suggested there is a saved sorting, but files were not in correct order. 


**What is the new behaviour?**
When entering a document list files are in correct sorting order


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
