### PR TITLE
[ACS-5841] - viewer details disappear on button click

### DIFF
--- a/projects/aca-content/src/lib/store/effects/node.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/node.effects.ts
@@ -49,7 +49,8 @@ import {
   NavigateRouteAction,
   ExpandInfoDrawerAction,
   ManageRulesAction,
-  ShowLoaderAction
+  ShowLoaderAction,
+  ToggleInfoDrawerAction
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { RenditionService } from '@alfresco/adf-content-services';
@@ -318,6 +319,7 @@ export class NodeEffects {
                 }
               });
           }
+          this.store.dispatch(new ToggleInfoDrawerAction());
         })
       ),
     { dispatch: false }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When in viewer mode, clicking details disappear buttons hides side drawer only after first click, if repeated nothing else happens


**What is the new behaviour?**
When in viewer mode, clicking details disappear button always hides side drawer

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
