### PR TITLE
[ACS-6278] - Permissions manager should not be showed for smart folder

### DIFF
--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -9,7 +9,7 @@
       <div class="aca-details-title">
         <div class="aca-details-breadcrumb" role="heading" aria-level="2" *ngIf="node">
           <span class="aca-details-breadcrumb-library">
-            <img class="aca-details-breadcrumb-icon" alt="{{ 'APP.INFO_DRAWER.ICON' | translate }}" src="{{ nodeIcon }}">       
+            <img class="aca-details-breadcrumb-icon" alt="{{ 'APP.INFO_DRAWER.ICON' | translate }}" src="{{ nodeIcon }}">
             {{ node.name }} </span>
         </div>
         <div class="acs-details-buttons">
@@ -36,7 +36,7 @@
             <app-comments-tab *ngIf="node && !isLoading; else loading" [node]="node"></app-comments-tab>
           </ng-template>
         </mat-tab>
-        <mat-tab label="{{ 'APP.INFO_DRAWER.TABS.PERMISSIONS' | translate }}">
+        <mat-tab [disabled]="!canManagePermissions" label="{{ 'APP.INFO_DRAWER.TABS.PERMISSIONS' | translate }}">
           <ng-template matTabContent>
             <adf-permission-list *ngIf="node && !isLoading; else loading" [nodeId]="node.id"></adf-permission-list>
           </ng-template>

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -30,7 +30,7 @@ import { BehaviorSubject, of, Subject } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
-import { STORE_INITIAL_APP_DATA, SetSelectedNodesAction, NavigateToFolder } from '@alfresco/aca-shared/store';
+import { NavigateToFolder, SetSelectedNodesAction, STORE_INITIAL_APP_DATA } from '@alfresco/aca-shared/store';
 import { NodeEntry, PathElement } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, PageTitleService } from '@alfresco/adf-core';
@@ -200,5 +200,46 @@ describe('DetailsComponent', () => {
       .catch((error) => {
         fail(`An error occurred: ${error}`);
       });
+  });
+
+  it('should disable the permissions tab for smart folders based on aspects', () => {
+    node.entry.isFolder = true;
+    node.entry.aspectNames = ['smf:customConfigSmartFolder'];
+    fixture.detectChanges();
+    component.ngOnInit();
+    expect(component.canManagePermissions).toBeFalse();
+    expect(component.activeTab).not.toBe(2);
+  });
+
+  it('should enable the permissions tab for regular folders based on aspects', () => {
+    node.entry.isFolder = true;
+    node.entry.aspectNames = [];
+    fixture.detectChanges();
+    component.ngOnInit();
+
+    expect(component.canManagePermissions).toBeTrue();
+  });
+
+  it('should change active tab based on canManagePermissions and tabName', () => {
+    component.nodeId = 'someNodeId';
+    component.activeTab = 0;
+
+    node.entry.isFolder = true;
+    node.entry.aspectNames = [];
+
+    fixture.detectChanges();
+    component.ngOnInit();
+
+    component.setActiveTab('permissions');
+    expect(component.activeTab).toBe(2);
+
+    node.entry.isFolder = true;
+    node.entry.aspectNames = ['smf:customConfigSmartFolder'];
+
+    fixture.detectChanges();
+    component.ngOnInit();
+
+    component.setActiveTab('permissions');
+    expect(component.activeTab).not.toBe(2);
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6278
It's possible to enter permissions for smart folders via link.


**What is the new behaviour?**
After going to smart folder permissions link, we will be redirected to the details tab. Permissions tab will be disabled.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
