### PR TITLE
[ACS-5678] update create folder from template tests

### DIFF
--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/content-node-selector-dialog.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/content-node-selector-dialog.ts
@@ -41,7 +41,14 @@ export class ContentNodeSelectorDialog extends BaseComponent {
   getDialogTitle = (text: string) => this.getChild('[data-automation-id="content-node-selector-title"]', { hasText: text });
   getBreadcrumb = (text: string) => this.getChild('[data-automation-id="current-folder"]', { hasText: text });
   getFolderIcon = this.getChild('mat-icon[role="img"]', { hasText: "folder" });
+  loadMoreButton = this.getChild('[data-automation-id="adf-infinite-pagination-button"]');
 
+  async loadMoreNodes(): Promise<void> {
+    await this.spinnerWaitForReload();
+    while (await this.loadMoreButton.isVisible()) {
+    await this.loadMoreButton.click();
+    }
+  }
 
   async selectLocation(location: string): Promise<void> {
     await this.locationDropDown.click();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

hruser used to perform tests.
No method to deal with "Load more" button on "Select a folder template".
![Screenshot 2023-12-16 at 12 01 10](https://github.com/Alfresco/alfresco-content-app/assets/122363592/2cfb5d5b-1af2-4f94-8b1a-88812bfc5ae4)


**What is the new behaviour?**
Creating new random user to perform tests.
Adding method to deal with "Load more" button on "Select a folder template".

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
