### PR TITLE
[ACS-6369] - ACA on multi select file/folder permisstion menu should not be shown

### DIFF
--- a/projects/aca-playwright-shared/src/resources/test-data/test-data-files-folders.ts
+++ b/projects/aca-playwright-shared/src/resources/test-data/test-data-files-folders.ts
@@ -51,8 +51,8 @@ export const folderFavFile = {
 
 // ---- multiple selection ---
 
-const multipleSelContextMenu = ['Download', 'Favorite', 'Move', 'Copy', 'Delete', 'Permissions'];
-const multipleSelToolbarMore = ['Favorite', 'Move', 'Copy', 'Delete', 'Permissions'];
+const multipleSelContextMenu = ['Download', 'Favorite', 'Move', 'Copy', 'Delete'];
+const multipleSelToolbarMore = ['Favorite', 'Move', 'Copy', 'Delete'];
 
 export const multipleSelFile = {
   contextMenu: multipleSelContextMenu,

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -849,12 +849,17 @@ describe('app.evaluators', () => {
       expect(app.canManagePermissions(context)).toBe(false);
     });
 
+    it('should return false if many nodes are selected', () => {
+      context.selection.count = 2;
+      expect(app.canManagePermissions(context)).toBe(false);
+    });
+
     it('should return false if the selected node is a smart folder', () => {
       context.selection.first = { entry: { aspectNames: ['smf:customConfigSmartFolder'], isFolder: true } } as NodeEntry;
       expect(app.canManagePermissions(context)).toBe(false);
     });
 
-    it('should return true if user can update the selected node and it is not a trashcan nor smart folder', () => {
+    it('should return true if user can update the selected node and it is not a trashcan nor smart folder nor multiselect', () => {
       expect(app.canManagePermissions(context)).toBe(true);
     });
   });

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -505,7 +505,7 @@ export const canEditAspects = (context: RuleContext): boolean =>
  * @param context Rule execution context
  */
 export const canManagePermissions = (context: RuleContext): boolean =>
-  [canUpdateSelectedNode(context), navigation.isNotTrashcan(context), !isSmartFolder(context)].every(Boolean);
+  [canUpdateSelectedNode(context), navigation.isNotTrashcan(context), !isSmartFolder(context), !isMultiselection(context)].every(Boolean);
 
 /**
  * Checks if user can toggle **Edit Offline** mode for selected node.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
On multi select file/folder permission menu should is shown


**What is the new behaviour?**
On multi select file/folder permission menu isn't shown


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
