### PR TITLE
[ACS-6573] Manage permissions window can now be opened from inside file preview

### DIFF
--- a/projects/aca-content/src/lib/store/effects/node.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/node.effects.spec.ts
@@ -381,19 +381,19 @@ describe('NodeEffects', () => {
 
   describe('managePermissions$', () => {
     it('should manage permissions from the payload', () => {
-      spyOn(router, 'navigate').and.stub();
+      spyOn(router, 'navigateByUrl').and.stub();
       const node: any = { entry: { isFile: true, id: 'fileId' } };
       store.dispatch(new ManagePermissionsAction(node));
 
-      expect(router.navigate).toHaveBeenCalledWith(['personal-files/details', 'fileId', 'permissions']);
+      expect(router.navigateByUrl).toHaveBeenCalledWith('personal-files/details/fileId/permissions');
     });
 
     it('should manage permissions from the active selection', () => {
       spyOn(store, 'select').and.returnValue(of({ isEmpty: false, last: { entry: { id: 'fileId' } } }));
-      spyOn(router, 'navigate').and.stub();
+      spyOn(router, 'navigateByUrl').and.stub();
       store.dispatch(new ManagePermissionsAction(null));
 
-      expect(router.navigate).toHaveBeenCalledWith(['personal-files/details', 'fileId', 'permissions']);
+      expect(router.navigateByUrl).toHaveBeenCalledWith('personal-files/details/fileId/permissions');
     });
 
     it('should do nothing if invoking manage permissions with no data', () => {

--- a/projects/aca-content/src/lib/store/effects/node.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/node.effects.ts
@@ -50,7 +50,8 @@ import {
   ExpandInfoDrawerAction,
   ManageRulesAction,
   ShowLoaderAction,
-  ToggleInfoDrawerAction
+  ToggleInfoDrawerAction,
+  NavigateUrlAction
 } from '@alfresco/aca-shared/store';
 import { ContentManagementService } from '../../services/content-management.service';
 import { RenditionService } from '@alfresco/adf-content-services';
@@ -285,7 +286,7 @@ export class NodeEffects {
         map((action) => {
           if (action?.payload) {
             const route = 'personal-files/details';
-            this.store.dispatch(new NavigateRouteAction([route, action.payload.entry.id, 'permissions']));
+            this.store.dispatch(new NavigateUrlAction([route, action.payload.entry.id, 'permissions'].join('/')));
           } else {
             this.store
               .select(getAppSelection)
@@ -293,7 +294,7 @@ export class NodeEffects {
               .subscribe((selection) => {
                 if (selection && !selection.isEmpty) {
                   const route = 'personal-files/details';
-                  this.store.dispatch(new NavigateRouteAction([route, selection.last.entry.id, 'permissions']));
+                  this.store.dispatch(new NavigateUrlAction([route, selection.last.entry.id, 'permissions'].join('/')));
                 }
               });
           }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Manage Permissions window could not be opened from inside file preview. The URL got updated to a wrong address


**What is the new behaviour?**
Manage Permissions window could not be opened from inside file preview. URL is now updated properly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
RCA [here](https://alfresco.atlassian.net/browse/ACS-6573?focusedCommentId=1232650)
