### PR TITLE
[ACS-5284] - updating a folder rule options has no effect when multiple rules exist and clicking between them

### DIFF
--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
@@ -106,6 +106,7 @@
               <div class="aca-manage-rules__container__rule-details__content" *ngIf="(selectedRule$ | async) as selectedRule">
                 <aca-rule-details
                   [actionDefinitions]="actionDefinitions$ | async"
+                  [parameterConstraints]="parameterConstraints$ | async"
                   [readOnly]="true"
                   [preview]="true"
                   [value]="selectedRule"

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.scss
@@ -13,6 +13,6 @@
   }
 
   .hide-error-script-dropdown {
-    opacity: 0;
+    visibility: hidden;
   }
 }

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
@@ -149,4 +149,33 @@ describe('RuleOptionsUiComponent', () => {
     expect(matFormField).not.toBeNull();
     expect(matFormField.componentInstance['floatLabel']).toBe('always');
   });
+
+  it('should properly update formFields on only isAsynchronous and errorScript changes', () => {
+    fixture.detectChanges();
+    component.writeValue({
+      isEnabled: false,
+      isInheritable: true,
+      isAsynchronous: true,
+      errorScript: '1234'
+    });
+    fixture.detectChanges();
+
+    expect(getByDataAutomationId('rule-option-checkbox-asynchronous').componentInstance.checked).toBeTrue();
+    expect(getByDataAutomationId('rule-option-checkbox-inheritable').componentInstance.checked).toBeTrue();
+    expect(getByDataAutomationId('rule-option-checkbox-disabled').componentInstance.checked).toBeTrue();
+    expect(getByDataAutomationId('rule-option-select-errorScript').componentInstance.value).toEqual('1234');
+
+    component.writeValue({
+      isEnabled: false,
+      isInheritable: true,
+      isAsynchronous: false,
+      errorScript: ''
+    });
+    fixture.detectChanges();
+
+    expect(getByDataAutomationId('rule-option-checkbox-asynchronous').componentInstance.checked).toBeFalse();
+    expect(getByDataAutomationId('rule-option-checkbox-inheritable').componentInstance.checked).toBeTrue();
+    expect(getByDataAutomationId('rule-option-checkbox-disabled').componentInstance.checked).toBeTrue();
+    expect(getByDataAutomationId('rule-option-select-errorScript').componentInstance.disabled).toBeTrue();
+  });
 });

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, DebugElement, SimpleChange } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RuleOptionsUiComponent } from './rule-options.ui-component';
 import { CoreTestingModule } from '@alfresco/adf-core';
