### PR TITLE
[ACS-5540] Moved Aspects icons top of properties panel

### DIFF
--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -1261,7 +1261,7 @@
             "click": "EXPAND_INFO_DRAWER"
           },
           "rules": {
-            "visible": "canNotShowExpand"
+            "visible": "canShowExpand"
           }
         }
       ],

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -1243,7 +1243,7 @@
         {
           "id": "app.toolbar.aspects",
           "order": 160,
-          "title": "APP.ACTIONS.CHANGE_ASPECT",
+          "title": "APP.ACTIONS.ADD_ASPECTS",
           "icon": "playlist_add",
           "actions": {
             "click": "ASPECT_LIST"

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -1261,7 +1261,7 @@
             "click": "EXPAND_INFO_DRAWER"
           },
           "rules": {
-            "visible": "app.navigation.isNotLibraries"
+            "visible": "canNotShowExpand"
           }
         }
       ],

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -1241,6 +1241,18 @@
           }
         },
         {
+          "id": "app.toolbar.aspects",
+          "order": 160,
+          "title": "APP.ACTIONS.CHANGE_ASPECT",
+          "icon": "playlist_add",
+          "actions": {
+            "click": "ASPECT_LIST"
+          },
+          "rules": {
+            "visible": "canEditAspects"
+          }
+        },
+        {
           "id": "app.sidebar.expand",
           "order": 200,
           "title": "APP.INFO_DRAWER.TABS.EXPAND",

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -259,7 +259,8 @@
             "LEAVE": "Leave Library",
             "EDIT_OFFLINE": "Edit Offline",
             "EDIT_OFFLINE_CANCEL": "Cancel Editing",
-            "CHANGE_ASPECT": "Edit Aspects"
+            "CHANGE_ASPECT": "Edit Aspects",
+            "ADD_ASPECTS": "Add Aspects"
         },
         "DIALOGS": {
             "CONFIRM_PURGE": {

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -395,7 +395,7 @@
         },
         "INFO_DRAWER": {
             "TITLE": "Details",
-            "CLOSE": "Close",
+            "REDUCE_PANEL": "Reduce panel",
             "DATA_LOADING": "Data is loading",
             "TABS": {
                 "PROPERTIES": "Properties",
@@ -403,7 +403,7 @@
                 "VERSIONS": "Versions",
                 "COMMENTS": "Comments",
                 "PERMISSIONS": "Permissions",
-                "EXPAND": "Expand"
+                "EXPAND": "Expand panel"
             }
         },
         "TOOLTIPS": {

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -192,6 +192,7 @@ export class ContentServiceExtensionModule {
       canToggleFavorite: rules.canToggleFavorite,
       isLibraryManager: rules.isLibraryManager,
       canEditAspects: rules.canEditAspects,
+      canNotShowExpand: rules.canNotShowExpand,
       canInfoPreview: rules.canInfoPreview,
       showInfoSelectionButton: rules.showInfoSelectionButton,
 

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -192,7 +192,7 @@ export class ContentServiceExtensionModule {
       canToggleFavorite: rules.canToggleFavorite,
       isLibraryManager: rules.isLibraryManager,
       canEditAspects: rules.canEditAspects,
-      canNotShowExpand: rules.canNotShowExpand,
+      canShowExpand: rules.canShowExpand,
       canInfoPreview: rules.canInfoPreview,
       showInfoSelectionButton: rules.showInfoSelectionButton,
 

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -12,14 +12,23 @@
           -
           <span class="acs-details-breadcrumb-item">{{ 'APP.INFO_DRAWER.TITLE' | translate }}</span>
         </div>
-        <button
-          class="aca-close-details-button"
-          mat-icon-button
-          data-automation-id="close-library"
-          title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}"
-          (click)="goBack()">
-          <mat-icon>fullscreen_exit</mat-icon>
-        </button>
+        <div>
+          <button
+                  mat-icon-button
+                  (click)="openAspectDialog()"
+                  [attr.title]="'CORE.METADATA.ACTIONS.EDIT_ASPECTS' | translate"
+                  [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT_ASPECTS' | translate"
+                  data-automation-id="meta-data-edit-aspect">
+                  <mat-icon>playlist_add</mat-icon>
+          </button>
+          <button mat-icon-button 
+                  class="aca-close-details-button"
+                  data-automation-id="close-library"
+                  title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}"
+                  (click)="goBack()">
+                  <mat-icon>fullscreen_exit</mat-icon>
+          </button>
+        </div>
       </div>
 
       <mat-tab-group [selectedIndex]="activeTab" class="aca-details-tabs" animationDuration="0">

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -14,9 +14,13 @@
         </div>
         <div class="acs-details-buttons">
           <aca-toolbar [items]="aspectActions" info-drawer-buttons></aca-toolbar>
-          <button class="aca-close-details-button" mat-icon-button data-automation-id="close-library"
-            title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}" (click)="goBack()">
-            <mat-icon>close</mat-icon>
+          <button
+                class="aca-close-details-button"
+                mat-icon-button
+                data-automation-id="close-library"
+                title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}"
+                (click)="goBack()">
+                <mat-icon>fullscreen_exit</mat-icon>
           </button>
         </div>
       </div>

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -18,7 +18,7 @@
                 class="aca-close-details-button"
                 mat-icon-button
                 data-automation-id="close-library"
-                title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}"
+                title="{{ 'APP.INFO_DRAWER.REDUCE_PANEL' | translate }}"
                 (click)="goBack()">
                 <mat-icon>fullscreen_exit</mat-icon>
           </button>

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -12,21 +12,11 @@
           -
           <span class="acs-details-breadcrumb-item">{{ 'APP.INFO_DRAWER.TITLE' | translate }}</span>
         </div>
-        <div>
-          <button *ngIf="!isNodeLocked"
-                  mat-icon-button
-                  (click)="openAspectDialog()"
-                  [attr.title]="'CORE.METADATA.ACTIONS.EDIT_ASPECTS' | translate"
-                  [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT_ASPECTS' | translate"
-                  data-automation-id="meta-data-edit-aspect">
-                  <mat-icon>playlist_add</mat-icon>
-          </button>
-          <button mat-icon-button 
-                  class="aca-close-details-button"
-                  data-automation-id="close-library"
-                  title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}"
-                  (click)="goBack()">
-                  <mat-icon>fullscreen_exit</mat-icon>
+        <div class="acs-details-buttons">
+          <aca-toolbar [items]="actionsAspect" info-drawer-buttons></aca-toolbar>
+          <button class="aca-close-details-button" mat-icon-button data-automation-id="close-library"
+            title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}" (click)="goBack()">
+            <mat-icon>close</mat-icon>
           </button>
         </div>
       </div>

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -13,7 +13,7 @@
           <span class="acs-details-breadcrumb-item">{{ 'APP.INFO_DRAWER.TITLE' | translate }}</span>
         </div>
         <div class="acs-details-buttons">
-          <aca-toolbar [items]="actionsAspect" info-drawer-buttons></aca-toolbar>
+          <aca-toolbar [items]="aspectActions" info-drawer-buttons></aca-toolbar>
           <button class="aca-close-details-button" mat-icon-button data-automation-id="close-library"
             title="{{ 'APP.INFO_DRAWER.CLOSE' | translate }}" (click)="goBack()">
             <mat-icon>close</mat-icon>

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -13,7 +13,7 @@
           <span class="acs-details-breadcrumb-item">{{ 'APP.INFO_DRAWER.TITLE' | translate }}</span>
         </div>
         <div>
-          <button
+          <button *ngIf="!isNodeLocked"
                   mat-icon-button
                   (click)="openAspectDialog()"
                   [attr.title]="'CORE.METADATA.ACTIONS.EDIT_ASPECTS' | translate"

