### PR TITLE
[ACS-5692] - fix focus for sidenav options

### DIFF
--- a/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.html
+++ b/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.html
@@ -25,17 +25,16 @@
     <mat-expansion-panel-header expandedHeight="32px" collapsedHeight="32px" role="group">
       <mat-panel-title>
         <div class="item">
-          <button
+          <span
             [attr.aria-label]="item.title | translate"
             [id]="item.id"
             [attr.title]="item.description | translate"
             [attr.data-automation-id]="item.id"
-            mat-button
             class="action-button full-width"
           >
             <adf-icon *ngIf="item.icon" [value]="item.icon"></adf-icon>
             <span class="action-button__label">{{ item.title | translate }}</span>
-          </button>
+          </span>
         </div>
       </mat-panel-title>
     </mat-expansion-panel-header>

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
@@ -97,8 +97,8 @@
       }
     }
 
-    .mat-expansion-panel:not(.mat-expanded) .mat-expansion-panel-header:not([aria-disabled='true']):hover {
-      background: none;
+    .mat-expansion-panel-header:hover {
+      background: var(--adf-theme-background-hover-color);
     }
 
     .item {
@@ -119,6 +119,7 @@
       height: 32px;
       padding: 0 24px;
       border-radius: 0;
+      line-height: 32px;
     }
 
     .full-width {

--- a/projects/aca-content/src/lib/ui/overrides/ay11.scss
+++ b/projects/aca-content/src/lib/ui/overrides/ay11.scss
@@ -157,6 +157,7 @@
 
   .mat-expansion-panel .mat-expansion-panel-header {
     border: 2px solid transparent;
+    box-sizing: border-box;
 
     .mat-button-base.mat-button {
       outline: none;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Tab button is focusing twice on sidenav panel header and blue border cuses changing of height of header


**What is the new behaviour?**
Focus is applied only once to panel header and there is no height 'jumping'


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
