### PR TITLE
[ACS-6278] - disable manage rules for smart folders

### DIFF
--- a/projects/aca-content/folder-rules/src/folder-rules.rules.spec.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.rules.spec.ts
@@ -23,7 +23,8 @@
  */
 
 import { AcaRuleContext } from '@alfresco/aca-shared/rules';
-import { isFolderRulesEnabled, canManageFolderRules } from './folder-rules.rules';
+import { canManageFolderRules, isFolderRulesEnabled } from './folder-rules.rules';
+import { NodeEntry } from '@alfresco/js-api';
 
 describe('Folder Rules Visibility Rules', () => {
   describe('isFolderRulesEnabled', () => {
@@ -80,6 +81,13 @@ describe('Folder Rules Visibility Rules', () => {
 
       const result = canManageFolderRules(context);
       expect(result).toEqual(false);
+    });
+
+    it('should not allow creating a rule if the selected node is a smart folder', () => {
+      context.selection.first = { entry: { aspectNames: ['smf:customConfigSmartFolder'], isFolder: true } } as NodeEntry;
+      const result = canManageFolderRules(context);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/projects/aca-content/folder-rules/src/folder-rules.rules.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.rules.ts
@@ -22,10 +22,10 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AcaRuleContext, hasFolderSelected, canEditFolder, isNotFavorites } from '@alfresco/aca-shared/rules';
+import { AcaRuleContext, canEditFolder, hasFolderSelected, isNotFavorites, isSmartFolder } from '@alfresco/aca-shared/rules';
 
 export const isFolderRulesEnabled = (context: AcaRuleContext) => context.appConfig.get<boolean>('plugins.folderRules', false);
 export const isFolderRulesAllowed = (context: AcaRuleContext) =>
-  isFolderRulesEnabled(context) && canEditFolder(context) && hasFolderSelected(context) && isNotFavorites(context);
+  isFolderRulesEnabled(context) && canEditFolder(context) && hasFolderSelected(context) && isNotFavorites(context) && !isSmartFolder(context);
 
 export const canManageFolderRules = (context: AcaRuleContext): boolean => isFolderRulesAllowed(context);

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -23,9 +23,9 @@
  */
 
 import * as app from './app.rules';
+import { getFileExtension } from './app.rules';
 import { TestRuleContext } from './test-rule-context';
 import { NodeEntry, RepositoryInfo } from '@alfresco/js-api';
-import { getFileExtension } from './app.rules';
 
 describe('app.evaluators', () => {
   describe('getFileExtension', () => {
@@ -821,12 +821,6 @@ describe('app.evaluators', () => {
 
     it('should return false if the context is trashcan', () => {
       context.navigation = { url: '/trashcan' };
-
-      expect(app.canEditAspects(context)).toBe(false);
-    });
-
-    it('should return false if the selected node is a smart folder', () => {
-      context.selection.first = { entry: { aspectNames: ['smf:customConfigSmartFolder'], isFolder: true } } as NodeEntry;
 
       expect(app.canEditAspects(context)).toBe(false);
     });

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -495,8 +495,7 @@ export const canEditAspects = (context: RuleContext): boolean =>
     canUpdateSelectedNode(context),
     !isWriteLocked(context),
     navigation.isNotTrashcan(context),
-    repository.isMajorVersionAvailable(context, '7'),
-    !isSmartFolder(context)
+    repository.isMajorVersionAvailable(context, '7')
   ].every(Boolean);
 
 /**
@@ -626,7 +625,7 @@ export function canOpenWithOffice(context: AcaRuleContext): boolean {
   return context.permissions.check(file, ['update']);
 }
 
-function isSmartFolder(context: RuleContext): boolean {
+export function isSmartFolder(context: RuleContext): boolean {
   if (!context.selection?.isEmpty) {
     const node = context.selection.first;
     if (!node?.entry.isFolder) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
'Manage rules' is visible for smart folders.


**What is the new behaviour?**
'Manage rules' is not visible for smart folders.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
