### PR TITLE
[ACS-5845] remove AlfrescoApiCompatibility usage

### DIFF
--- a/e2e/protractor/e2e-config/utils/upload-output.js
+++ b/e2e/protractor/e2e-config/utils/upload-output.js
@@ -1,6 +1,7 @@
-const path = require('path');
-const fs = require('fs');
-const AlfrescoApi = require('@alfresco/js-api').AlfrescoApiCompatibility;
+const path = require('node:path');
+const fs = require('node:fs');
+const child_process = require('node:child_process');
+const { AlfrescoApi, NodesApi, UploadApi } = require('@alfresco/js-api');
 const buildNumber = require('./build-number');
 const outputDir = path.resolve(__dirname, '../../../e2e-output/');
 
@@ -8,54 +9,59 @@ async function saveScreenshots(retryCount) {
   const folderName = process.env.GITHUB_JOB;
   console.log(`Start uploading report in ${folderName}`);
 
-  let alfrescoJsApi = new AlfrescoApi({
+  const alfrescoJsApi = new AlfrescoApi({
     provider: 'ECM',
     hostEcm: process.env.SCREENSHOT_URL
   });
+
+  const nodesApi = new NodesApi(alfrescoJsApi);
+  const uploadApi = new UploadApi(alfrescoJsApi);
 
   await alfrescoJsApi.login(process.env.SCREENSHOT_USERNAME, process.env.SCREENSHOT_PASSWORD);
 
   let folderNode;
 
   try {
-    folderNode = await alfrescoJsApi.nodes.addNode('-my-', {
-      'name': `retry-${retryCount}`,
-      'relativePath': `Builds/ACA-${buildNumber()}/${folderName}/`,
-      'nodeType': 'cm:folder'
-    }, {}, {
-      'overwrite': true
-    });
+    folderNode = await nodesApi.createNode(
+      '-my-',
+      {
+        name: `retry-${retryCount}`,
+        relativePath: `Builds/ACA-${buildNumber()}/${folderName}/`,
+        nodeType: 'cm:folder'
+      },
+      {},
+      {
+        overwrite: true
+      }
+    );
   } catch (error) {
-    folderNode = await alfrescoJsApi.nodes.getNode('-my-', {
-      'relativePath': `Builds/ACA-${buildNumber()}/${folderName}/retry-${retryCount}`,
-      'nodeType': 'cm:folder'
-    }, {}, {
-      'overwrite': true
-    });
+    folderNode = await nodesApi.createNode(
+      '-my-',
+      {
+        relativePath: `Builds/ACA-${buildNumber()}/${folderName}/retry-${retryCount}`,
+        nodeType: 'cm:folder'
+      },
+      {},
+      {
+        overwrite: true
+      }
+    );
   }
 
   fs.renameSync(outputDir, path.join(`${outputDir}-${folderName}-${retryCount}/`));
 
-  const child_process = require("child_process");
   child_process.execSync(` tar -czvf ../e2e-result-${folderName}-${retryCount}.tar .`, {
     cwd: `${outputDir}-${folderName}-${retryCount}/`
   });
 
-  let pathFile = path.join(outputDir, `../e2e-result-${folderName}-${retryCount}.tar`);
+  const pathFile = path.join(outputDir, `../e2e-result-${folderName}-${retryCount}.tar`);
+  const file = fs.createReadStream(pathFile);
 
-  let file = fs.createReadStream(pathFile);
-  await alfrescoJsApi.upload.uploadFile(
-    file,
-    '',
-    folderNode.entry.id,
-    null,
-    {
-      'name': `e2e-result-${folderName}-${retryCount}.tar`,
-      'nodeType': 'cm:content',
-      'autoRename': true
-    }
-  );
-
+  await uploadApi.uploadFile(file, '', folderNode.entry.id, null, {
+    name: `e2e-result-${folderName}-${retryCount}.tar`,
+    nodeType: 'cm:content',
+    autoRename: true
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

remove the deprecated `AlfrescoApiCompatibility` usage and migrate to proper client classes

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5845