### PR TITLE
[ACS-5680] fix library properties to show labels in edit mode

### DIFF
--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -81,7 +81,7 @@
 
   <mat-card-content *ngIf="edit">
     <form [formGroup]="form" autocomplete="off">
-      <mat-form-field>
+      <mat-form-field floatLabel="auto">
         <input
           matInput
           cdkFocusInitial
@@ -96,11 +96,11 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field floatLabel="auto">
         <input matInput placeholder="{{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}" formControlName="id" />
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field floatLabel="auto">
         <mat-select placeholder="{{ 'LIBRARY.DIALOG.FORM.VISIBILITY' | translate }}" formControlName="visibility">
           <mat-option [value]="type.value" *ngFor="let type of libraryType">
             {{ type.label | translate }}
@@ -108,7 +108,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field floatLabel="auto">
         <textarea
           matInput
           placeholder="{{ 'LIBRARY.DIALOG.FORM.DESCRIPTION' | translate }}"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5680
Properties' labels are not shown in edit mode in ADW.
![image](https://github.com/Alfresco/alfresco-content-app/assets/138671284/0d242eff-1866-4ff3-a457-6a50dc43d870)



**What is the new behaviour?**
Properties' labels are shown in edit mode.
![image](https://github.com/Alfresco/alfresco-content-app/assets/138671284/d51fe820-3023-49e9-a579-b422fa0a092b)




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
