### PR TITLE
[ACS-5994] Remove redundant deleteNodes method from e2e

### DIFF
--- a/e2e/protractor/suites/actions/delete/delete-undo-delete.test.ts
+++ b/e2e/protractor/suites/actions/delete/delete-undo-delete.test.ts
@@ -117,7 +117,7 @@ describe('Delete and undo delete', () => {
       try {
         await userActions.login(username, username);
         await userActions.unlockNodes([fileLocked1Id, fileLocked2Id, fileLocked3Id, fileLocked4Id]);
-        await userActions.deleteNodes([parentId]);
+        await apis.user.nodes.deleteNodeById(parentId);
         await userActions.emptyTrashcan();
       } catch {}
     });

--- a/e2e/protractor/suites/actions/delete/permanently-delete.test.ts
+++ b/e2e/protractor/suites/actions/delete/permanently-delete.test.ts
@@ -58,7 +58,7 @@ describe('Permanently delete from Trash', () => {
     await apis.user.sites.createSite(site);
 
     await userActions.login(username, username);
-    await userActions.deleteNodes([...filesIds, ...foldersIds], false);
+    await apis.user.nodes.deleteNodesById([...filesIds, ...foldersIds], false);
     await userActions.deleteSites([site], false);
 
     await loginPage.loginWith(username);

--- a/e2e/protractor/suites/actions/delete/restore.test.ts
+++ b/e2e/protractor/suites/actions/delete/restore.test.ts
@@ -61,7 +61,7 @@ describe('Restore from Trash', () => {
       await apis.user.sites.createSite(site);
 
       await userActions.login(username, username);
-      await userActions.deleteNodes([fileId, folderId], false);
+      await apis.user.nodes.deleteNodesById([fileId, folderId], false);
       await userActions.deleteSites([site], false);
     });
 
@@ -85,7 +85,7 @@ describe('Restore from Trash', () => {
       await page.clickPersonalFilesAndWait();
       expect(await page.dataTable.isItemPresent(file)).toBe(true, 'Item not displayed in list');
 
-      await userActions.deleteNodes([fileId], false);
+      await apis.user.nodes.deleteNodeById(fileId, false);
     });
 
     it('[C280438] restore folder', async () => {
@@ -99,7 +99,7 @@ describe('Restore from Trash', () => {
       await page.clickPersonalFilesAndWait();
       expect(await page.dataTable.isItemPresent(folder)).toBe(true, 'Item not displayed in list');
 
-      await userActions.deleteNodes([folderId], false);
+      await apis.user.nodes.deleteNodeById(folderId, false);
     });
 
     it('[C290104] restore library', async () => {
@@ -127,7 +127,7 @@ describe('Restore from Trash', () => {
       expect(await page.dataTable.isItemPresent(file)).toBe(true, 'Item not displayed in list');
       expect(await page.dataTable.isItemPresent(folder)).toBe(true, 'Item not displayed in list');
 
-      await userActions.deleteNodes([fileId, folderId], false);
+      await apis.user.nodes.deleteNodesById([fileId, folderId], false);
     });
 
     it('[C217181] View from notification', async () => {
@@ -138,7 +138,7 @@ describe('Restore from Trash', () => {
       expect(await page.sidenav.isActive('Personal Files')).toBe(true, 'Personal Files sidebar link not active');
       expect(await browser.getCurrentUrl()).toContain(APP_ROUTES.PERSONAL_FILES);
 
-      await userActions.deleteNodes([fileId], false);
+      await apis.user.nodes.deleteNodeById(fileId, false);
     });
   });
 
@@ -159,13 +159,13 @@ describe('Restore from Trash', () => {
       file1Id1 = (await apis.user.nodes.createFile(file1, folder1Id)).entry.id;
 
       await userActions.login(username, username);
-      await userActions.deleteNodes([file1Id1], false);
+      await apis.user.nodes.deleteNodeById(file1Id1, false);
       file1Id2 = (await apis.user.nodes.createFile(file1, folder1Id)).entry.id;
 
       folder2Id = (await apis.user.nodes.createFolder(folder2)).entry.id;
       file2Id = (await apis.user.nodes.createFile(file2, folder2Id)).entry.id;
 
-      await userActions.deleteNodes([file2Id, folder2Id], false);
+      await apis.user.nodes.deleteNodesById([file2Id, folder2Id], false);
     });
 
     beforeEach(async () => {
@@ -174,7 +174,7 @@ describe('Restore from Trash', () => {
 
     afterAll(async () => {
       await userActions.login(username, username);
-      await userActions.deleteNodes([file1Id2]);
+      await apis.user.nodes.deleteNodeById(file1Id2);
       await userActions.emptyTrashcan();
     });
 
@@ -220,7 +220,7 @@ describe('Restore from Trash', () => {
         file2Id = (await apis.user.nodes.createFile(file2, folder2Id)).entry.id;
 
         await userActions.login(username, username);
-        await userActions.deleteNodes([file1Id, folder1Id, file2Id], false);
+        await apis.user.nodes.deleteNodesById([file1Id, folder1Id, file2Id], false);
 
         folder3Id = (await apis.user.nodes.createFolder(folder3)).entry.id;
         file3Id = (await apis.user.nodes.createFile(file3, folder3Id)).entry.id;
@@ -228,7 +228,7 @@ describe('Restore from Trash', () => {
         folder4Id = (await apis.user.nodes.createFolder(folder4)).entry.id;
         file5Id = (await apis.user.nodes.createFile(file5, folder4Id)).entry.id;
 
-        await userActions.deleteNodes([file3Id, file4Id, folder3Id, file5Id], false);
+        await apis.user.nodes.deleteNodesById([file3Id, file4Id, folder3Id, file5Id], false);
         await loginPage.loginWith(username);
       } catch {}
     });

--- a/e2e/protractor/suites/actions/edit/edit-offline.test.ts
+++ b/e2e/protractor/suites/actions/edit/edit-offline.test.ts
@@ -77,7 +77,7 @@ describe('Edit offline', () => {
 
     afterAll(async () => {
       await userActions.login(username, username);
-      await userActions.deleteNodes([parentPFId]);
+      await apis.user.nodes.deleteNodeById(parentPFId);
     });
 
     it('[C297538] File is locked and downloaded when clicking Edit Offline', async () => {

--- a/e2e/protractor/suites/actions/favorite/mark-favorite.test.ts
+++ b/e2e/protractor/suites/actions/favorite/mark-favorite.test.ts
@@ -102,7 +102,7 @@ describe('Mark items as favorites', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
   });
 
   afterEach(async () => {

--- a/e2e/protractor/suites/actions/upload-download/download.test.ts
+++ b/e2e/protractor/suites/actions/upload-download/download.test.ts
@@ -112,7 +112,7 @@ describe('Download', () => {
 
   afterAll(async () => {
     await userActions.login(username, username);
-    await userActions.deleteNodes([parentId]);
+    await apis.user.nodes.deleteNodeById(parentId);
     await userActions.emptyTrashcan();
   });
 

--- a/e2e/protractor/suites/actions/upload-download/upload-file.test.ts
+++ b/e2e/protractor/suites/actions/upload-download/upload-file.test.ts
@@ -60,7 +60,7 @@ describe('Upload files', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([folder1Id]);
+    await apis.user.nodes.deleteNodeById(folder1Id);
   });
 
   it('Upload a file', async () => {

--- a/e2e/protractor/suites/actions/upload-download/upload-new-version.test.ts
+++ b/e2e/protractor/suites/actions/upload-download/upload-new-version.test.ts
@@ -112,7 +112,7 @@ describe('Upload new version', () => {
 
   afterAll(async () => {
     await userActions.login(username, username);
-    await userActions.deleteNodes([parentPFId, parentSFId, parentRFId, parentFavId, parentSearchId]);
+    await apis.user.nodes.deleteNodesById([parentPFId, parentSFId, parentRFId, parentFavId, parentSearchId]);
   });
 
   describe('on Search Results', () => {

--- a/e2e/protractor/suites/actions/upload-download/version-actions.test.ts
+++ b/e2e/protractor/suites/actions/upload-download/version-actions.test.ts
@@ -90,7 +90,7 @@ describe('Version actions', () => {
   });
 
   afterAll(async () => {
-    await userActions.deleteNodes([parentFolderId]);
+    await apis.user.nodes.deleteNodeById(parentFolderId);
   });
 
   describe('on Personal Files', () => {

--- a/e2e/protractor/suites/viewer/viewer-actions.test.ts
+++ b/e2e/protractor/suites/viewer/viewer-actions.test.ts
@@ -126,7 +126,7 @@ describe('Viewer actions', () => {
     afterAll(async () => {
       try {
         await userActions.login(username, username);
-        await userActions.deleteNodes([parentId, destinationId]);
+        await apis.user.nodes.deleteNodesById([parentId, destinationId]);
         await userActions.emptyTrashcan();
       } catch {}
     });
@@ -228,7 +228,7 @@ describe('Viewer actions', () => {
     afterAll(async () => {
       try {
         await userActions.login(username, username);
-        await userActions.deleteNodes([parentId, destinationId]);
+        await apis.user.nodes.deleteNodesById([parentId, destinationId]);
         await userActions.emptyTrashcan();
       } catch {}
     });
@@ -329,7 +329,7 @@ describe('Viewer actions', () => {
     afterAll(async () => {
       try {
         await userActions.login(username, username);
-        await userActions.deleteNodes([parentId, destinationId]);
+        await apis.user.nodes.deleteNodesById([parentId, destinationId]);
         await userActions.emptyTrashcan();
       } catch {}
     });
@@ -402,7 +402,7 @@ describe('Viewer actions', () => {
     afterAll(async () => {
       try {
         await userActions.login(username, username);
-        await userActions.deleteNodes([parentId, destinationId]);
+        await apis.user.nodes.deleteNodesById([parentId, destinationId]);
         await userActions.emptyTrashcan();
       } catch {}
     });

--- a/projects/aca-playwright-shared/src/api/nodes-api.ts
+++ b/projects/aca-playwright-shared/src/api/nodes-api.ts
@@ -144,9 +144,7 @@ export class NodesApi {
    */
   async deleteNodes(nodeIds: string[], permanent: boolean = true): Promise<any> {
     try {
-      for (const nodeId of nodeIds) {
-        await this.apiService.nodes.deleteNode(nodeId, { permanent });
-      }
+      await this.apiService.nodes.deleteNodes(nodeIds, { permanent });
     } catch (error) {
       console.error(`${this.constructor.name} ${this.deleteNodes.name}`, error);
     }

--- a/projects/aca-testing-shared/src/utilities/repo-client/apis/nodes/nodes-api.ts
+++ b/projects/aca-testing-shared/src/utilities/repo-client/apis/nodes/nodes-api.ts
@@ -166,9 +166,7 @@ export class NodesApi extends RepoApi {
   async deleteNodesById(ids: string[], permanent: boolean = true): Promise<void> {
     try {
       await this.apiAuth();
-      for (const id of ids) {
-        await this.nodesApi.deleteNode(id, { permanent });
-      }
+      await this.nodesApi.deleteNodes(ids, { permanent });
     } catch (error) {
       this.handleError(`${this.constructor.name} ${this.deleteNodesById.name}`, error);
     }

--- a/projects/aca-testing-shared/src/utilities/user-actions.ts
+++ b/projects/aca-testing-shared/src/utilities/user-actions.ts
@@ -70,21 +70,6 @@ export class UserActions {
   }
 
   /**
-   * Delete multiple nodes.
-   * @param nodeIds The list of node IDs to delete.
-   * @param permanent Delete permanently, without moving to the trashcan? (default: true)
-   */
-  async deleteNodes(nodeIds: string[], permanent: boolean = true): Promise<any> {
-    try {
-      for (const nodeId of nodeIds) {
-        await this.nodesApi.deleteNode(nodeId, { permanent });
-      }
-    } catch (error) {
-      this.handleError('User Actions - deleteNodes failed : ', error);
-    }
-  }
-
-  /**
    * Empties the trashcan. Uses multiple batches 1000 nodes each.
    */
   async emptyTrashcan(): Promise<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-5994

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
