### PR TITLE
[ACS-5563] Fixed incorrect initial loading of security marks

### DIFF
--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -29,7 +29,7 @@ import { DocumentListService, FilterSearch, PathElementEntity, UploadService } f
 import { NodeActionsService } from '../../services/node-actions.service';
 import { FilesComponent } from './files.component';
 import { AppTestingModule } from '../../testing/app-testing.module';
-import { ContentApiService } from '@alfresco/aca-shared';
+import { AppExtensionService, ContentApiService } from '@alfresco/aca-shared';
 import { of, Subject, throwError } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { NodeEntry, NodePaging } from '@alfresco/js-api';
@@ -39,6 +39,7 @@ describe('FilesComponent', () => {
   let fixture: ComponentFixture<FilesComponent>;
   let component: FilesComponent;
   let uploadService: UploadService;
+  let extensions: AppExtensionService;
   let nodeActionsService: NodeActionsService;
   let contentApi: ContentApiService;
   let route: ActivatedRoute;
@@ -77,7 +78,8 @@ describe('FilesComponent', () => {
             params: of({ folderId: 'someId' }),
             queryParamMap: of({})
           }
-        }
+        },
+        AppExtensionService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });
@@ -96,6 +98,7 @@ describe('FilesComponent', () => {
     route = TestBed.inject(ActivatedRoute);
     nodeActionsService = TestBed.inject(NodeActionsService);
     contentApi = TestBed.inject(ContentApiService);
+    extensions = TestBed.inject(AppExtensionService);
     spyContent = spyOn(contentApi, 'getNode');
   });
 
@@ -146,6 +149,24 @@ describe('FilesComponent', () => {
     it('should set current node', () => {
       fixture.detectChanges();
       expect(component.node).toBe(node);
+    });
+
+    it('should set columns', () => {
+      const filesDocumentListPresetMock = [
+        {
+          id: 'app.files.modifiedOn',
+          key: 'modifiedAt',
+          type: 'date',
+          sortable: true,
+          desktopOnly: true,
+          template: 'template',
+          sortingKey: 'sorting-key'
+        }
+      ];
+
+      extensions.filesDocumentListPreset$ = of(filesDocumentListPresetMock);
+      fixture.detectChanges();
+      expect(component.columns).toEqual(filesDocumentListPresetMock);
     });
 
     it('should navigate to parent if node is not a folder', () => {

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -127,7 +127,10 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
         this.isAdmin = value;
       });
 
-    this.columns = this.extensions.documentListPresets.files || [];
+    this.extensions.filesDocumentListPreset$.pipe(takeUntil(this.onDestroy$)).subscribe((preset) => {
+      this.columns = preset;
+    });
+
     if (this.queryParams && Object.keys(this.queryParams).length > 0) {
       this.isFilterHeaderActive = true;
     }

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -174,7 +174,7 @@ describe('AppExtensionService', () => {
       });
     });
 
