### PR TITLE
[ACS-5539] Icon and pressed state of buttons updated as per the figma

### DIFF
--- a/projects/aca-content/src/lib/components/details/details.component.scss
+++ b/projects/aca-content/src/lib/components/details/details.component.scss
@@ -5,6 +5,12 @@ app-details-manager {
     outline: none;
     border-radius: 4px;
 
+    &:focus {
+      background-color: #1f74db3d;
+      outline: 2px solid var(--theme-blue-button-color);
+      border-radius: 4px;
+    }
+
     &:focus-visible {
       outline: 2px solid var(--theme-blue-button-color);
       border-radius: 4px;

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
@@ -44,7 +44,7 @@ import { MatIconModule } from '@angular/material/icon';
       [attr.title]="'APP.ACTIONS.DETAILS' | translate"
       (click)="onClick()"
     >
-      <mat-icon>menu_open</mat-icon>
+      <mat-icon>view_sidebar</mat-icon>
     </button>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
@@ -47,6 +47,15 @@ import { MatIconModule } from '@angular/material/icon';
       <mat-icon>view_sidebar</mat-icon>
     </button>
   `,
+  styles: [
+    `
+      .app-toggle-info-drawer button:focus {
+        background-color: #1f74db3d;
+        border: 2px solid #1f74db;
+        border-radius: 6px;
+      }
+    `
+  ],
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-toggle-info-drawer' }
 })

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
@@ -45,6 +45,20 @@ export enum ToolbarButtonType {
   selector: 'app-toolbar-button',
   templateUrl: './toolbar-button.component.html',
   encapsulation: ViewEncapsulation.None,
+  styles: [
+    `
+      .app-toolbar-button button:focus {
+        background-color: #1f74db3d;
+        border: 2px solid #1f74db;
+        border-radius: 6px;
+      }
+    `,
+    `
+      .app-toolbar-button .mat-button-focus-overlay {
+        background-color: transparent !important;
+      }
+    `
+  ],
   host: { class: 'app-toolbar-button' }
 })
 export class ToolbarButtonComponent {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently menu_open class were used in the details component.

**What is the new behaviour?**
Now the icon classes  and pressed state of buttons are updated as per the figma.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5539