### PR TITLE
[ACS-5949] library property update and cancel button do not reflect the change in UI

### DIFF
--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -28,7 +28,7 @@ import { Store } from '@ngrx/store';
 import { SnackbarAction, SnackbarErrorAction, SnackbarInfoAction, UpdateLibraryAction } from '@alfresco/aca-shared/store';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { Site, SitePaging } from '@alfresco/js-api';
+import { Site, SiteBodyCreate, SitePaging } from '@alfresco/js-api';
 import { Actions } from '@ngrx/effects';
 import { Subject } from 'rxjs';
 
@@ -37,6 +37,7 @@ describe('LibraryMetadataFormComponent', () => {
   let component: LibraryMetadataFormComponent;
   let store: Store<any>;
   let actions$: Subject<SnackbarAction>;
+  let siteEntryModel: SiteBodyCreate;
 
   beforeEach(() => {
     actions$ = new Subject<SnackbarAction>();
@@ -61,13 +62,10 @@ describe('LibraryMetadataFormComponent', () => {
 
     fixture = TestBed.createComponent(LibraryMetadataFormComponent);
     component = fixture.componentInstance;
-  });
-
-  it('should initialize form with node data', () => {
-    const siteEntryModel = {
+    siteEntryModel = {
       title: 'libraryTitle',
       description: 'description',
-      visibility: 'PRIVATE'
+      visibility: Site.VisibilityEnum.PRIVATE
     };
     component.node = {
       entry: {
@@ -75,29 +73,19 @@ describe('LibraryMetadataFormComponent', () => {
         ...siteEntryModel
       } as Site
     };
+  });
+
+  it('should initialize form with node data', () => {
     fixture.detectChanges();
 
     expect(component.form.value).toEqual(siteEntryModel);
   });
 
   it('should update form data when node data changes', () => {
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-
     const newSiteEntryModel = {
       title: 'libraryTitle2',
       description: 'description2',
       visibility: 'PUBLIC'
-    };
-
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        ...siteEntryModel
-      } as Site
     };
 
     fixture.detectChanges();
@@ -117,15 +105,6 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should assign form value to node entry if updating of form is finished with success', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
     const entry = {
       id: 'libraryId',
       title: 'some different title',
@@ -140,15 +119,6 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should not assign form value to node entry if info snackbar was displayed for different action than updating library', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
     const entry = {
       id: 'libraryId',
       title: 'some different title',
@@ -162,7 +132,7 @@ describe('LibraryMetadataFormComponent', () => {
     expect(component.node.entry).not.toEqual(jasmine.objectContaining(entry));
   });
 
-  it('should not call markAsDirty on form if updating of form is finished with error', () => {
+  it('should call markAsDirty on form if updating of form is finished with error', () => {
     component.node = {
       entry: {
         id: 'libraryId',
@@ -179,16 +149,7 @@ describe('LibraryMetadataFormComponent', () => {
     expect(component.form.markAsDirty).toHaveBeenCalled();
   });
 
-  it('should call markAsDirty on form if error snackbar was displayed for different action than updating library', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
+  it('should not call markAsDirty on form if error snackbar was displayed for different action than updating library', () => {
     component.ngOnInit();
     spyOn(component.form, 'markAsDirty');
 
@@ -197,18 +158,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should update library node if form is valid', () => {
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        ...siteEntryModel
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteManager;
 
     fixture.detectChanges();
 
@@ -218,15 +168,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should call markAsPristine on form when updating valid form and has permission to update', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteManager;
     spyOn(component.form, 'markAsPristine');
     component.ngOnInit();
 
@@ -235,18 +177,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should not update library node if it has no permission', () => {
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'Consumer',
-        ...siteEntryModel
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteConsumer;
 
     fixture.detectChanges();
 
@@ -256,15 +187,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should not call markAsPristine on form when updating valid form but has not permission to update', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'Consumer',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteConsumer;
     spyOn(component.form, 'markAsPristine');
     component.ngOnInit();
 
@@ -273,18 +196,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should not update library node if form is invalid', () => {
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        ...siteEntryModel
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteManager;
 
     fixture.detectChanges();
 
@@ -296,15 +208,7 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should not call markAsPristine on form when updating invalid form and has permission to update', () => {
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        role: 'SiteManager',
-        title: 'libraryTitle',
-        description: 'description',
-        visibility: Site.VisibilityEnum.PRIVATE
-      } as Site
-    };
+    component.node.entry.role = Site.RoleEnum.SiteManager;
     spyOn(component.form, 'markAsPristine');
     spyOnProperty(component.form, 'valid').and.returnValue(false);
     component.ngOnInit();
@@ -324,17 +228,6 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should cancel from changes', () => {
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        ...siteEntryModel
-      } as Site
-    };
     fixture.detectChanges();
 
     expect(component.form.value).toEqual(siteEntryModel);
@@ -349,13 +242,6 @@ describe('LibraryMetadataFormComponent', () => {
   });
 
   it('should call markAsPristine on form when cancelled', () => {
-    component.node = {
-      entry: {
-        id: 'some id',
-        title: 'some title',
-        visibility: Site.VisibilityEnum.PUBLIC
-      } as Site
-    };
     spyOn(component.form, 'markAsPristine');
 
     component.cancel();
@@ -369,19 +255,6 @@ describe('LibraryMetadataFormComponent', () => {
         list: { entries: [{ entry: { title } }] }
       } as SitePaging)
     );
-
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        ...siteEntryModel
-      } as Site
-    };
 
     fixture.detectChanges();
     component.form.controls.title.setValue(title);
@@ -398,19 +271,6 @@ describe('LibraryMetadataFormComponent', () => {
       } as SitePaging)
     );
 
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        ...siteEntryModel
-      } as Site
-    };
-
     fixture.detectChanges();
     component.form.controls.title.setValue('libraryTitle');
     fixture.detectChanges();
@@ -425,19 +285,6 @@ describe('LibraryMetadataFormComponent', () => {
         list: { entries: [] }
       } as SitePaging)
     );
-
-    const siteEntryModel = {
-      title: 'libraryTitle',
-      description: 'description',
-      visibility: 'PRIVATE'
-    };
-
-    component.node = {
-      entry: {
-        id: 'libraryId',
-        ...siteEntryModel
-      } as Site
-    };
 
     fixture.detectChanges();
     component.form.controls.title.setValue('some-name');

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -146,10 +146,10 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
       });
     this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager';
     this.visibilityLabel = this.libraryType.find((type) => type.value === this.form.controls['visibility'].value).label;
-    this.handleUpdatingEvents<SnackbarInfoAction>(SnackbarActionTypes.Info, 'LIBRARY.SUCCESS.LIBRARY_UPDATED', () =>
+    this.handleUpdatingEvent<SnackbarInfoAction>(SnackbarActionTypes.Info, 'LIBRARY.SUCCESS.LIBRARY_UPDATED', () =>
       Object.assign(this.node.entry, this.form.value)
     );
-    this.handleUpdatingEvents<SnackbarErrorAction>(SnackbarActionTypes.Error, 'LIBRARY.ERRORS.LIBRARY_UPDATE_ERROR', () => this.form.markAsDirty());
+    this.handleUpdatingEvent<SnackbarErrorAction>(SnackbarActionTypes.Error, 'LIBRARY.ERRORS.LIBRARY_UPDATE_ERROR', () => this.form.markAsDirty());
   }
 
   ngOnDestroy() {
@@ -190,7 +190,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
     );
   }
 
-  private handleUpdatingEvents<T extends SnackbarAction>(actionType: SnackbarActionTypes, payload: string, handle: () => void): void {
+  private handleUpdatingEvent<T extends SnackbarAction>(actionType: SnackbarActionTypes, payload: string, handle: () => void): void {
     this.actions$
       .pipe(
         ofType<T>(actionType),

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -23,7 +23,7 @@
  */
 
 import { Component, Input, OnChanges, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { FormGroupDirective, FormsModule, NgForm, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { UntypedFormGroup, UntypedFormControl, Validators, FormGroupDirective, NgForm, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { QueriesApi, SiteEntry, SitePaging } from '@alfresco/js-api';
 import { Store } from '@ngrx/store';
 import {
@@ -36,7 +36,7 @@ import {
 } from '@alfresco/aca-shared/store';
 import { debounceTime, filter, mergeMap, takeUntil } from 'rxjs/operators';
 import { AlfrescoApiService } from '@alfresco/adf-core';
-import { from, Observable, Subject } from 'rxjs';
+import { Observable, from, Subject } from 'rxjs';
 import { ErrorStateMatcher, MatOptionModule } from '@angular/material/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -119,6 +119,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   cancel() {
     this.updateForm(this.node);
     this.toggleEdit();
+    this.form.markAsPristine();
   }
 
   ngOnInit() {
@@ -193,7 +194,8 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
     this.actions$
       .pipe(
         ofType<T>(actionType),
-        filter((action) => action.payload === payload)
+        filter((action) => action.payload === payload),
+        takeUntil(this.onDestroy$)
       )
       .subscribe(handle);
   }

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -149,7 +149,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
     this.handleUpdatingEvents<SnackbarInfoAction>(SnackbarActionTypes.Info, 'LIBRARY.SUCCESS.LIBRARY_UPDATED', () =>
       Object.assign(this.node.entry, this.form.value)
     );
-    this.handleUpdatingEvents<SnackbarErrorAction>(SnackbarActionTypes.Error, 'LIBRARY.ERRORS.LIBRARY_UPDATE_ERROR', this.form.markAsDirty);
+    this.handleUpdatingEvents<SnackbarErrorAction>(SnackbarActionTypes.Error, 'LIBRARY.ERRORS.LIBRARY_UPDATE_ERROR', () => this.form.markAsDirty());
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5949


**What is the new behaviour?**
Update button is disabled when changes are saved and cancel restores proper values for fields. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
