### PR TITLE
[ACS-6106] Breadcrumb navigation fail on Details tab

### DIFF
--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -1,6 +1,6 @@
 <aca-page-layout>
   <div class="aca-page-layout-header">
-    <adf-breadcrumb [root]="title" [folderNode]="node" (navigate)="goBack()"> </adf-breadcrumb>
+    <adf-breadcrumb [root]="title" [folderNode]="node" (navigate)="onBreadcrumbNavigate($event)"> </adf-breadcrumb>
     <aca-toolbar [items]="actions"></aca-toolbar>
   </div>
 

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -30,11 +30,12 @@ import { of, Subject } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
-import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { NodeEntry } from '@alfresco/js-api';
+import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction, NavigateToFolder } from '@alfresco/aca-shared/store';
+import { NodeEntry, PathElement } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, PageTitleService } from '@alfresco/adf-core';
-import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { BreadcrumbComponent, SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { By } from '@angular/platform-browser';
 
 describe('DetailsComponent', () => {
   let component: DetailsComponent;
@@ -45,7 +46,7 @@ describe('DetailsComponent', () => {
 
   const mockStream = new Subject();
   const storeMock = {
-    dispatch: jasmine.createSpy('dispatch'),
+    dispatch: jasmine.createSpy('dispatch').and.stub(),
     select: () => mockStream
   };
 
@@ -122,6 +123,17 @@ describe('DetailsComponent', () => {
   it('should get node info after setting node from router', () => {
     fixture.detectChanges();
     expect(contentApiService.getNode).toHaveBeenCalled();
+  });
+
+  it('should dispatch navigation to a given folder', () => {
+    const breadcrumbComponent: BreadcrumbComponent = fixture.debugElement.query(By.directive(BreadcrumbComponent)).componentInstance;
+    const pathElement: PathElement = {
+      id: 'fake-id'
+    };
+    breadcrumbComponent.navigate.emit(pathElement);
+    fixture.detectChanges();
+
+    expect(store.dispatch).toHaveBeenCalledWith(new NavigateToFolder({ entry: pathElement } as NodeEntry));
   });
 
   it('should dispatch node selection', () => {

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -25,7 +25,7 @@
 import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent } from '@alfresco/aca-shared';
-import { NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
+import { NavigateToFolder, NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { Subject } from 'rxjs';
 import { BreadcrumbModule, PermissionManagerModule } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
@@ -36,6 +36,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
 import { MetadataTabComponent } from '../info-drawer/metadata-tab/metadata-tab.component';
 import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.component';
+import { NodeEntry, PathElement } from '@alfresco/js-api';
 
 @Component({
   standalone: true,
@@ -103,6 +104,10 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
 
   goBack() {
     this.store.dispatch(new NavigateToPreviousPage());
+  }
+
+  onBreadcrumbNavigate(path: PathElement) {
+    this.store.dispatch(new NavigateToFolder({ entry: path } as NodeEntry));
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Clicking on a folder from the breadcrumbs navigates the user to the previous page. 
https://alfresco.atlassian.net/browse/ACS-6106

**What is the new behaviour?**

Clicking on a folder from the breadcrumbs navigates the user to the destination folder. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
