### PR TITLE
[ACA-4722] - add multi-arch images publish scripts

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -26,6 +26,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Login to Docker Registry
       uses: docker/login-action@v2
       with:
@@ -38,15 +44,16 @@ runs:
       with:
         branch_name: ${{ inputs.branch_name }}
 
-    - name: Publish
-      if: ${{ github.event.inputs.dry-run != 'true' }}
+    - name: Install dependencies and build project
       shell: bash
       run: |
-        npm ci && npm run build.release
-        echo "Running the docker with tag $TAG_VERSION"
+        npm ci
+        npm run build.release
 
-        npx @alfresco/adf-cli docker-publish \
-          --dockerRepo "${{ inputs.registry }}/alfresco/alfresco-content-app" \
-          --buildArgs "PROJECT_NAME=content-ce" \
-          --dockerTags "$TAG_VERSION" \
-          --pathProject "$(pwd)"
+    - name: Build and push multi-platform image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event.inputs.dry-run != 'true' }}
+        tags: ${{ inputs.registry }}/alfresco/alfresco-content-app:${{ env.TAG_VERSION }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4722

There are multi-arch images of ACA available


**What is the new behaviour?**
Multi-arch image are available which benefits M1/M2 Apple users.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
