### PR TITLE
[ACS-5988] - Details tab not opening in custom file preview

### DIFF
--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
@@ -29,7 +29,7 @@ import { OnDestroy, OnInit, OnChanges, ViewChild, SimpleChanges, Directive, inje
 import { Store } from '@ngrx/store';
 import { NodeEntry, Node, NodePaging } from '@alfresco/js-api';
 import { Observable, Subject, Subscription } from 'rxjs';
-import { takeUntil, map } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { DocumentBasePageService } from './document-base-page.service';
 import {
   AppStore,
@@ -90,7 +90,7 @@ export abstract class PageComponent implements OnInit, OnDestroy, OnChanges {
       });
 
     this.sharedPreviewUrl$ = this.store.select(getSharedUrl);
-    this.infoDrawerOpened$ = this.store.select(isInfoDrawerOpened).pipe(map((infoDrawerState) => !this.isOutletPreviewUrl() && infoDrawerState));
+    this.infoDrawerOpened$ = this.store.select(isInfoDrawerOpened);
 
     this.store
       .select(getAppSelection)

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
@@ -355,13 +355,13 @@ describe('Info Drawer state', () => {
     });
   });
 
-  it('should not open info drawer if viewer outlet is active', (done) => {
+  it('should open info drawer even if viewer outlet is active', (done) => {
     window.history.pushState({}, null, `${locationHref}#test(viewer:view)`);
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
       component.infoDrawerOpened$.subscribe((state) => {
-        expect(state).toBe(false);
+        expect(state).toBe(true);
         done();
       });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There was a lack of consistency in document base page component. There was a condition that when i viewer mode, details tab should not be opened, which actually is an allowed action. But it some cases (eg. custom component) it wrongly blocked opening of the tab.  


**What is the new behaviour?**
Details tab can be opened.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
