### PR TITLE
[#3569] Implement case-insensitive matching for file extensions

### DIFF
--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -71,7 +71,7 @@ export const supportedExtensions = {
 
 export function getFileExtension(fileName: string): string | null {
   if (fileName) {
-    const match = fileName.match(/\.([^\./\?\#]+)($|\?|\#)/);
+    const match = fileName.toLowerCase().match(/\.([^\./\?\#]+)($|\?|\#)/);
 
     return match ? match[1] : null;
   }


### PR DESCRIPTION
Enable case-insensitive matching when determining file extensions in the application. This enhancement ensures that the system accurately recognizes and processes file extensions regardless of the case used in the filenames.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?**
https://github.com/Alfresco/alfresco-content-app/issues/3569



**What is the new behaviour?**
Enable case-insensitive matching when determining file extensions in the application to allow Office editing.


**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No
