### PR TITLE
[ACS-5647] rework template of library metadata form component

### DIFF
--- a/e2e/playwright/actions/src/tests/create-library.spec.ts
+++ b/e2e/playwright/actions/src/tests/create-library.spec.ts
@@ -145,10 +145,10 @@ test.describe('Create Libraries ', () => {
     await expect(libraryTable.getCellLinkByName(randomLibraryName).and(myLibrariesPage.page.getByTitle(randomLibraryDescription))).toBeVisible();
     await libraryTable.getRowByName(randomLibraryName).click();
     await libraryViewDetails.click();
-    await expect(libraryDetails.getNameField('Name').getByText(randomLibraryName)).toBeVisible();
-    await expect(libraryDetails.getIdField('Library ID').getByText(randomLibraryId)).toBeVisible();
-    await expect(libraryDetails.getVisibilityField('Visibility').getByText(publicVisibility)).toBeVisible();
-    await expect(libraryDetails.getDescriptionField(libraryDescriptionLabel).getByText(randomLibraryDescription)).toBeVisible();
+    expect(await libraryDetails.getNameField('Name').locator('input').inputValue()).toBe(randomLibraryName);
+    expect(await libraryDetails.getIdField('Library ID').locator('input').inputValue()).toBe(randomLibraryId);
+    await expect(libraryDetails.getVisibilityField('Visibility').locator('.mat-select-value').getByText(publicVisibility)).toBeVisible();
+    expect(await libraryDetails.getDescriptionField.inputValue()).toBe(randomLibraryDescription);
 
     await apiClientFactory.sites.deleteSite(randomLibraryId, { permanent: true });
   });

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -1,7 +1,7 @@
 <mat-card *ngIf="node">
   <mat-card-content>
     <form [formGroup]="form" autocomplete="off">
-      <mat-form-field floatLabel="auto">
+      <mat-form-field floatLabel="auto" data-automation-id="library-name-properties-wrapper">
         <input
           matInput
           [cdkTrapFocusAutoCapture]="form.enabled"
@@ -17,11 +17,11 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field floatLabel="auto">
+      <mat-form-field floatLabel="auto" data-automation-id="library-id-properties-wrapper">
         <input matInput placeholder="{{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}" formControlName="id" />
       </mat-form-field>
 
-      <mat-form-field floatLabel="auto">
+      <mat-form-field floatLabel="auto" data-automation-id="library-visibility-properties-wrapper">
         <mat-select placeholder="{{ 'LIBRARY.DIALOG.FORM.VISIBILITY' | translate }}" formControlName="visibility">
           <mat-option [value]="type.value" *ngFor="let type of libraryType">
             {{ type.label | translate }}
@@ -29,7 +29,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field floatLabel="auto">
+      <mat-form-field floatLabel="auto" data-automation-id="library-description-properties-wrapper">
         <textarea
           matInput
           placeholder="{{ 'LIBRARY.DIALOG.FORM.DESCRIPTION' | translate }}"

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -1,85 +1,5 @@
 <mat-card *ngIf="node">
