### PR TITLE
[ACS-5752] Fixed incorrect info drawer properties update

### DIFF
--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -82,7 +82,7 @@ describe('LibraryMetadataFormComponent', () => {
     expect(component.form.value).toEqual(siteEntryModel);
   });
 
-  it('should update form data when node data changes', () => {
+  it('should update form data and properties when node data changes', () => {
     const newSiteEntryModel = {
       title: 'libraryTitle2',
       description: 'description2',
@@ -93,10 +93,12 @@ describe('LibraryMetadataFormComponent', () => {
     component.toggleEdit();
 
     expect(component.form.value).toEqual(siteEntryModel);
+    expect(component.canUpdateLibrary).toBeFalse();
 
     component.node = {
       entry: {
         id: 'libraryId',
+        role: 'SiteManager',
         ...newSiteEntryModel
       } as Site
     };
@@ -104,6 +106,7 @@ describe('LibraryMetadataFormComponent', () => {
     component.ngOnChanges();
 
     expect(component.form.value).toEqual(newSiteEntryModel);
+    expect(component.canUpdateLibrary).toBeTrue();
   });
 
   it('should assign form value to node entry if updating of form is finished with success', () => {

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -186,6 +186,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
 
   ngOnChanges() {
     this.updateForm(this.node);
+    this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager';
   }
 
   update() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-5752
The visibility of the libraries are not getting updated properly. Same happens to the 'edit' button, It is always stuck at whatever the visibility of the originally selected library was.

**What is the new behaviour?**

- State of the Edit button is updated properly.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
