### PR TITLE
[APPS-2171][APPS-2172] Replace from moment.js to date-fns in search-filter.test and search-results-file-folders.test

### DIFF
--- a/e2e/protractor/suites/search/search-filters.test.ts
+++ b/e2e/protractor/suites/search/search-filters.test.ts
@@ -34,8 +34,7 @@ import {
   SizeOperator
 } from '@alfresco/aca-testing-shared';
 import { BrowserActions } from '@alfresco/adf-testing';
-
-const moment = require('moment');
+import { addDays, format, subDays } from 'date-fns';
 
 describe('Search filters', () => {
   const random = Utils.random();
@@ -162,9 +161,9 @@ describe('Search filters', () => {
   });
 
   describe('Filter by Created date', () => {
-    const yesterday = moment().subtract(1, 'day').format('DD-MMM-YY');
-    const today = moment().format('DD-MMM-YY');
-    const future = moment().add(1, 'month').format('DD-MMM-YY');
+    const yesterday = format(subDays(new Date(), 1), 'dd-MMM-yy');
+    const today = format(new Date(), 'dd-MMM-yy');
+    const future = format(addDays(new Date(), 1), 'dd-MMM-yy');
 
     afterEach(async () => {
       await Utils.pressEscape();

--- a/e2e/protractor/suites/search/search-results-files-folders.test.ts
+++ b/e2e/protractor/suites/search/search-results-files-folders.test.ts
@@ -92,7 +92,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const fileEntry = await apis.user.nodes.getNodeById(fileId);
-    const modifiedDate = format(new Date(fileEntry.entry.modifiedAt), 'MMM d, yyyy, h:mm:ss A');
+    const modifiedDate = format(fileEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss A');
     const modifiedBy = fileEntry.entry.modifiedByUser.displayName;
     const size = fileEntry.entry.content.sizeInBytes;
 
@@ -114,7 +114,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const folderEntry = await apis.user.nodes.getNodeById(folderId);
-    const modifiedDate = format(new Date(folderEntry.entry.modifiedAt), 'MMM d, yyyy, h:mm:ss A');
+    const modifiedDate = format(folderEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss A');
     const modifiedBy = folderEntry.entry.modifiedByUser.displayName;
 
     expect(await dataTable.isItemPresent(folder)).toBe(true, `${folder} is not displayed`);

--- a/e2e/protractor/suites/search/search-results-files-folders.test.ts
+++ b/e2e/protractor/suites/search/search-results-files-folders.test.ts
@@ -92,7 +92,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const fileEntry = await apis.user.nodes.getNodeById(fileId);
-    const modifiedDate = format(fileEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss A');
+    const modifiedDate = format(fileEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss a..aa');
     const modifiedBy = fileEntry.entry.modifiedByUser.displayName;
     const size = fileEntry.entry.content.sizeInBytes;
 
@@ -114,7 +114,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const folderEntry = await apis.user.nodes.getNodeById(folderId);
-    const modifiedDate = format(folderEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss A');
+    const modifiedDate = format(folderEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss a..aa');
     const modifiedBy = folderEntry.entry.modifiedByUser.displayName;
 
     expect(await dataTable.isItemPresent(folder)).toBe(true, `${folder} is not displayed`);

--- a/e2e/protractor/suites/search/search-results-files-folders.test.ts
+++ b/e2e/protractor/suites/search/search-results-files-folders.test.ts
@@ -92,7 +92,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const fileEntry = await apis.user.nodes.getNodeById(fileId);
-    const modifiedDate = format(fileEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss a..aa');
+    const modifiedDate = format(fileEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss aa');
     const modifiedBy = fileEntry.entry.modifiedByUser.displayName;
     const size = fileEntry.entry.content.sizeInBytes;
 
@@ -114,7 +114,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const folderEntry = await apis.user.nodes.getNodeById(folderId);
-    const modifiedDate = format(folderEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss a..aa');
+    const modifiedDate = format(folderEntry.entry.modifiedAt, 'MMM d, yyyy, h:mm:ss aa');
     const modifiedBy = folderEntry.entry.modifiedByUser.displayName;
 
     expect(await dataTable.isItemPresent(folder)).toBe(true, `${folder} is not displayed`);

--- a/e2e/protractor/suites/search/search-results-files-folders.test.ts
+++ b/e2e/protractor/suites/search/search-results-files-folders.test.ts
@@ -23,7 +23,7 @@
  */
 
 import { AdminActions, LoginPage, SearchResultsPage, RepoClient, Utils } from '@alfresco/aca-testing-shared';
-const moment = require('moment');
+import { format } from 'date-fns';
 
 describe('Search results - files and folders', () => {
   const random = Utils.random();
@@ -92,7 +92,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const fileEntry = await apis.user.nodes.getNodeById(fileId);
-    const modifiedDate = moment(fileEntry.entry.modifiedAt).format('MMM D, YYYY, h:mm:ss A');
+    const modifiedDate = format(new Date(fileEntry.entry.modifiedAt), 'MMM d, yyyy, h:mm:ss A');
     const modifiedBy = fileEntry.entry.modifiedByUser.displayName;
     const size = fileEntry.entry.content.sizeInBytes;
 
@@ -114,7 +114,7 @@ describe('Search results - files and folders', () => {
     await dataTable.waitForBody();
 
     const folderEntry = await apis.user.nodes.getNodeById(folderId);
-    const modifiedDate = moment(folderEntry.entry.modifiedAt).format('MMM D, YYYY, h:mm:ss A');
+    const modifiedDate = format(new Date(folderEntry.entry.modifiedAt), 'MMM d, yyyy, h:mm:ss A');
     const modifiedBy = folderEntry.entry.modifiedByUser.displayName;
 
     expect(await dataTable.isItemPresent(folder)).toBe(true, `${folder} is not displayed`);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

search-filter.test and search-results-file-folders.test use moment.js

**What is the new behaviour?**

search-filter.test and search-results-file-folders.test's use of moment.js have been replaced to date-fns

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

This PR requires certain changes at the HXP environment as well. Should be merged keep them in cognisance.
**Other information**:
