### PR TITLE
[ACS-6085] user is not prevented from renaming library to name containing only spaces

### DIFF
--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -488,7 +488,7 @@
             "CONFLICT": "This Library ID is already used. Check the trashcan.",
             "ID_TOO_LONG": "Use 72 characters or less for the URL name",
             "DESCRIPTION_TOO_LONG": "Use 512 characters or less for description",
-            "TITLE_TOO_LONG": "Use 256 characters or less for title",
+            "TITLE_TOO_LONG_OR_MISSING": "Use 256 characters or less for title",
             "ILLEGAL_CHARACTERS": "Use numbers and letters only",
             "ONLY_SPACES": "Library name can't contain only spaces",
             "LIBRARY_UPDATE_ERROR": "There was an error updating library properties"

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -92,7 +92,7 @@
         />
         <mat-hint *ngIf="libraryTitleExists">{{ 'LIBRARY.HINTS.SITE_TITLE_EXISTS' | translate }}</mat-hint>
         <mat-error>
-          {{ 'LIBRARY.ERRORS.TITLE_TOO_LONG' | translate }}
+          {{ titleErrorTranslationKey | translate }}
         </mat-error>
       </mat-form-field>
 

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -167,6 +167,20 @@ describe('LibraryMetadataFormComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new UpdateLibraryAction(siteEntryModel));
   });
 
+  it('should update library node with trimmed title', () => {
+    component.node.entry.role = Site.RoleEnum.SiteManager;
+    siteEntryModel.title = '   some title    ';
+    component.ngOnInit();
+
+    component.update();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new UpdateLibraryAction({
+        ...siteEntryModel,
+        title: siteEntryModel.title.trim()
+      })
+    );
+  });
+
   it('should call markAsPristine on form when updating valid form and has permission to update', () => {
     component.node.entry.role = Site.RoleEnum.SiteManager;
     spyOn(component.form, 'markAsPristine');
@@ -293,4 +307,25 @@ describe('LibraryMetadataFormComponent', () => {
     tick(500);
     expect(component.libraryTitleExists).toBe(false);
   }));
+
+  it('should set proper titleErrorTranslationKey when there is error for empty title', () => {
+    component.ngOnInit();
+
+    component.form.controls.title.setValue('     ');
+    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.ONLY_SPACES');
+  });
+
+  it('should set proper titleErrorTranslationKey when there is error for required', () => {
+    component.ngOnInit();
+
+    component.form.controls.title.setValue('');
+    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG');
+  });
+
+  it('should set proper titleErrorTranslationKey when there is error for too long title', () => {
+    component.ngOnInit();
+
+    component.form.controls.title.setValue('t'.repeat(257));
+    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG');
+  });
 });

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -333,13 +333,6 @@ describe('LibraryMetadataFormComponent', () => {
     expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.ONLY_SPACES');
   });
 
-  it('should set proper titleErrorTranslationKey when there is error for required', () => {
-    component.ngOnInit();
-
-    component.form.controls.title.setValue('');
-    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG');
-  });
-
   it('should set proper titleErrorTranslationKey when there is error for too long title', () => {
     component.ngOnInit();
 

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -337,6 +337,13 @@ describe('LibraryMetadataFormComponent', () => {
     component.ngOnInit();
 
     component.form.controls.title.setValue('t'.repeat(257));
-    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG');
+    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG_OR_MISSING');
+  });
+
+  it('should set proper titleErrorTranslationKey when there is error for missing title', () => {
+    component.ngOnInit();
+
+    component.form.controls.title.setValue('');
+    expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.TITLE_TOO_LONG_OR_MISSING');
   });
 });

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -170,6 +170,7 @@ describe('LibraryMetadataFormComponent', () => {
   it('should update library node with trimmed title', () => {
     component.node.entry.role = Site.RoleEnum.SiteManager;
     siteEntryModel.title = '   some title    ';
+    component.node.entry.title = siteEntryModel.title;
     component.ngOnInit();
 
     component.update();
@@ -276,6 +277,23 @@ describe('LibraryMetadataFormComponent', () => {
 
     tick(500);
     expect(component.libraryTitleExists).toBe(true);
+  }));
+
+  it('should call findSites on queriesApi with trimmed title', fakeAsync(() => {
+    const title = '    test   ';
+    spyOn(component.queriesApi, 'findSites').and.returnValue(
+      Promise.resolve({
+        list: { entries: [{ entry: { title } }] }
+      } as SitePaging)
+    );
+    component.ngOnInit();
+
+    component.form.controls.title.setValue(title);
+    tick(300);
+    expect(component.queriesApi.findSites).toHaveBeenCalledWith(title.trim(), {
+      maxItems: 1,
+      fields: ['title']
+    });
   }));
 
   it('should not warn if library name input is the same with library node data', fakeAsync(() => {

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -31,7 +31,8 @@ import {
   NgForm,
   FormsModule,
   ReactiveFormsModule,
-  FormControl
+  FormControl,
+  ValidationErrors
 } from '@angular/forms';
 import { QueriesApi, SiteEntry, SitePaging } from '@alfresco/js-api';
 import { Store } from '@ngrx/store';
@@ -225,7 +226,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
       .subscribe(handle);
   }
 
-  private validateEmptyName(control: FormControl<string>) {
+  private validateEmptyName(control: FormControl<string>): ValidationErrors {
     return control.value.length && !control.value.trim() ? { empty: true } : null;
   }
 }

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -184,7 +184,12 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   update() {
     if (this.canUpdateLibrary && this.form.valid) {
       this.form.markAsPristine();
-      this.store.dispatch(new UpdateLibraryAction(this.form.value));
+      this.store.dispatch(
+        new UpdateLibraryAction({
+          ...this.form.value,
+          title: this.form.value.title.trim()
+        })
+      );
     }
   }
 
@@ -202,7 +207,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   private findLibraryByTitle(libraryTitle: string): Observable<SitePaging | { list: { entries: any[] } }> {
     return from(
       this.queriesApi
-        .findSites(libraryTitle, {
+        .findSites(libraryTitle.trim(), {
           maxItems: 1,
           fields: ['title']
         })

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -144,7 +144,9 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
       .pipe(takeUntil(this.onDestroy$))
       .subscribe(
         () =>
-          (this._titleErrorTranslationKey = this.form.controls.title.errors?.empty ? 'LIBRARY.ERRORS.ONLY_SPACES' : 'LIBRARY.ERRORS.TITLE_TOO_LONG')
+          (this._titleErrorTranslationKey = this.form.controls.title.errors?.empty
+            ? 'LIBRARY.ERRORS.ONLY_SPACES'
+            : 'LIBRARY.ERRORS.TITLE_TOO_LONG_OR_MISSING')
       );
     this.form.controls['title'].valueChanges
       .pipe(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6085


**What is the new behaviour?**
User can't edit library name to name which contains only spaces. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
