### PR TITLE
[ACS-5686] add reselect to edit offline, shorten template

### DIFF
--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -46,8 +46,7 @@ import { MatIconModule } from '@angular/material/icon';
   selector: 'app-toggle-edit-offline',
   template: `
     <button mat-menu-item [attr.title]="nodeTitle | translate" (click)="onClick()">
-      <mat-icon *ngIf="isNodeLocked">cancel</mat-icon>
-      <mat-icon *ngIf="!isNodeLocked">edit</mat-icon>
+      <mat-icon>{{ isNodeLocked ? 'cancel' : 'edit' }}</mat-icon>
       <span>{{ (isNodeLocked ? 'APP.ACTIONS.EDIT_OFFLINE_CANCEL' : 'APP.ACTIONS.EDIT_OFFLINE') | translate }}</span>
     </button>
   `,
@@ -131,7 +130,7 @@ export class ToggleEditOfflineComponent implements OnInit {
   }
 
   private update(data: Node) {
-    if (data && data.properties) {
+    if (data?.properties) {
       const properties = this.selection.entry.properties || {};
 
       properties['cm:lockLifetime'] = data.properties['cm:lockLifetime'];

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -22,7 +22,14 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppStore, DownloadNodesAction, EditOfflineAction, SnackbarErrorAction, getAppSelection } from '@alfresco/aca-shared/store';
+import {
+  AppStore,
+  DownloadNodesAction,
+  EditOfflineAction,
+  SetSelectedNodesAction,
+  SnackbarErrorAction,
+  getAppSelection
+} from '@alfresco/aca-shared/store';
 import { NodeEntry, SharedLinkEntry, Node, NodesApi } from '@alfresco/js-api';
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
@@ -39,15 +46,9 @@ import { MatIconModule } from '@angular/material/icon';
   selector: 'app-toggle-edit-offline',
   template: `
     <button mat-menu-item [attr.title]="nodeTitle | translate" (click)="onClick()">
-      <ng-container *ngIf="isNodeLocked">
-        <mat-icon>cancel</mat-icon>
-        <span>{{ 'APP.ACTIONS.EDIT_OFFLINE_CANCEL' | translate }}</span>
-      </ng-container>
-
-      <ng-container *ngIf="!isNodeLocked">
-        <mat-icon>edit</mat-icon>
-        <span>{{ 'APP.ACTIONS.EDIT_OFFLINE' | translate }}</span>
-      </ng-container>
+      <mat-icon *ngIf="isNodeLocked">cancel</mat-icon>
+      <mat-icon *ngIf="!isNodeLocked">edit</mat-icon>
+      <span>{{ (isNodeLocked ? 'APP.ACTIONS.EDIT_OFFLINE_CANCEL' : 'APP.ACTIONS.EDIT_OFFLINE') | translate }}</span>
     </button>
   `,
   encapsulation: ViewEncapsulation.None,
@@ -84,6 +85,7 @@ export class ToggleEditOfflineComponent implements OnInit {
 
         this.update(response?.entry);
         this.store.dispatch(new EditOfflineAction(this.selection));
+        this.store.dispatch(new SetSelectedNodesAction([this.selection]));
       } catch {
         this.onUnlockError();
       }
@@ -94,6 +96,7 @@ export class ToggleEditOfflineComponent implements OnInit {
         this.update(response?.entry);
         this.store.dispatch(new DownloadNodesAction([this.selection]));
         this.store.dispatch(new EditOfflineAction(this.selection));
+        this.store.dispatch(new SetSelectedNodesAction([this.selection]));
       } catch {
         this.onLockError();
       }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5686


**What is the new behaviour?**
Node is reselected to get updated actions in toolbar menu, to trigger disabling edit in office menu item.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