@@ -40,6 +40,18 @@ describe('RuleOptionsUiComponent', () => {
 
   const toggleMatCheckbox = (dataAutomationId: string) => {
     ((getByDataAutomationId(dataAutomationId).nativeElement as HTMLElement).children[0] as HTMLElement).click();
+  };
+
+  const testErrorScriptFormFieldVisibility = (isVisible: boolean) => {
+    if (isVisible) {
+      expect((getByDataAutomationId('rule-option-form-field-errorScript').nativeElement as HTMLElement).classList).not.toContain(
+        'hide-error-script-dropdown'
+      );
+    } else {
+      expect((getByDataAutomationId('rule-option-form-field-errorScript').nativeElement as HTMLElement).classList).toContain(
+        'hide-error-script-dropdown'
+      );
+    }
   };
 
   beforeEach(() => {
@@ -66,7 +78,7 @@ describe('RuleOptionsUiComponent', () => {
     expect(getByDataAutomationId('rule-option-checkbox-asynchronous').componentInstance.checked).toBeFalsy();
     expect(getByDataAutomationId('rule-option-checkbox-inheritable').componentInstance.checked).toBeFalsy();
     expect(getByDataAutomationId('rule-option-checkbox-disabled').componentInstance.checked).toBeFalsy();
-    expect(getByDataAutomationId('rule-option-select-errorScript').componentInstance.disabled).toBeTruthy();
+    testErrorScriptFormFieldVisibility(false);
 
     component.writeValue({
       isEnabled: false,
@@ -79,7 +91,7 @@ describe('RuleOptionsUiComponent', () => {
     expect(getByDataAutomationId('rule-option-checkbox-asynchronous').componentInstance.checked).toBeTruthy();
     expect(getByDataAutomationId('rule-option-checkbox-inheritable').componentInstance.checked).toBeTruthy();
     expect(getByDataAutomationId('rule-option-checkbox-disabled').componentInstance.checked).toBeTruthy();
-    expect(getByDataAutomationId('rule-option-select-errorScript').componentInstance.disabled).toBeFalsy();
+    testErrorScriptFormFieldVisibility(true);
   });
 
   it('should enable selector when async checkbox is truthy', () => {
@@ -122,6 +134,7 @@ describe('RuleOptionsUiComponent', () => {
       errorScript: ''
     });
     component.errorScriptConstraint = errorScriptConstraintMock;
+    component.ngOnChanges({ errorScriptConstraint: {} as SimpleChange });
     fixture.detectChanges();
 
     (getByDataAutomationId('rule-option-select-errorScript').nativeElement as HTMLElement).click();
@@ -176,6 +189,6 @@ describe('RuleOptionsUiComponent', () => {
     expect(getByDataAutomationId('rule-option-checkbox-asynchronous').componentInstance.checked).toBeFalse();
     expect(getByDataAutomationId('rule-option-checkbox-inheritable').componentInstance.checked).toBeTrue();
     expect(getByDataAutomationId('rule-option-checkbox-disabled').componentInstance.checked).toBeTrue();
-    expect(getByDataAutomationId('rule-option-select-errorScript').componentInstance.disabled).toBeTrue();
+    testErrorScriptFormFieldVisibility(false);
   });
 });

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
@@ -22,8 +22,8 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, forwardRef, HostBinding, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { AbstractControl, ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { Component, forwardRef, HostBinding, Input, OnChanges, OnDestroy, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { RuleOptions } from '../../model/rule.model';
 import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
@@ -48,7 +48,7 @@ import { MatSelectModule } from '@angular/material/select';
     }
   ]
 })
-export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnDestroy {
+export class RuleOptionsUiComponent implements ControlValueAccessor, OnChanges, OnDestroy {
   form = new FormGroup({
     isDisabled: new FormControl(),
     isInheritable: new FormControl(),
@@ -86,7 +86,6 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
   errorScriptOptions: ConstraintValue[] = [];
 
   writeValue(options: RuleOptions) {
-    const errorScriptFormControl = this.form.get('errorScript');
     this.form.setValue(
       {
         isDisabled: !options.isEnabled,
@@ -98,13 +97,7 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
     );
     this.isAsynchronousChecked = options.isAsynchronous;
     this.isInheritableChecked = options.isInheritable;
-    if (this.isAsynchronousChecked) {
-      this.hideErrorScriptDropdown = false;
-      errorScriptFormControl.enable({ onlySelf: true, emitEvent: false });
-    } else {
-      this.hideErrorScriptDropdown = true;
-      errorScriptFormControl.disable({ onlySelf: true, emitEvent: false });
-    }
+    this.hideErrorScriptDropdown = !this.isAsynchronousChecked;
   }
 
   registerOnChange(fn: () => void) {
@@ -125,8 +118,10 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
     }
   }
 
-  ngOnInit(): void {
-    this.errorScriptOptions = this.errorScriptConstraint?.constraints ?? [];
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['errorScriptConstraint']) {
+      this.errorScriptOptions = this.errorScriptConstraint?.constraints ?? [];
+    }
   }
 
   ngOnDestroy() {
@@ -134,13 +129,6 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
   }
 
   toggleErrorScriptDropdown(value: MatCheckboxChange) {
-    const formControl: AbstractControl = this.form.get('errorScript');
-    if (value.checked) {
-      this.hideErrorScriptDropdown = false;
-      formControl.enable();
-    } else {
-      this.hideErrorScriptDropdown = true;
-      formControl.disable();
-    }
+    this.hideErrorScriptDropdown = !value.checked;
   }
 }

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
@@ -57,13 +57,14 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
   });
 
   formSubscription = this.form.valueChanges.subscribe((value: any) => {
+    const formValue = { ...this.form.value, ...value };
     this.isAsynchronousChecked = value.isAsynchronous;
     this.isInheritableChecked = value.isInheritable;
     this.onChange({
-      isEnabled: !value.isDisabled,
-      isInheritable: value.isInheritable,
-      isAsynchronous: value.isAsynchronous,
-      errorScript: value.errorScript ?? ''
+      isEnabled: !formValue.isDisabled,
+      isInheritable: formValue.isInheritable,
+      isAsynchronous: formValue.isAsynchronous,
+      errorScript: formValue.errorScript ?? ''
     });
     this.onTouch();
   });
@@ -85,18 +86,24 @@ export class RuleOptionsUiComponent implements ControlValueAccessor, OnInit, OnD
   errorScriptOptions: ConstraintValue[] = [];
 
   writeValue(options: RuleOptions) {
-    const isAsynchronousFormControl = this.form.get('isAsynchronous');
     const errorScriptFormControl = this.form.get('errorScript');
-    this.form.get('isDisabled').setValue(!options.isEnabled);
-    this.form.get('isInheritable').setValue(options.isInheritable);
-    this.form.get('isAsynchronous').setValue(options.isAsynchronous);
-    errorScriptFormControl.setValue(options.errorScript ?? '');
-    if (isAsynchronousFormControl.value) {
+    this.form.setValue(
+      {
+        isDisabled: !options.isEnabled,
+        isAsynchronous: options.isAsynchronous,
+        isInheritable: options.isInheritable,
+        errorScript: options.errorScript ?? ''
+      },
+      { emitEvent: false }
+    );
+    this.isAsynchronousChecked = options.isAsynchronous;
+    this.isInheritableChecked = options.isInheritable;
+    if (this.isAsynchronousChecked) {
       this.hideErrorScriptDropdown = false;
-      errorScriptFormControl.enable();
+      errorScriptFormControl.enable({ onlySelf: true, emitEvent: false });
     } else {
       this.hideErrorScriptDropdown = true;
-      errorScriptFormControl.disable();
+      errorScriptFormControl.disable({ onlySelf: true, emitEvent: false });
     }
   }
 


### PR DESCRIPTION
…le rules exist and clicking between them

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When clicking between different rules with different options (error script, running in background, influence on subfolders) sometimes no changes are visible altough the should be. Options remains usually as in the first visible rule or randomly disappear.


**What is the new behaviour?**
When clicking between different rules with different options everything is updated and visible as expected. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
