### PR TITLE
[ACS-6212] Corrected color for warning

### DIFF
--- a/projects/aca-content/src/lib/ui/colors.scss
+++ b/projects/aca-content/src/lib/ui/colors.scss
@@ -76,7 +76,7 @@ $aca-warn: (
   A100: #b8082a,
   A200: #db0f36,
   A400: #ff5252,
-  A700: #ff8a80,
+  A700: #c95100,
   contrast: (
     50: $black-87-opacity,
     100: $black-87-opacity,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6212


**What is the new behaviour?**
Color for warning message for public link is correct now.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ADF PR: https://github.com/Alfresco/alfresco-ng2-components/pull/9219