-    it('should support column orders', () => {
+    it('should support column orders', (done) => {
       applyConfig({
         $id: 'test',
         $name: 'test',
@@ -236,6 +236,7 @@ describe('AppExtensionService', () => {
         expect(columns[0].id).toBe('app.files.thumbnail');
         expect(columns[1].id).toBe('app.files.name');
         expect(columns[2].id).toBe('app.files.securityMarks');
+        done();
       });
 
       expect(libraries.length).toBe(2);
@@ -243,7 +244,7 @@ describe('AppExtensionService', () => {
       expect(libraries[1].id).toBe('app.libraries.thumbnail');
     });
 
-    it('should ignore column if visibility in rules is false', () => {
+    it('should ignore column if visibility in rules is false', (done) => {
       applyConfig({
         $id: 'test',
         $name: 'test',
@@ -288,6 +289,7 @@ describe('AppExtensionService', () => {
         expect(columns.length).toBe(2);
         expect(columns[0].id).toBe('app.files.thumbnail');
         expect(columns[1].id).toBe('app.files.name');
+        done();
       });
     });
   });

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -228,12 +228,15 @@ describe('AppExtensionService', () => {
         }
       });
 
-      const { files, libraries } = service.documentListPresets;
+      const { libraries } = service.documentListPresets;
+      const files = service.filesDocumentListPreset$;
 
-      expect(files.length).toBe(3);
-      expect(files[0].id).toBe('app.files.thumbnail');
-      expect(files[1].id).toBe('app.files.name');
-      expect(files[2].id).toBe('app.files.securityMarks');
+      files.subscribe((columns) => {
+        expect(columns.length).toBe(3);
+        expect(columns[0].id).toBe('app.files.thumbnail');
+        expect(columns[1].id).toBe('app.files.name');
+        expect(columns[2].id).toBe('app.files.securityMarks');
+      });
 
       expect(libraries.length).toBe(2);
       expect(libraries[0].id).toBe('app.libraries.name');
@@ -279,11 +282,13 @@ describe('AppExtensionService', () => {
         }
       });
 
-      const { files } = service.documentListPresets;
+      const files = service.filesDocumentListPreset$;
 
-      expect(files.length).toBe(2);
-      expect(files[0].id).toBe('app.files.thumbnail');
-      expect(files[1].id).toBe('app.files.name');
+      files.subscribe((columns) => {
+        expect(columns.length).toBe(2);
+        expect(columns[0].id).toBe('app.files.thumbnail');
+        expect(columns[1].id).toBe('app.files.name');
+      });
     });
   });
 

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -80,9 +80,9 @@ export class AppExtensionService implements RuleContext {
   private _createActions = new BehaviorSubject<Array<ContentActionRef>>([]);
   private _mainActions = new BehaviorSubject<ContentActionRef>(null);
   private _sidebarActions = new BehaviorSubject<Array<ContentActionRef>>([]);
+  private _filesDocumentListPreset = new BehaviorSubject<Array<DocumentListPresetRef>>([]);
 
   documentListPresets: {
-    files: Array<DocumentListPresetRef>;
     libraries: Array<DocumentListPresetRef>;
     favoriteLibraries: Array<DocumentListPresetRef>;
     shared: Array<DocumentListPresetRef>;
@@ -91,7 +91,6 @@ export class AppExtensionService implements RuleContext {
     trashcan: Array<DocumentListPresetRef>;
     searchLibraries: Array<DocumentListPresetRef>;
   } = {
-    files: [],
     libraries: [],
     favoriteLibraries: [],
     shared: [],
@@ -108,6 +107,7 @@ export class AppExtensionService implements RuleContext {
   withCredentials: boolean;
 
   references$: Observable<ExtensionRef[]>;
+  filesDocumentListPreset$: Observable<DocumentListPresetRef[]> = this._filesDocumentListPreset.asObservable();
 
   config: ExtensionConfig;
 
@@ -158,6 +158,7 @@ export class AppExtensionService implements RuleContext {
     this._openWithActions.next(this.loader.getContentActions(config, 'features.viewer.openWith'));
     this._createActions.next(this.loader.getElements<ContentActionRef>(config, 'features.create'));
     this._mainActions.next(this.loader.getFeatures(config).mainAction);
+    this._filesDocumentListPreset.next(this.getDocumentListPreset(config, 'files'));
 
     this.navbar = this.loadNavBar(config);
     this.sidebarTabs = this.loader.getElements<SidebarTabRef>(config, 'features.sidebar.tabs');
@@ -165,7 +166,6 @@ export class AppExtensionService implements RuleContext {
     this.search = this.loadSearchForms(config);
 
     this.documentListPresets = {
-      files: this.getDocumentListPreset(config, 'files'),
       libraries: this.getDocumentListPreset(config, 'libraries'),
       favoriteLibraries: this.getDocumentListPreset(config, 'favoriteLibraries'),
       shared: this.getDocumentListPreset(config, 'shared'),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-5563

**What is the new behaviour?**

Security marks are being loaded correctly as expected.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