--- a/projects/aca-content/src/lib/components/details/details.component.scss
+++ b/projects/aca-content/src/lib/components/details/details.component.scss
@@ -1,19 +1,29 @@
 app-details-manager {
-  .aca-close-details-button {
-    margin-right: 15px;
-    margin-top: 2px;
-    outline: none;
-    border-radius: 4px;
+  .acs-details-buttons {
+    display: flex;
 
-    &:focus {
-      background-color: var(--theme-selected-background-color);
-      outline: 2px solid var(--theme-blue-button-color);
+    .aca-close-details-button {
+      margin-right: 15px;
+      margin-top: 2px;
+      outline: none;
       border-radius: 4px;
-    }
 
-    &:focus-visible {
-      outline: 2px solid var(--theme-blue-button-color);
-      border-radius: 4px;
+      &:focus {
+        background-color: var(--theme-selected-background-color);
+        outline: 2px solid var(--theme-blue-button-color);
+        border-radius: 4px;
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--theme-blue-button-color);
+        border-radius: 4px;
+        margin-top: 12px;
+
+        &:focus-visible {
+          outline: 2px solid var(--theme-blue-button-color);
+          border-radius: 4px;
+        }
+      }
     }
   }
 }

--- a/projects/aca-content/src/lib/components/details/details.component.scss
+++ b/projects/aca-content/src/lib/components/details/details.component.scss
@@ -4,7 +4,7 @@ app-details-manager {
 
     .aca-close-details-button {
       margin-right: 15px;
-      margin-top: 2px;
+      margin-top: 12px;
       outline: none;
       border-radius: 4px;
 

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -42,7 +42,7 @@ describe('DetailsComponent', () => {
   let contentApiService: ContentApiService;
   let store: Store;
   let node: NodeEntry;
-  let mockNodeAspectService: jasmine.SpyObj<NodeAspectService>;
+  let nodeAspectService: NodeAspectService;
 
   const mockStream = new Subject();
   const storeMock = {
@@ -51,7 +51,6 @@ describe('DetailsComponent', () => {
   };
 
   beforeEach(() => {
-    const nodeAspectServiceSpy = jasmine.createSpyObj('NodeAspectService', ['updateNodeAspects']);
     TestBed.configureTestingModule({
       imports: [AppTestingModule, DetailsComponent],
       providers: [
@@ -80,10 +79,6 @@ describe('DetailsComponent', () => {
             onLogout: new Subject<any>(),
             isLoggedIn: () => true
           }
-        },
-        {
-          provide: NodeAspectService,
-          useValue: nodeAspectServiceSpy
         }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -92,7 +87,7 @@ describe('DetailsComponent', () => {
     fixture = TestBed.createComponent(DetailsComponent);
     component = fixture.componentInstance;
     contentApiService = TestBed.inject(ContentApiService);
-    mockNodeAspectService = TestBed.inject(NodeAspectService) as jasmine.SpyObj<NodeAspectService>;
+    nodeAspectService = TestBed.inject(NodeAspectService);
     component.node = { id: 'test-id' } as MinimalNodeEntryEntity;
     store = TestBed.inject(Store);
 
@@ -111,6 +106,7 @@ describe('DetailsComponent', () => {
       }
     };
     spyOn(contentApiService, 'getNode').and.returnValue(of(node));
+    spyOn(nodeAspectService, 'updateNodeAspects').and.callThrough();
   });
 
   afterEach(() => {
@@ -137,9 +133,9 @@ describe('DetailsComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([node]));
   });
 
-  it('should call openAspectDialog and updateNodeAspects when the button is clicked', () => {
+  it('should call updateNodeAspects when the button is clicked', () => {
     component.openAspectDialog();
     fixture.detectChanges();
-    expect(mockNodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');
+    expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -31,10 +31,10 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { Node, NodeEntry } from '@alfresco/js-api';
+import { NodeEntry } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, PageTitleService } from '@alfresco/adf-core';
-import { NodeAspectService, SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
 
 describe('DetailsComponent', () => {
   let component: DetailsComponent;
@@ -42,7 +42,6 @@ describe('DetailsComponent', () => {
   let contentApiService: ContentApiService;
   let store: Store;
   let node: NodeEntry;
-  let nodeAspectService: NodeAspectService;
 
   const mockStream = new Subject();
   const storeMock = {
@@ -87,8 +86,6 @@ describe('DetailsComponent', () => {
     fixture = TestBed.createComponent(DetailsComponent);
     component = fixture.componentInstance;
     contentApiService = TestBed.inject(ContentApiService);
-    nodeAspectService = TestBed.inject(NodeAspectService);
-    component.node = { id: 'test-id' } as Node;
     store = TestBed.inject(Store);
 
     node = {
@@ -106,7 +103,6 @@ describe('DetailsComponent', () => {
       }
     };
     spyOn(contentApiService, 'getNode').and.returnValue(of(node));
-    spyOn(nodeAspectService, 'updateNodeAspects');
   });
 
   afterEach(() => {
@@ -131,27 +127,5 @@ describe('DetailsComponent', () => {
   it('should dispatch node selection', () => {
     fixture.detectChanges();
     expect(store.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([node]));
-  });
-
-  it('should call updateNodeAspects when the aspect dialog is opened', () => {
-    component.openAspectDialog();
-    fixture.detectChanges();
-    expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');
-  });
-
-  it('should subscribe to store and update isNodeLocked', () => {
-    const mockSelection = { file: { entry: { name: 'test', properties: {}, isLocked: false } } };
-    spyOn(store, 'select').and.returnValue(of(mockSelection));
-    fixture.detectChanges();
-    expect(store.select).toHaveBeenCalled();
-    expect(component.isNodeLocked).toBe(false);
-  });
-
-  it('should unsubscribe from observables on component destroy', () => {
-    spyOn(component.onDestroy$, 'next');
-    spyOn(component.onDestroy$, 'complete');
-    fixture.detectChanges();
-    component.ngOnDestroy();
-    expect(component.onDestroy$.complete).toHaveBeenCalled();
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -26,7 +26,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { DetailsComponent } from './details.component';
 import { ActivatedRoute } from '@angular/router';
-import { of, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
@@ -48,6 +48,16 @@ describe('DetailsComponent', () => {
     dispatch: jasmine.createSpy('dispatch'),
     select: () => mockStream
   };
+
+  const extensionsServiceMock = {
+    getAllowedSidebarActions: jasmine.createSpy('getAllowedSidebarActions')
+  };
+
+  const mockAspectActions = [];
+
+  // Mock the observable returned by getAllowedSidebarActions
+  const mockObservable = new BehaviorSubject(mockAspectActions);
+  extensionsServiceMock.getAllowedSidebarActions.and.returnValue(mockObservable);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -127,5 +137,13 @@ describe('DetailsComponent', () => {
   it('should dispatch node selection', () => {
     fixture.detectChanges();
     expect(store.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([node]));
+  });
+
+  it('should set aspectActions from extensions', () => {
+    extensionsServiceMock.getAllowedSidebarActions.and.returnValue(of(mockAspectActions));
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(component.aspectActions).toEqual(mockAspectActions);
+    });
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -133,7 +133,7 @@ describe('DetailsComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([node]));
   });
 
-  it('should call updateNodeAspects when the button is clicked', () => {
+  it('should call updateNodeAspects when the aspect dialog is opened', () => {
     component.openAspectDialog();
     fixture.detectChanges();
     expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -55,7 +55,6 @@ describe('DetailsComponent', () => {
 
   const mockAspectActions = [];
 
-  // Mock the observable returned by getAllowedSidebarActions
   const mockObservable = new BehaviorSubject(mockAspectActions);
   extensionsServiceMock.getAllowedSidebarActions.and.returnValue(mockObservable);
 

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -31,10 +31,10 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { NodeEntry } from '@alfresco/js-api';
+import { MinimalNodeEntryEntity, NodeEntry } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, PageTitleService } from '@alfresco/adf-core';
-import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { NodeAspectService, SearchQueryBuilderService } from '@alfresco/adf-content-services';
 
 describe('DetailsComponent', () => {
   let component: DetailsComponent;
@@ -42,6 +42,7 @@ describe('DetailsComponent', () => {
   let contentApiService: ContentApiService;
   let store: Store;
   let node: NodeEntry;
+  let mockNodeAspectService: jasmine.SpyObj<NodeAspectService>;
 
   const mockStream = new Subject();
   const storeMock = {
@@ -50,6 +51,7 @@ describe('DetailsComponent', () => {
   };
 
   beforeEach(() => {
+    const nodeAspectServiceSpy = jasmine.createSpyObj('NodeAspectService', ['updateNodeAspects']);
     TestBed.configureTestingModule({
       imports: [AppTestingModule, DetailsComponent],
       providers: [
@@ -78,6 +80,10 @@ describe('DetailsComponent', () => {
             onLogout: new Subject<any>(),
             isLoggedIn: () => true
           }
+        },
+        {
+          provide: NodeAspectService,
+          useValue: nodeAspectServiceSpy
         }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -86,6 +92,8 @@ describe('DetailsComponent', () => {
     fixture = TestBed.createComponent(DetailsComponent);
     component = fixture.componentInstance;
     contentApiService = TestBed.inject(ContentApiService);
+    mockNodeAspectService = TestBed.inject(NodeAspectService) as jasmine.SpyObj<NodeAspectService>;
+    component.node = { id: 'test-id' } as MinimalNodeEntryEntity;
     store = TestBed.inject(Store);
 
     node = {
@@ -127,5 +135,11 @@ describe('DetailsComponent', () => {
   it('should dispatch node selection', () => {
     fixture.detectChanges();
     expect(store.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([node]));
+  });
+
+  it('should call openAspectDialog and updateNodeAspects when the button is clicked', () => {
+    component.openAspectDialog();
+    fixture.detectChanges();
+    expect(mockNodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -31,7 +31,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { MinimalNodeEntryEntity, NodeEntry } from '@alfresco/js-api';
+import { Node, NodeEntry } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, PageTitleService } from '@alfresco/adf-core';
 import { NodeAspectService, SearchQueryBuilderService } from '@alfresco/adf-content-services';
@@ -88,7 +88,7 @@ describe('DetailsComponent', () => {
     component = fixture.componentInstance;
     contentApiService = TestBed.inject(ContentApiService);
     nodeAspectService = TestBed.inject(NodeAspectService);
-    component.node = { id: 'test-id' } as MinimalNodeEntryEntity;
+    component.node = { id: 'test-id' } as Node;
     store = TestBed.inject(Store);
 
     node = {
@@ -106,7 +106,7 @@ describe('DetailsComponent', () => {
       }
     };
     spyOn(contentApiService, 'getNode').and.returnValue(of(node));
-    spyOn(nodeAspectService, 'updateNodeAspects').and.callThrough();
+    spyOn(nodeAspectService, 'updateNodeAspects');
   });
 
   afterEach(() => {
@@ -137,5 +137,21 @@ describe('DetailsComponent', () => {
     component.openAspectDialog();
     fixture.detectChanges();
     expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('test-id');
+  });
+
+  it('should subscribe to store and update isNodeLocked', () => {
+    const mockSelection = { file: { entry: { name: 'test', properties: {}, isLocked: false } } };
+    spyOn(store, 'select').and.returnValue(of(mockSelection));
+    fixture.detectChanges();
+    expect(store.select).toHaveBeenCalled();
+    expect(component.isNodeLocked).toBe(false);
+  });
+
+  it('should unsubscribe from observables on component destroy', () => {
+    spyOn(component.onDestroy$, 'next');
+    spyOn(component.onDestroy$, 'complete');
+    fixture.detectChanges();
+    component.ngOnDestroy();
+    expect(component.onDestroy$.complete).toHaveBeenCalled();
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -65,7 +65,7 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
   isLoading: boolean;
   onDestroy$ = new Subject<boolean>();
   activeTab = 1;
-  actionsAspect: Array<ContentActionRef> = [];
+  aspectActions: Array<ContentActionRef> = [];
 
   constructor(private route: ActivatedRoute, private contentApi: ContentApiService) {
     super();
@@ -91,8 +91,8 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
     this.extensions
       .getAllowedSidebarActions()
       .pipe(takeUntil(this.onDestroy$))
-      .subscribe((actionsAspect) => {
-        this.actionsAspect = actionsAspect;
+      .subscribe((aspectActions) => {
+        this.aspectActions = aspectActions;
       });
   }
 

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit, ViewEncapsulation, OnDestroy, Input } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent, isLocked } from '@alfresco/aca-shared';
 import { NavigateToPreviousPage, SetSelectedNodesAction, getAppSelection } from '@alfresco/aca-shared/store';
@@ -38,6 +38,7 @@ import { MetadataTabComponent } from '../info-drawer/metadata-tab/metadata-tab.c
 import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.component';
 import { NodeActionsService } from '../../services/node-actions.service';
 import { NodeEntry } from '@alfresco/js-api';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   standalone: true,
@@ -61,9 +62,6 @@ import { NodeEntry } from '@alfresco/js-api';
   encapsulation: ViewEncapsulation.None
 })
 export class DetailsComponent extends PageComponent implements OnInit, OnDestroy {
-  @Input()
-  readOnly = false;
-
   nodeId: string;
   isLoading: boolean;
   onDestroy$ = new Subject<boolean>();
@@ -101,7 +99,7 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
     this.store.select(getAppSelection).subscribe(({ file }) => {
       this.selectionState = file;
       const isNodeLockedFromStore = this.selection && isLocked(this.selectionState);
-      this.nodeActionsService.isNodeLocked().subscribe((isNodeLockedFromService) => {
+      this.nodeActionsService.isNodeLocked$.pipe(takeUntil(this.onDestroy$)).subscribe((isNodeLockedFromService) => {
         this.isNodeLocked = isNodeLockedFromStore || isNodeLockedFromService;
       });
     });

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent, isLocked } from '@alfresco/aca-shared';
 import { NavigateToPreviousPage, SetSelectedNodesAction, getAppSelection } from '@alfresco/aca-shared/store';
@@ -67,13 +67,14 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
   onDestroy$ = new Subject<boolean>();
   activeTab = 1;
   selectionState: NodeEntry;
-  isNodeLocked: boolean;
+  isNodeLocked = false;
 
   constructor(
     private route: ActivatedRoute,
     private contentApi: ContentApiService,
     private nodeAspectService: NodeAspectService,
-    private nodeActionsService: NodeActionsService
+    private nodeActionsService: NodeActionsService,
+    private cdr: ChangeDetectorRef
   ) {
     super();
   }
@@ -95,12 +96,12 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
         this.store.dispatch(new SetSelectedNodesAction([{ entry: this.node }]));
       });
     });
-
     this.store.select(getAppSelection).subscribe(({ file }) => {
       this.selectionState = file;
       const isNodeLockedFromStore = this.selection && isLocked(this.selectionState);
       this.nodeActionsService.isNodeLocked$.pipe(takeUntil(this.onDestroy$)).subscribe((isNodeLockedFromService) => {
         this.isNodeLocked = isNodeLockedFromStore || isNodeLockedFromService;
+        this.cdr.detectChanges();
       });
     });
   }

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -22,12 +22,12 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, OnDestroy, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent } from '@alfresco/aca-shared';
 import { NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { Subject } from 'rxjs';
-import { BreadcrumbModule, PermissionManagerModule } from '@alfresco/adf-content-services';
+import { BreadcrumbModule, PermissionManagerModule, NodeAspectService } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
@@ -59,12 +59,17 @@ import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.c
   encapsulation: ViewEncapsulation.None
 })
 export class DetailsComponent extends PageComponent implements OnInit, OnDestroy {
+  @Input()
+  readOnly = false;
+
   nodeId: string;
   isLoading: boolean;
   onDestroy$ = new Subject<boolean>();
   activeTab = 1;
+  editAspectSupported = false;
+  hasAllowableOperations = false;
 
-  constructor(private route: ActivatedRoute, private contentApi: ContentApiService) {
+  constructor(private route: ActivatedRoute, private contentApi: ContentApiService, private nodeAspectService: NodeAspectService) {
     super();
   }
 
@@ -103,6 +108,10 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
 
   goBack() {
     this.store.dispatch(new NavigateToPreviousPage());
+  }
+
+  openAspectDialog() {
+    this.nodeAspectService.updateNodeAspects(this.node.id);
   }
 
   ngOnDestroy(): void {

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -22,12 +22,12 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, OnInit, ViewEncapsulation, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent, isLocked } from '@alfresco/aca-shared';
-import { NavigateToPreviousPage, SetSelectedNodesAction, getAppSelection } from '@alfresco/aca-shared/store';
+import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent } from '@alfresco/aca-shared';
+import { NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { Subject } from 'rxjs';
-import { BreadcrumbModule, PermissionManagerModule, NodeAspectService } from '@alfresco/adf-content-services';
+import { BreadcrumbModule, PermissionManagerModule } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
@@ -36,9 +36,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
 import { MetadataTabComponent } from '../info-drawer/metadata-tab/metadata-tab.component';
 import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.component';
-import { NodeActionsService } from '../../services/node-actions.service';
-import { NodeEntry } from '@alfresco/js-api';
 import { takeUntil } from 'rxjs/operators';
+import { ContentActionRef } from '@alfresco/adf-extensions';
 
 @Component({
   standalone: true,
@@ -66,16 +65,9 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
   isLoading: boolean;
   onDestroy$ = new Subject<boolean>();
   activeTab = 1;
-  selectionState: NodeEntry;
-  isNodeLocked = false;
+  actionsAspect: Array<ContentActionRef> = [];
 
-  constructor(
-    private route: ActivatedRoute,
-    private contentApi: ContentApiService,
-    private nodeAspectService: NodeAspectService,
-    private nodeActionsService: NodeActionsService,
-    private cdr: ChangeDetectorRef
-  ) {
+  constructor(private route: ActivatedRoute, private contentApi: ContentApiService) {
     super();
   }
 
@@ -96,14 +88,12 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
         this.store.dispatch(new SetSelectedNodesAction([{ entry: this.node }]));
       });
     });
-    this.store.select(getAppSelection).subscribe(({ file }) => {
-      this.selectionState = file;
-      const isNodeLockedFromStore = this.selection && isLocked(this.selectionState);
-      this.nodeActionsService.isNodeLocked$.pipe(takeUntil(this.onDestroy$)).subscribe((isNodeLockedFromService) => {
-        this.isNodeLocked = isNodeLockedFromStore || isNodeLockedFromService;
-        this.cdr.detectChanges();
+    this.extensions
+      .getAllowedSidebarActions()
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((actionsAspect) => {
+        this.actionsAspect = actionsAspect;
       });
-    });
   }
 
   setActiveTab(tabName: string) {
@@ -122,10 +112,6 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
 
   goBack() {
     this.store.dispatch(new NavigateToPreviousPage());
-  }
-
-  openAspectDialog() {
-    this.nodeAspectService.updateNodeAspects(this.node.id);
   }
 
   ngOnDestroy(): void {

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.spec.ts
@@ -256,7 +256,7 @@ describe('MetadataTabComponent', () => {
     });
 
     it('show pass empty when store is in initial state', () => {
-      const initialState = fixture.debugElement.query(By.css('adf-content-metadata-card'));
+      const initialState = fixture.debugElement.query(By.css('adf-content-metadata'));
       expect(initialState.componentInstance.displayAspect).toBeFalsy();
     });
 
@@ -266,7 +266,7 @@ describe('MetadataTabComponent', () => {
         expect(aspect).toBe('EXIF');
       });
       fixture.detectChanges();
-      const initialState = fixture.debugElement.query(By.css('adf-content-metadata-card'));
+      const initialState = fixture.debugElement.query(By.css('adf-content-metadata'));
       expect(initialState.componentInstance.displayAspect).toBe('EXIF');
     });
   });

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -49,6 +49,7 @@ import { Actions, ofType } from '@ngrx/effects';
       [(editable)]="editable"
       [(editableTags)]="editableTags"
       [(editableCategories)]="editableCategories"
+      [(group)]="group"
     >
     </adf-content-metadata>
   `,
@@ -65,6 +66,9 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
   editable = false;
   editableTags = false;
   editableCategories = false;
+  group: any = {
+    editable: false
+  };
 
   constructor(
     private permission: NodePermissionService,
@@ -98,6 +102,7 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
           this.editable = false;
           this.editableTags = false;
           this.editableCategories = false;
+          this.group.editable = false;
         }
       });
   }

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -39,14 +39,16 @@ import { Actions, ofType } from '@ngrx/effects';
   imports: [CommonModule, ContentMetadataModule],
   selector: 'app-metadata-tab',
   template: `
-    <adf-content-metadata-card
+    <adf-content-metadata
       [readOnly]="!canUpdateNode"
       [preset]="'custom'"
       [node]="node"
       [displayAspect]="displayAspect$ | async"
+      [displayTags]="displayTags"
+      [displayCategories]="displayCategories"
       [(editable)]="editable"
     >
-    </adf-content-metadata-card>
+    </adf-content-metadata>
   `,
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-metadata-tab' }
@@ -56,6 +58,14 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
 
   @Input()
   node: Node;
+
+  /** Display tags in the card **/
+  @Input()
+  displayTags = true;
+
+  /** Display categories in the card **/
+  @Input()
+  displayCategories = true;
 
   displayAspect$: Observable<string>;
   canUpdateNode = false;

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -44,8 +44,8 @@ import { Actions, ofType } from '@ngrx/effects';
       [preset]="'custom'"
       [node]="node"
       [displayAspect]="displayAspect$ | async"
-      [displayTags]="displayTags"
-      [displayCategories]="displayCategories"
+      [displayTags]="true"
+      [displayCategories]="true"
       [(editable)]="editable"
       [(editableTags)]="editableTags"
       [(editableCategories)]="editableCategories"
@@ -57,17 +57,8 @@ import { Actions, ofType } from '@ngrx/effects';
 })
 export class MetadataTabComponent implements OnInit, OnDestroy {
   protected onDestroy$ = new Subject<boolean>();
-
   @Input()
   node: Node;
-
-  /** Display tags in the card **/
-  @Input()
-  displayTags = true;
-
-  /** Display categories in the card **/
-  @Input()
-  displayCategories = true;
 
   displayAspect$: Observable<string>;
   canUpdateNode = false;

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -29,7 +29,7 @@ import { AppStore, EditOfflineAction, infoDrawerMetadataAspect, NodeActionTypes 
 import { AppConfigService, NotificationService } from '@alfresco/adf-core';
 import { Observable, Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { ContentMetadataModule, ContentMetadataService } from '@alfresco/adf-content-services';
+import { CardViewGroup, ContentMetadataModule, ContentMetadataService } from '@alfresco/adf-content-services';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { Actions, ofType } from '@ngrx/effects';
@@ -49,6 +49,7 @@ import { Actions, ofType } from '@ngrx/effects';
       [(editable)]="editable"
       [(editableTags)]="editableTags"
       [(editableCategories)]="editableCategories"
+      [(group)]="group"
     >
     </adf-content-metadata>
   `,
@@ -65,6 +66,7 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
   editable = false;
   editableTags = false;
   editableCategories = false;
+  group: CardViewGroup;
 
   constructor(
     private permission: NodePermissionService,
@@ -98,6 +100,7 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
           this.editable = false;
           this.editableTags = false;
           this.editableCategories = false;
+          this.group.editable = false;
         }
       });
   }

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -47,6 +47,8 @@ import { Actions, ofType } from '@ngrx/effects';
       [displayTags]="displayTags"
       [displayCategories]="displayCategories"
       [(editable)]="editable"
+      [(editableTags)]="editableTags"
+      [(editableCategories)]="editableCategories"
     >
     </adf-content-metadata>
   `,
@@ -70,6 +72,8 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
   displayAspect$: Observable<string>;
   canUpdateNode = false;
   editable = false;
+  editableTags = false;
+  editableCategories = false;
 
   constructor(
     private permission: NodePermissionService,
@@ -101,6 +105,8 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
         this.checkIfNodeIsUpdatable(updatedNode?.payload.entry);
         if (!this.canUpdateNode) {
           this.editable = false;
+          this.editableTags = false;
+          this.editableCategories = false;
         }
       });
   }

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -29,7 +29,7 @@ import { AppStore, EditOfflineAction, infoDrawerMetadataAspect, NodeActionTypes 
 import { AppConfigService, NotificationService } from '@alfresco/adf-core';
 import { Observable, Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { CardViewGroup, ContentMetadataModule, ContentMetadataService } from '@alfresco/adf-content-services';
+import { ContentMetadataModule, ContentMetadataService } from '@alfresco/adf-content-services';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { Actions, ofType } from '@ngrx/effects';
@@ -49,7 +49,6 @@ import { Actions, ofType } from '@ngrx/effects';
       [(editable)]="editable"
       [(editableTags)]="editableTags"
       [(editableCategories)]="editableCategories"
-      [(group)]="group"
     >
     </adf-content-metadata>
   `,
@@ -66,7 +65,6 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
   editable = false;
   editableTags = false;
   editableCategories = false;
-  group: CardViewGroup;
 
   constructor(
     private permission: NodePermissionService,
@@ -100,7 +98,6 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
           this.editable = false;
           this.editableTags = false;
           this.editableCategories = false;
-          this.group.editable = false;
         }
       });
   }

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
@@ -29,6 +29,7 @@ import { Store } from '@ngrx/store';
 import { NodeEntry } from '@alfresco/js-api';
 import { DownloadNodesAction, EditOfflineAction, SnackbarErrorAction } from '@alfresco/aca-shared/store';
 import { AppTestingModule } from '../../../testing/app-testing.module';
+import { AppExtensionService } from '@alfresco/aca-shared';
 
 describe('ToggleEditOfflineComponent', () => {
   let fixture: ComponentFixture<ToggleEditOfflineComponent>;
@@ -37,6 +38,10 @@ describe('ToggleEditOfflineComponent', () => {
   let dispatchSpy: jasmine.Spy;
   let selectSpy: jasmine.Spy;
   let selection: any;
+
+  const extensionsMock = {
+    updateSidebarActions: jasmine.createSpy('updateSidebarActions')
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -48,6 +53,10 @@ describe('ToggleEditOfflineComponent', () => {
             select: () => {},
             dispatch: () => {}
           }
+        },
+        {
+          provide: AppExtensionService,
+          useValue: extensionsMock
         }
       ]
     });
@@ -132,5 +141,15 @@ describe('ToggleEditOfflineComponent', () => {
         fileName: 'test'
       })
     ]);
+  });
+
+  it('should call updateSidebarActions on click', async () => {
+    selectSpy.and.returnValue(of(selection));
+    fixture.detectChanges();
+
+    await component.onClick();
+    fixture.detectChanges();
+
+    expect(extensionsMock.updateSidebarActions).toHaveBeenCalled();
   });
 });

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
@@ -26,10 +26,9 @@ import { ToggleEditOfflineComponent } from './toggle-edit-offline.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { NodeEntry, NodesApi } from '@alfresco/js-api';
+import { NodeEntry } from '@alfresco/js-api';
 import { DownloadNodesAction, EditOfflineAction, SnackbarErrorAction } from '@alfresco/aca-shared/store';
 import { AppTestingModule } from '../../../testing/app-testing.module';
-import { NodeActionsService } from '../../../services/node-actions.service';
 
 describe('ToggleEditOfflineComponent', () => {
   let fixture: ComponentFixture<ToggleEditOfflineComponent>;
@@ -38,49 +37,6 @@ describe('ToggleEditOfflineComponent', () => {
   let dispatchSpy: jasmine.Spy;
   let selectSpy: jasmine.Spy;
   let selection: any;
-
-  const lockedNodeEntry: NodeEntry = {
-    entry: {
-      isFile: true,
-      createdByUser: {
-        id: 'hruser',
-        displayName: 'hruser'
-      },
-      modifiedAt: new Date('2023-09-08T11:54:48.325+0000'),
-      nodeType: 'cm:content',
-      content: {
-        mimeType: 'image/jpeg',
-        mimeTypeName: 'JPEG Image',
-        sizeInBytes: 128473,
-        encoding: 'UTF-8'
-      },
-      parentId: '5a2d88ec-a29c-408a-874d-6394940c51d7',
-      aspectNames: ['cm:versionable', 'cm:lockable', 'cm:auditable', 'cm:taggable', 'exif:exif'],
-      createdAt: new Date('2023-09-07T11:10:48.788+0000'),
-      isFolder: false,
-      modifiedByUser: {
-        id: 'hruser',
-        displayName: 'hruser'
-      },
-      name: 'e2e_favorite_file.jpg',
-      id: '36e5b5ad-3fa0-47e2-b256-016b868ac772',
-      properties: {
-        'cm:lockType': 'WRITE_LOCK',
-        'cm:lockOwner': {
-          id: 'hruser',
-          displayName: 'hruser'
-        },
-        'cm:versionType': 'MAJOR',
-        'cm:versionLabel': '1.0',
-        'cm:lockLifetime': 'PERSISTENT',
-        'exif:pixelYDimension': 1253,
-        'exif:pixelXDimension': 1024
-      }
-    }
-  };
-
-  const nodesApiMock = jasmine.createSpyObj('nodesApi', ['lockNode', 'unlockNode']);
-  const nodeActionsServiceMock = jasmine.createSpyObj('nodeActionsService', ['setNodeLocked']);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -92,9 +48,7 @@ describe('ToggleEditOfflineComponent', () => {
             select: () => {},
             dispatch: () => {}
           }
-        },
-        { provide: NodesApi, useValue: nodesApiMock },
-        { provide: NodeActionsService, useValue: nodeActionsServiceMock }
+        }
       ]
     });
 
@@ -178,52 +132,5 @@ describe('ToggleEditOfflineComponent', () => {
         fileName: 'test'
       })
     ]);
-  });
-
-  it('should call setNodeLocked with true when a node is locked', () => {
-    const nodeId = 'testNode1';
-    nodesApiMock.lockNode.and.returnValue(Promise.resolve(lockedNodeEntry));
-
-    component.lockNode(nodeId).then((result) => {
-      expect(nodesApiMock.lockNode).toHaveBeenCalledWith(nodeId, {
-        type: 'ALLOW_OWNER_CHANGES',
-        lifetime: 'PERSISTENT'
-      });
-      expect(nodeActionsServiceMock.setNodeLocked).toHaveBeenCalledWith(true);
-      expect(result).toEqual(lockedNodeEntry);
-    });
-  });
-
-  it('should call setNodeLocked with false when a node is unlocked', () => {
-    const nodeId = 'testNode2';
-    nodesApiMock.unlockNode.and.returnValue(Promise.resolve(lockedNodeEntry));
-
-    component.unlockNode(nodeId).then((result) => {
-      expect(nodesApiMock.unlockNode).toHaveBeenCalledWith(nodeId);
-      expect(nodeActionsServiceMock.setNodeLocked).toHaveBeenCalledWith(false);
-      expect(result).toEqual(lockedNodeEntry);
-    });
-  });
-
-  it('should handle errors when locking a node encounters an error', () => {
-    const nodeId = 'testNode1';
-    const error = new Error('Locking failed');
-    nodesApiMock.lockNode.and.returnValue(Promise.reject(error));
-    component.lockNode(nodeId).catch((err) => {
-      expect(nodesApiMock.lockNode).toHaveBeenCalledWith(nodeId, { type: 'ALLOW_OWNER_CHANGES', lifetime: 'PERSISTENT' });
-      expect(nodeActionsServiceMock.setNodeLocked).not.toHaveBeenCalled();
-      expect(err).toEqual(error);
-    });
-  });
-
-  it('should handle errors when unlocking a node encounters an error', () => {
-    const nodeId = 'testNode1';
-    const error = new Error('Unlocking failed');
-    nodesApiMock.unlockNode.and.returnValue(Promise.reject(error));
-    component.unlockNode(nodeId).catch((err) => {
-      expect(nodesApiMock.lockNode).toHaveBeenCalledWith(nodeId);
-      expect(nodeActionsServiceMock.setNodeLocked).not.toHaveBeenCalled();
-      expect(err).toEqual(error);
-    });
   });
 });

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -31,7 +31,7 @@ import {
   getAppSelection
 } from '@alfresco/aca-shared/store';
 import { NodeEntry, SharedLinkEntry, Node, NodesApi } from '@alfresco/js-api';
-import { ChangeDetectorRef, Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppExtensionService, isLocked } from '@alfresco/aca-shared';
 import { AlfrescoApiService } from '@alfresco/adf-core';
@@ -39,7 +39,6 @@ import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
-import { NodeActionsService } from '../../../services/node-actions.service';
 
 @Component({
   standalone: true,
@@ -60,13 +59,7 @@ export class ToggleEditOfflineComponent implements OnInit {
   nodeTitle = '';
   isNodeLocked = false;
 
-  constructor(
-    private store: Store<AppStore>,
-    private alfrescoApiService: AlfrescoApiService,
-    private nodeActionsService: NodeActionsService,
-    private cdr: ChangeDetectorRef,
-    private extensions: AppExtensionService
-  ) {
+  constructor(private store: Store<AppStore>, private alfrescoApiService: AlfrescoApiService, private extensions: AppExtensionService) {
     this.nodesApi = new NodesApi(this.alfrescoApiService.getInstance());
   }
 
@@ -75,7 +68,6 @@ export class ToggleEditOfflineComponent implements OnInit {
       this.selection = file;
       this.isNodeLocked = this.selection && isLocked(this.selection);
       this.nodeTitle = this.isNodeLocked ? 'APP.ACTIONS.EDIT_OFFLINE_CANCEL' : 'APP.ACTIONS.EDIT_OFFLINE';
-      this.cdr.detectChanges();
     });
   }
 
@@ -127,27 +119,15 @@ export class ToggleEditOfflineComponent implements OnInit {
     );
   }
 
-  lockNode(nodeId: string): Promise<NodeEntry> {
-    return this.nodesApi.lockNode(nodeId, { type: 'ALLOW_OWNER_CHANGES', lifetime: 'PERSISTENT' }).then(
-      (res: NodeEntry) => {
-        this.nodeActionsService.setNodeLocked(true);
-        return res;
-      },
-      (error) => {
-        return error;
-      }
-    );
+  lockNode(nodeId: string) {
+    return this.nodesApi.lockNode(nodeId, {
+      type: 'ALLOW_OWNER_CHANGES',
+      lifetime: 'PERSISTENT'
+    });
   }
-  unlockNode(nodeId: string): Promise<NodeEntry> {
-    return this.nodesApi.unlockNode(nodeId).then(
-      (res: NodeEntry) => {
-        this.nodeActionsService.setNodeLocked(false);
-        return res;
-      },
-      (error) => {
-        return error;
-      }
-    );
+
+  unlockNode(nodeId: string) {
+    return this.nodesApi.unlockNode(nodeId);
   }
 
   private update(data: Node) {

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -31,7 +31,7 @@ import {
   getAppSelection
 } from '@alfresco/aca-shared/store';
 import { NodeEntry, SharedLinkEntry, Node, NodesApi } from '@alfresco/js-api';
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { isLocked } from '@alfresco/aca-shared';
 import { AlfrescoApiService } from '@alfresco/adf-core';
@@ -60,7 +60,12 @@ export class ToggleEditOfflineComponent implements OnInit {
   nodeTitle = '';
   isNodeLocked = false;
 
-  constructor(private store: Store<AppStore>, private alfrescoApiService: AlfrescoApiService, private nodeActionsService: NodeActionsService) {
+  constructor(
+    private store: Store<AppStore>,
+    private alfrescoApiService: AlfrescoApiService,
+    private nodeActionsService: NodeActionsService,
+    private cdr: ChangeDetectorRef
+  ) {
     this.nodesApi = new NodesApi(this.alfrescoApiService.getInstance());
   }
 
@@ -69,6 +74,7 @@ export class ToggleEditOfflineComponent implements OnInit {
       this.selection = file;
       this.isNodeLocked = this.selection && isLocked(this.selection);
       this.nodeTitle = this.isNodeLocked ? 'APP.ACTIONS.EDIT_OFFLINE_CANCEL' : 'APP.ACTIONS.EDIT_OFFLINE';
+      this.cdr.detectChanges();
     });
   }
 

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -33,7 +33,7 @@ import {
 import { NodeEntry, SharedLinkEntry, Node, NodesApi } from '@alfresco/js-api';
 import { ChangeDetectorRef, Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { isLocked } from '@alfresco/aca-shared';
+import { AppExtensionService, isLocked } from '@alfresco/aca-shared';
 import { AlfrescoApiService } from '@alfresco/adf-core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
@@ -64,7 +64,8 @@ export class ToggleEditOfflineComponent implements OnInit {
     private store: Store<AppStore>,
     private alfrescoApiService: AlfrescoApiService,
     private nodeActionsService: NodeActionsService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private extensions: AppExtensionService
   ) {
     this.nodesApi = new NodesApi(this.alfrescoApiService.getInstance());
   }
@@ -80,6 +81,7 @@ export class ToggleEditOfflineComponent implements OnInit {
 
   async onClick() {
     await this.toggleLock(this.selection);
+    this.extensions.updateSidebarActions();
   }
 
   private async toggleLock(node: NodeEntry | SharedLinkEntry) {

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -125,17 +125,27 @@ export class ToggleEditOfflineComponent implements OnInit {
     );
   }
 
-  lockNode(nodeId: string) {
-    this.nodeActionsService.setNodeLocked(true);
-    return this.nodesApi.lockNode(nodeId, {
-      type: 'ALLOW_OWNER_CHANGES',
-      lifetime: 'PERSISTENT'
-    });
+  lockNode(nodeId: string): Promise<NodeEntry> {
+    return this.nodesApi.lockNode(nodeId, { type: 'ALLOW_OWNER_CHANGES', lifetime: 'PERSISTENT' }).then(
+      (res: NodeEntry) => {
+        this.nodeActionsService.setNodeLocked(true);
+        return res;
+      },
+      (error) => {
+        return error;
+      }
+    );
   }
-
-  unlockNode(nodeId: string) {
-    this.nodeActionsService.setNodeLocked(false);
-    return this.nodesApi.unlockNode(nodeId);
+  unlockNode(nodeId: string): Promise<NodeEntry> {
+    return this.nodesApi.unlockNode(nodeId).then(
+      (res: NodeEntry) => {
+        this.nodeActionsService.setNodeLocked(false);
+        return res;
+      },
+      (error) => {
+        return error;
+      }
+    );
   }
 
   private update(data: Node) {

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -39,6 +39,7 @@ import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
+import { NodeActionsService } from '../../../services/node-actions.service';
 
 @Component({
   standalone: true,
@@ -59,7 +60,7 @@ export class ToggleEditOfflineComponent implements OnInit {
   nodeTitle = '';
   isNodeLocked = false;
 
-  constructor(private store: Store<AppStore>, private alfrescoApiService: AlfrescoApiService) {
+  constructor(private store: Store<AppStore>, private alfrescoApiService: AlfrescoApiService, private nodeActionsService: NodeActionsService) {
     this.nodesApi = new NodesApi(this.alfrescoApiService.getInstance());
   }
 
@@ -119,6 +120,7 @@ export class ToggleEditOfflineComponent implements OnInit {
   }
 
   lockNode(nodeId: string) {
+    this.nodeActionsService.setNodeLocked(true);
     return this.nodesApi.lockNode(nodeId, {
       type: 'ALLOW_OWNER_CHANGES',
       lifetime: 'PERSISTENT'
@@ -126,6 +128,7 @@ export class ToggleEditOfflineComponent implements OnInit {
   }
 
   unlockNode(nodeId: string) {
+    this.nodeActionsService.setNodeLocked(false);
     return this.nodesApi.unlockNode(nodeId);
   }
 

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -24,7 +24,7 @@
 
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, Subject, of, zip, from, BehaviorSubject } from 'rxjs';
+import { Observable, Subject, of, zip, from } from 'rxjs';
 import { AlfrescoApiService, TranslationService, ThumbnailService } from '@alfresco/adf-core';
 import {
   DocumentListService,
@@ -49,7 +49,6 @@ export class NodeActionsService {
   contentMoved: Subject<any> = new Subject<any>();
   moveDeletedEntries: any[] = [];
   isSitesDestinationAvailable = false;
-  private isNodeLockedSubject = new BehaviorSubject<boolean>(false);
   isNodeLocked$: Observable<any>;
 
   _nodesApi: NodesApi;
@@ -66,9 +65,7 @@ export class NodeActionsService {
     private apiService: AlfrescoApiService,
     private translation: TranslationService,
     private thumbnailService: ThumbnailService
-  ) {
-    this.isNodeLocked$ = this.isNodeLockedSubject.asObservable();
-  }
+  ) {}
 
   /**
    * Copy node list
@@ -90,10 +87,6 @@ export class NodeActionsService {
    */
   moveNodes(contentEntities: any[], permission?: string, focusedElementOnCloseSelector?: string): Subject<string> {
     return this.doBatchOperation(NodeAction.MOVE, contentEntities, permission, focusedElementOnCloseSelector);
-  }
-
-  setNodeLocked(isLocked: boolean) {
-    this.isNodeLockedSubject.next(isLocked);
   }
 
   /**

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -24,7 +24,7 @@
 
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, Subject, of, zip, from } from 'rxjs';
+import { Observable, Subject, of, zip, from, BehaviorSubject } from 'rxjs';
 import { AlfrescoApiService, TranslationService, ThumbnailService } from '@alfresco/adf-core';
 import {
   DocumentListService,
@@ -49,6 +49,7 @@ export class NodeActionsService {
   contentMoved: Subject<any> = new Subject<any>();
   moveDeletedEntries: any[] = [];
   isSitesDestinationAvailable = false;
+  private isNodeLockedSubject: BehaviorSubject<boolean>;
 
   _nodesApi: NodesApi;
   get nodesApi(): NodesApi {
@@ -64,7 +65,9 @@ export class NodeActionsService {
     private apiService: AlfrescoApiService,
     private translation: TranslationService,
     private thumbnailService: ThumbnailService
-  ) {}
+  ) {
+    this.isNodeLockedSubject = new BehaviorSubject<boolean>(false);
+  }
 
   /**
    * Copy node list
@@ -86,6 +89,14 @@ export class NodeActionsService {
    */
   moveNodes(contentEntities: any[], permission?: string, focusedElementOnCloseSelector?: string): Subject<string> {
     return this.doBatchOperation(NodeAction.MOVE, contentEntities, permission, focusedElementOnCloseSelector);
+  }
+
+  setNodeLocked(isLocked: boolean) {
+    this.isNodeLockedSubject.next(isLocked);
+  }
+
+  isNodeLocked(): Observable<boolean> {
+    return this.isNodeLockedSubject.asObservable();
   }
 
   /**

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -49,7 +49,6 @@ export class NodeActionsService {
   contentMoved: Subject<any> = new Subject<any>();
   moveDeletedEntries: any[] = [];
   isSitesDestinationAvailable = false;
-  isNodeLocked$: Observable<any>;
 
   _nodesApi: NodesApi;
   get nodesApi(): NodesApi {

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -49,7 +49,8 @@ export class NodeActionsService {
   contentMoved: Subject<any> = new Subject<any>();
   moveDeletedEntries: any[] = [];
   isSitesDestinationAvailable = false;
-  private isNodeLockedSubject: BehaviorSubject<boolean>;
+  private isNodeLockedSubject = new BehaviorSubject<boolean>(false);
+  isNodeLocked$: Observable<any>;
 
   _nodesApi: NodesApi;
   get nodesApi(): NodesApi {
@@ -66,7 +67,7 @@ export class NodeActionsService {
     private translation: TranslationService,
     private thumbnailService: ThumbnailService
   ) {
-    this.isNodeLockedSubject = new BehaviorSubject<boolean>(false);
+    this.isNodeLocked$ = this.isNodeLockedSubject.asObservable();
   }
 
   /**
@@ -93,10 +94,6 @@ export class NodeActionsService {
 
   setNodeLocked(isLocked: boolean) {
     this.isNodeLockedSubject.next(isLocked);
-  }
-
-  isNodeLocked(): Observable<boolean> {
-    return this.isNodeLockedSubject.asObservable();
   }
 
   /**

--- a/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
+++ b/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
@@ -14,7 +14,7 @@
 }
 
 .adf-info-drawer-layout-content .app-metadata-tab .adf-metadata-properties .mat-expansion-panel {
-  border: 1px solid var(--adf-metadata-property-panel-border-color);
+  border: 1px solid var(--theme-metadata-property-panel-border-color);
   border-radius: 12px;
   margin-bottom: 12px;
 }
@@ -24,7 +24,7 @@
     .adf-metadata-properties {
       .mat-expansion-panel {
         width: 755px;
-        border: 1px solid var(--adf-metadata-property-panel-border-color);
+        border: 1px solid var(--theme-metadata-property-panel-border-color);
         margin: 24px;
         border-radius: 12px;
       }

--- a/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
+++ b/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
@@ -12,3 +12,22 @@
     }
   }
 }
+
+.adf-info-drawer-layout-content .app-metadata-tab .adf-metadata-properties .mat-expansion-panel {
+  border: 1px solid var(--adf-metadata-property-panel-border-color);
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+
+.acs-details-container {
+  .mat-tab-body-content {
+    .adf-metadata-properties {
+      .mat-expansion-panel {
+        width: 755px;
+        border: 1px solid var(--adf-metadata-property-panel-border-color);
+        margin: 24px;
+        border-radius: 12px;
+      }
+    }
+  }
+}

--- a/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
+++ b/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
@@ -27,6 +27,10 @@
         border: 1px solid var(--theme-metadata-property-panel-border-color);
         margin: 24px;
         border-radius: 12px;
+
+        .adf-metadata-properties-group-title {
+          width: 548px;
+        }
       }
     }
   }

--- a/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
+++ b/projects/aca-content/src/lib/ui/overrides/adf-style-fixes.theme.scss
@@ -17,6 +17,10 @@
   border: 1px solid var(--theme-metadata-property-panel-border-color);
   border-radius: 12px;
   margin-bottom: 12px;
+
+  .mat-expansion-panel-header {
+    border-radius: 12px;
+  }
 }
 
 .acs-details-container {
@@ -27,6 +31,10 @@
         border: 1px solid var(--theme-metadata-property-panel-border-color);
         margin: 24px;
         border-radius: 12px;
+
+        .mat-expansion-panel-header {
+          border-radius: 12px;
+        }
 
         .adf-metadata-properties-group-title {
           width: 548px;

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -36,6 +36,8 @@ $page-layout-header-background-color: #fff;
 $search-chip-icon-color: #757575;
 $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: #646569;
+$adf-metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
+$adf-metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
 
 // CSS Variables
 $defaults: (
@@ -76,7 +78,9 @@ $defaults: (
   --theme-page-layout-header-background-color: $page-layout-header-background-color,
   --theme-search-chip-icon-color: $search-chip-icon-color,
   --theme-disabled-chip-background-color: $disabled-chip-background-color,
-  --theme-contrast-gray: $contrast-gray
+  --theme-contrast-gray: $contrast-gray,
+  --adf-metadata-property-panel-border-color: $adf-metadata-property-panel-border-color,
+  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -38,6 +38,7 @@ $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: #646569;
 $metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
 $metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
+$metadata-action-button-clear-color: #212328b2;
 
 // CSS Variables
 $defaults: (
@@ -80,7 +81,8 @@ $defaults: (
   --theme-disabled-chip-background-color: $disabled-chip-background-color,
   --theme-contrast-gray: $contrast-gray,
   --theme-metadata-property-panel-border-color: $metadata-property-panel-border-color,
-  --theme-metadata-buttons-background-color: $metadata-buttons-background-color
+  --theme-metadata-buttons-background-color: $metadata-buttons-background-color,
+  --theme-metadata-action-button-clear-color: $metadata-action-button-clear-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -38,8 +38,6 @@ $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: #646569;
 $adf-metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
 $adf-metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
-$adf-snackbar-message-background-color: #ba1b1b;
-$adf-snackbar-message-color: #f8f8f8;
 
 // CSS Variables
 $defaults: (
@@ -82,9 +80,7 @@ $defaults: (
   --theme-disabled-chip-background-color: $disabled-chip-background-color,
   --theme-contrast-gray: $contrast-gray,
   --adf-metadata-property-panel-border-color: $adf-metadata-property-panel-border-color,
-  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color,
-  --adf-snackbar-message-background-color: $adf-snackbar-message-background-color,
-  --adf-snackbar-message-color: $adf-snackbar-message-color
+  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -36,8 +36,8 @@ $page-layout-header-background-color: #fff;
 $search-chip-icon-color: #757575;
 $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: #646569;
-$adf-metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
-$adf-metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
+$metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
+$metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
 
 // CSS Variables
 $defaults: (
@@ -79,8 +79,8 @@ $defaults: (
   --theme-search-chip-icon-color: $search-chip-icon-color,
   --theme-disabled-chip-background-color: $disabled-chip-background-color,
   --theme-contrast-gray: $contrast-gray,
-  --adf-metadata-property-panel-border-color: $adf-metadata-property-panel-border-color,
-  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color
+  --theme-metadata-property-panel-border-color: $metadata-property-panel-border-color,
+  --theme-metadata-buttons-background-color: $metadata-buttons-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -39,6 +39,7 @@ $contrast-gray: #646569;
 $adf-metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
 $adf-metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
 $adf-snackbar-message-background-color: #ba1b1b;
+$adf-snackbar-message-color: #f8f8f8;
 
 // CSS Variables
 $defaults: (
@@ -82,7 +83,8 @@ $defaults: (
   --theme-contrast-gray: $contrast-gray,
   --adf-metadata-property-panel-border-color: $adf-metadata-property-panel-border-color,
   --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color,
-  --adf-snackbar-message-background-color: $adf-snackbar-message-background-color
+  --adf-snackbar-message-background-color: $adf-snackbar-message-background-color,
+  --adf-snackbar-message-color: $adf-snackbar-message-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -38,6 +38,7 @@ $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: #646569;
 $adf-metadata-property-panel-border-color: rgba(0, 0, 0, 0.12);
 $adf-metadata-buttons-background-color: rgba(33, 33, 33, 0.05);
+$adf-snackbar-message-background-color: #ba1b1b;
 
 // CSS Variables
 $defaults: (
@@ -80,7 +81,8 @@ $defaults: (
   --theme-disabled-chip-background-color: $disabled-chip-background-color,
   --theme-contrast-gray: $contrast-gray,
   --adf-metadata-property-panel-border-color: $adf-metadata-property-panel-border-color,
-  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color
+  --adf-metadata-buttons-background-color: $adf-metadata-buttons-background-color,
+  --adf-snackbar-message-background-color: $adf-snackbar-message-background-color
 );
 
 // propagates SCSS variables into the CSS variables scope

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -121,6 +121,28 @@ describe('app.evaluators', () => {
     });
   });
 
+  describe('canShowExpand', () => {
+    it('should return false when isLibraries returns true', () => {
+      const context: any = {
+        navigation: {
+          url: '/libraries'
+        }
+      };
+
+      expect(app.canShowExpand(context)).toBe(false);
+    });
+
+    it('should return false when isDetails returns true', () => {
+      const context: any = {
+        navigation: {
+          url: '/details'
+        }
+      };
+
+      expect(app.canShowExpand(context)).toBe(false);
+    });
+  });
+
   describe('hasLockedFiles', () => {
     it('should return [false] if selection not present', () => {
       const context: any = {};

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -511,7 +511,7 @@ export const canEditAspects = (context: RuleContext): boolean =>
     repository.isMajorVersionAvailable(context, '7')
   ].every(Boolean);
 
-export const canNotShowExpand = (context: RuleContext): boolean => [!navigation.isLibraries(context), !navigation.isDetails(context)].every(Boolean);
+export const canShowExpand = (context: RuleContext): boolean => [!navigation.isLibraries(context), !navigation.isDetails(context)].every(Boolean);
 
 /**
  * Checks if user can manage permissions for the selected node.

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -511,6 +511,8 @@ export const canEditAspects = (context: RuleContext): boolean =>
     repository.isMajorVersionAvailable(context, '7')
   ].every(Boolean);
 
+export const canNotShowExpand = (context: RuleContext): boolean => [!navigation.isLibraries(context), !navigation.isDetails(context)].every(Boolean);
+
 /**
  * Checks if user can manage permissions for the selected node.
  * JSON ref: `canManagePermissions`

--- a/projects/aca-shared/rules/src/navigation.rules.spec.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.spec.ts
@@ -226,7 +226,7 @@ describe('navigation.evaluators', () => {
   });
 
   describe('isDetails', () => {
-    it('should return [true] if url ends with `/details`', () => {
+    it('should return true if url ends with `/details`', () => {
       const context: any = {
         navigation: {
           url: '/path/details'
@@ -236,7 +236,7 @@ describe('navigation.evaluators', () => {
       expect(app.isDetails(context)).toBe(true);
     });
 
-    it('should return [true] if url starts with `/details`', () => {
+    it('should return true if url starts with `/details`', () => {
       const context: any = {
         navigation: {
           url: '/details/path'
@@ -246,7 +246,7 @@ describe('navigation.evaluators', () => {
       expect(app.isDetails(context)).toBe(true);
     });
 
-    it('should return [true] if url includes with `/details`', () => {
+    it('should return true if url includes with `/details`', () => {
       const context: any = {
         navigation: {
           url: '/details/path'

--- a/projects/aca-shared/rules/src/navigation.rules.spec.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.spec.ts
@@ -225,6 +225,38 @@ describe('navigation.evaluators', () => {
     });
   });
 
+  describe('isDetails', () => {
+    it('should return [true] if url ends with `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: '/path/details'
+        }
+      };
+
+      expect(app.isDetails(context)).toBe(true);
+    });
+
+    it('should return [true] if url starts with `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: '/details/path'
+        }
+      };
+
+      expect(app.isDetails(context)).toBe(true);
+    });
+
+    it('should return [true] if url includes with `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: '/details/path'
+        }
+      };
+
+      expect(app.isDetails(context)).toBe(true);
+    });
+  });
+
   describe('isRecentFiles', () => {
     it('should return [true] if url starts with `/recent-files`', () => {
       const context: any = {

--- a/projects/aca-shared/rules/src/navigation.rules.spec.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.spec.ts
@@ -226,26 +226,6 @@ describe('navigation.evaluators', () => {
   });
 
   describe('isDetails', () => {
-    it('should return true if url ends with `/details`', () => {
-      const context: any = {
-        navigation: {
-          url: '/path/details'
-        }
-      };
-
-      expect(app.isDetails(context)).toBe(true);
-    });
-
-    it('should return true if url starts with `/details`', () => {
-      const context: any = {
-        navigation: {
-          url: '/details/path'
-        }
-      };
-
-      expect(app.isDetails(context)).toBe(true);
-    });
-
     it('should return true if url includes with `/details`', () => {
       const context: any = {
         navigation: {
@@ -254,6 +234,16 @@ describe('navigation.evaluators', () => {
       };
 
       expect(app.isDetails(context)).toBe(true);
+    });
+
+    it('should return false if url not includes with `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: '/path'
+        }
+      };
+
+      expect(app.isDetails(context)).toBe(false);
     });
   });
 

--- a/projects/aca-shared/rules/src/navigation.rules.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.ts
@@ -110,6 +110,11 @@ export function isLibraryContent(context: RuleContext): boolean {
   return url && (url.endsWith('/libraries') || url.includes('/libraries/') || url.startsWith('/search-libraries'));
 }
 
+export function isDetails(context: RuleContext): boolean {
+  const { url } = context.navigation;
+  return url && (url.endsWith('/details') || url.includes('/details/') || url.startsWith('/details'));
+}
+
 /**
  * Checks if the activated route is neither **Libraries** nor **Library Search Results**.
  * JSON ref: `app.navigation.isNotLibraries`

--- a/projects/aca-shared/rules/src/navigation.rules.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.ts
@@ -112,7 +112,7 @@ export function isLibraryContent(context: RuleContext): boolean {
 
 export function isDetails(context: RuleContext): boolean {
   const { url } = context.navigation;
-  return url && (url.endsWith('/details') || url.includes('/details/') || url.startsWith('/details'));
+  return url?.includes('/details');
 }
 
 /**

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -348,6 +348,10 @@ export class AppExtensionService implements RuleContext {
     };
   }
 
+  updateSidebarActions() {
+    this._sidebarActions.next(this.loader.getContentActions(this.config, 'features.sidebar.toolbar'));
+  }
+
   getCreateActions(): Observable<Array<ContentActionRef>> {
     return this._createActions.pipe(
       map((createActions) =>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
In the property panel, there is an aspect icon at the bottom.


**What is the new behaviour?**
In accordance with the design, we removed the footer of the property panel and moved the edit aspect icon to the top.
[screen-capture (16).webm](https://github.com/Alfresco/alfresco-content-app/assets/107834418/f870bfba-f73f-4a9b-8992-0347e5cf7e9c)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5540
https://github.com/Alfresco/alfresco-ng2-components/pull/8837 was a dependency of this PR.