-  <mat-card-content *ngIf="!edit">
-    <div class="mat-form-field mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float">
-      <div class="mat-form-field-wrapper" data-automation-id="library-name-properties-wrapper">
-        <div class="mat-form-field-flex">
-          <div class="mat-form-field-infix">
-            <span class="mat-form-field-label-wrapper">
-              <span class="mat-form-field-label">
-                {{ 'LIBRARY.DIALOG.FORM.NAME' | translate }}
-              </span>
-            </span>
-
-            <span class="mat-input-element">
-              {{ form.controls.title.value }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float">
-      <div class="mat-form-field-wrapper" data-automation-id="library-id-properties-wrapper">
-        <div class="mat-form-field-flex">
-          <div class="mat-form-field-infix">
-            <span class="mat-form-field-label-wrapper">
-              <span class="mat-form-field-label">
-                {{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}
-              </span>
-            </span>
-
-            <span class="mat-input-element">
-              {{ form.controls.id.value }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float">
-      <div class="mat-form-field-wrapper" data-automation-id="library-visibility-properties-wrapper">
-        <div class="mat-form-field-flex">
-          <div class="mat-form-field-infix">
-            <span class="mat-form-field-label-wrapper">
-              <span class="mat-form-field-label">
-                {{ 'LIBRARY.DIALOG.FORM.VISIBILITY' | translate }}
-              </span>
-            </span>
-
-            <span class="mat-input-element">
-              {{ visibilityLabel | translate }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="mat-form-field mat-primary mat-form-field-type-mat-input mat-form-field-can-float mat-form-field-should-float">
-      <div class="mat-form-field-wrapper" data-automation-id="library-description-properties-wrapper">
-        <div class="mat-form-field-flex">
-          <div class="mat-form-field-infix">
-            <span class="mat-form-field-label-wrapper">
-              <span class="mat-form-field-label">
-                {{ 'LIBRARY.DIALOG.FORM.DESCRIPTION' | translate }}
-              </span>
-            </span>
-
-            <span class="mat-input-element">
-              {{ form.controls.description?.value }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </mat-card-content>
-
-  <mat-card-actions align="end" *ngIf="!edit && canUpdateLibrary">
-    <button mat-button color="primary" (click)="toggleEdit()">
-      {{ 'LIBRARY.DIALOG.EDIT' | translate }}
-    </button>
-  </mat-card-actions>
-
-  <mat-card-content *ngIf="edit">
+  <mat-card-content>
     <form [formGroup]="form" autocomplete="off">
       <mat-form-field floatLabel="auto">
         <input
@@ -123,12 +43,17 @@
     </form>
   </mat-card-content>
 
-  <mat-card-actions align="end" *ngIf="edit && canUpdateLibrary">
-    <button mat-button (click)="cancel()">
-      {{ 'LIBRARY.DIALOG.CANCEL' | translate }}
-    </button>
-    <button mat-button color="primary" [disabled]="form.invalid || form.pristine" (click)="update()">
-      {{ 'LIBRARY.DIALOG.UPDATE' | translate }}
+  <mat-card-actions align="end" *ngIf="canUpdateLibrary">
+    <ng-container *ngIf="form.enabled">
+      <button mat-button (click)="cancel()">
+        {{ 'LIBRARY.DIALOG.CANCEL' | translate }}
+      </button>
+      <button mat-button color="primary" [disabled]="form.invalid || form.pristine" (click)="update()">
+        {{ 'LIBRARY.DIALOG.UPDATE' | translate }}
+      </button>
+    </ng-container>
+    <button mat-button color="primary" (click)="toggleEdit()" *ngIf="form.disabled">
+      {{ 'LIBRARY.DIALOG.EDIT' | translate }}
     </button>
   </mat-card-actions>
 </mat-card>

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -4,7 +4,8 @@
       <mat-form-field floatLabel="auto">
         <input
           matInput
-          cdkFocusInitial
+          [cdkTrapFocusAutoCapture]="form.enabled"
+          [cdkTrapFocus]="form.enabled"
           required
           placeholder="{{ 'LIBRARY.DIALOG.FORM.NAME' | translate }}"
           formControlName="title"

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -77,6 +77,7 @@ describe('LibraryMetadataFormComponent', () => {
 
   it('should initialize form with node data', () => {
     fixture.detectChanges();
+    component.toggleEdit();
 
     expect(component.form.value).toEqual(siteEntryModel);
   });
@@ -89,6 +90,7 @@ describe('LibraryMetadataFormComponent', () => {
     };
 
     fixture.detectChanges();
+    component.toggleEdit();
 
     expect(component.form.value).toEqual(siteEntryModel);
 
@@ -161,6 +163,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.node.entry.role = Site.RoleEnum.SiteManager;
 
     fixture.detectChanges();
+    component.toggleEdit();
 
     component.update();
 
@@ -172,6 +175,7 @@ describe('LibraryMetadataFormComponent', () => {
     siteEntryModel.title = '   some title    ';
     component.node.entry.title = siteEntryModel.title;
     component.ngOnInit();
+    component.toggleEdit();
 
     component.update();
     expect(store.dispatch).toHaveBeenCalledWith(
@@ -186,6 +190,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.node.entry.role = Site.RoleEnum.SiteManager;
     spyOn(component.form, 'markAsPristine');
     component.ngOnInit();
+    component.toggleEdit();
 
     component.update();
     expect(component.form.markAsPristine).toHaveBeenCalled();
@@ -195,6 +200,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.node.entry.role = Site.RoleEnum.SiteConsumer;
 
     fixture.detectChanges();
+    component.toggleEdit();
 
     component.update();
 
@@ -205,6 +211,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.node.entry.role = Site.RoleEnum.SiteConsumer;
     spyOn(component.form, 'markAsPristine');
     component.ngOnInit();
+    component.toggleEdit();
 
     component.update();
     expect(component.form.markAsPristine).not.toHaveBeenCalled();
@@ -214,6 +221,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.node.entry.role = Site.RoleEnum.SiteManager;
 
     fixture.detectChanges();
+    component.toggleEdit();
 
     component.form.controls['title'].setErrors({ maxlength: true });
 
@@ -227,23 +235,36 @@ describe('LibraryMetadataFormComponent', () => {
     spyOn(component.form, 'markAsPristine');
     spyOnProperty(component.form, 'valid').and.returnValue(false);
     component.ngOnInit();
+    component.toggleEdit();
 
     component.update();
     expect(component.form.markAsPristine).not.toHaveBeenCalled();
   });
 
-  it('should toggle edit mode', () => {
-    component.edit = false;
+  it('should disable form after calling toggleEdit if form was enabled', () => {
+    spyOn(component.form, 'disable');
 
     component.toggleEdit();
-    expect(component.edit).toBe(true);
+    expect(component.form.disable).toHaveBeenCalledWith({
+      emitEvent: false
+    });
+  });
+
+  it('should enable form without id field after calling toggleEdit if form was disabled', () => {
+    component.toggleEdit();
+    spyOn(component.form, 'enable');
+    spyOn(component.form.controls.id, 'disable');
 
     component.toggleEdit();
-    expect(component.edit).toBe(false);
+    expect(component.form.enable).toHaveBeenCalledWith({
+      emitEvent: false
+    });
+    expect(component.form.controls.id.disable).toHaveBeenCalled();
   });
 
   it('should cancel from changes', () => {
     fixture.detectChanges();
+    component.toggleEdit();
 
     expect(component.form.value).toEqual(siteEntryModel);
 
@@ -252,6 +273,7 @@ describe('LibraryMetadataFormComponent', () => {
     expect(component.form.value.title).toBe('libraryTitle-edit');
 
     component.cancel();
+    component.toggleEdit();
 
     expect(component.form.value).toEqual(siteEntryModel);
   });
@@ -328,6 +350,7 @@ describe('LibraryMetadataFormComponent', () => {
 
   it('should set proper titleErrorTranslationKey when there is error for empty title', () => {
     component.ngOnInit();
+    component.toggleEdit();
 
     component.form.controls.title.setValue('     ');
     expect(component.titleErrorTranslationKey).toBe('LIBRARY.ERRORS.ONLY_SPACES');

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -118,18 +118,16 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
 
   matcher = new InstantErrorStateMatcher();
   canUpdateLibrary = false;
-  visibilityLabel = '';
 
   onDestroy$: Subject<boolean> = new Subject<boolean>();
 
   constructor(private alfrescoApiService: AlfrescoApiService, protected store: Store<AppStore>, private actions$: Actions) {}
-  getVisibilityLabel(value: string) {
-    return this.libraryType.find((type) => type.value === value).label;
-  }
 
   toggleEdit() {
     if (this.form.enabled) {
-      this.form.disable();
+      this.form.disable({
+        emitEvent: false
+      });
     } else {
       this.form.enable({
         emitEvent: false
@@ -175,7 +173,6 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
         }
       });
     this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager';
-    this.visibilityLabel = this.libraryType.find((type) => type.value === this.form.controls['visibility'].value).label;
     this.handleUpdatingEvent<SnackbarInfoAction>(SnackbarActionTypes.Info, 'LIBRARY.SUCCESS.LIBRARY_UPDATED', () =>
       Object.assign(this.node.entry, this.form.value)
     );

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -101,7 +101,6 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   @Input()
   node: SiteEntry;
 
-  edit: boolean;
   libraryTitleExists = false;
 
   libraryType = [
@@ -129,7 +128,14 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   }
 
   toggleEdit() {
-    this.edit = !this.edit;
+    if (this.form.enabled) {
+      this.form.disable();
+    } else {
+      this.form.enable({
+        emitEvent: false
+      });
+      this.form.controls.id.disable();
+    }
   }
 
   cancel() {
@@ -139,6 +145,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
   }
 
   ngOnInit() {
+    this.toggleEdit();
     this.updateForm(this.node);
     this.form.controls.title.statusChanges
       .pipe(takeUntil(this.onDestroy$))

--- a/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
@@ -35,5 +35,5 @@ export class AdfInfoDrawerComponent extends BaseComponent {
   public getNameField = (labelText: string) => this.getChild('[data-automation-id="library-name-properties-wrapper"]', { hasText: labelText });
   public getIdField = (labelText: string) => this.getChild('[data-automation-id="library-id-properties-wrapper"]', { hasText: labelText });
   public getVisibilityField = (labelText: string) => this.getChild('[data-automation-id="library-visibility-properties-wrapper"]', { hasText: labelText });
-  public getDescriptionField = (labelText: string) => this.getChild('[data-automation-id="library-description-properties-wrapper"]', { hasText: labelText });
+  public getDescriptionField = this.getChild('[data-automation-id="library-description-properties-wrapper"] textarea');
 }

--- a/projects/aca-testing-shared/src/components/info-drawer/info-drawer-metadata-library.ts
+++ b/projects/aca-testing-shared/src/components/info-drawer/info-drawer-metadata-library.ts
@@ -32,6 +32,8 @@ export class LibraryMetadata extends Component {
   visibilityPublic = this.byCssText('.mat-option .mat-option-text', 'Public', browser);
   visibilityPrivate = this.byCssText('.mat-option .mat-option-text', 'Private', browser);
   visibilityModerated = this.byCssText('.mat-option .mat-option-text', 'Moderated', browser);
+  visibilityValue = this.byCss('[data-automation-id="library-visibility-properties-wrapper"] .mat-select');
+
   hint = this.byCss('.mat-hint');
   error = this.byCss('.mat-error');
 
@@ -57,7 +59,7 @@ export class LibraryMetadata extends Component {
   }
 
   private async getValueOfField(fieldName: string) {
-    return this.getFieldByName(fieldName).getText();
+    return this.getFieldByName(fieldName).getAttribute('value');
   }
 
   private async enterTextInInput(fieldName: string, text: string) {
@@ -140,11 +142,11 @@ export class LibraryMetadata extends Component {
   }
 
   async isVisibilityDisplayed() {
-    return this.isFieldDisplayed('Visibility');
+    return browser.isElementPresent(this.visibilityValue);
   }
 
   async getVisibility(): Promise<string> {
-    return this.getValueOfField('Visibility');
+    return this.visibilityValue.getText();
   }
 
   async setVisibility(visibility: string) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5647


**What is the new behaviour?**
Template for Edit mode is used also in View mode. So now there is only one template instead of two. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
