### PR TITLE
[ACS-5654] Retain filter header in document list.

### DIFF
--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -156,6 +156,14 @@ describe('FilesComponent', () => {
 
       expect(router.navigate['calls'].argsFor(0)[0]).toEqual(['/personal-files', 'parent-id']);
     });
+
+    it('should show the message "Your filter returned 0 results" when filter(s) are selected and there are no records', () => {
+      Object.defineProperty(route, 'queryParamMap', { value: of({ params: { $thumbnail: 'TYPE:"cm:folder"' } }) });
+
+      fixture.detectChanges();
+
+      expect(component.isFilterHeaderActive).toBeTrue();
+    });
   });
 
   describe('refresh on events', () => {

--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -157,7 +157,7 @@ describe('FilesComponent', () => {
       expect(router.navigate['calls'].argsFor(0)[0]).toEqual(['/personal-files', 'parent-id']);
     });
 
-    it('should show the message "Your filter returned 0 results" when filter(s) are selected and there are no records', () => {
+    it('should check isFilterHeaderActive to be true when filters are present in queryParamMap', () => {
       Object.defineProperty(route, 'queryParamMap', { value: of({ params: { $thumbnail: 'TYPE:"cm:folder"' } }) });
 
       fixture.detectChanges();

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -96,7 +96,6 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
     this.route.queryParamMap.subscribe((queryMap: Params) => {
       this.queryParams = queryMap.params;
     });
-
     this.route.params.subscribe(({ folderId }: Params) => {
       const nodeId = folderId || data.defaultNodeId;
 
@@ -130,7 +129,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       });
 
     this.columns = this.extensions.documentListPresets.files || [];
-    if (Object.keys(this.queryParams).length > 0) {
+    if (this.queryParams && Object.keys(this.queryParams).length > 0) {
       this.isFilterHeaderActive = true;
     }
   }

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -130,6 +130,9 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
       });
 
     this.columns = this.extensions.documentListPresets.files || [];
+    if (Object.keys(this.queryParams).length > 0) {
+      this.isFilterHeaderActive = true;
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The filters and header of the table disappears after a refresh if there are no records in the table.
https://alfresco.atlassian.net/browse/ACS-5654


**What is the new behaviour?**

The filters and header of the table is retained after a refresh if there are no records in the table.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
