### PR TITLE
[ACS-6576] Local storage prefix is not always created/updated properly in ADW 

### DIFF
--- a/projects/aca-shared/src/lib/services/app.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.service.spec.ts
@@ -157,7 +157,7 @@ describe('AppService', () => {
     await expect(isReady).toEqual(true);
   });
 
-  it('should set storage prefix after login', async () => {
+  it('should set local storage prefix after login', () => {
     spyOn(preferencesService, 'setStoragePrefix');
     spyOn(auth, 'getUsername').and.returnValue('test-username');
     auth.onLogin.next();

--- a/projects/aca-shared/src/lib/services/app.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.service.spec.ts
@@ -31,7 +31,8 @@ import {
   PageTitleService,
   AlfrescoApiServiceMock,
   TranslationMock,
-  TranslationService
+  TranslationService,
+  UserPreferencesService
 } from '@alfresco/adf-core';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
@@ -66,6 +67,7 @@ describe('AppService', () => {
   let sharedLinksApiService: SharedLinksApiService;
   let contentApi: ContentApiService;
   let groupService: GroupService;
+  let preferencesService: UserPreferencesService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -110,10 +112,12 @@ describe('AppService', () => {
           useValue: {
             onLogin: new Subject<any>(),
             onLogout: new Subject<any>(),
-            isLoggedIn: () => false
+            isLoggedIn: () => false,
+            getUsername: () => null
           }
         },
-        { provide: TranslationService, useClass: TranslationMock }
+        { provide: TranslationService, useClass: TranslationMock },
+        { provide: UserPreferencesService, useValue: { setStoragePrefix: () => null } }
       ]
     });
 
@@ -126,6 +130,7 @@ describe('AppService', () => {
     contentApi = TestBed.inject(ContentApiService);
     groupService = TestBed.inject(GroupService);
     service = TestBed.inject(AppService);
+    preferencesService = TestBed.inject(UserPreferencesService);
   });
 
   it('should be ready if [withCredentials] mode is used', (done) => {
@@ -150,6 +155,14 @@ describe('AppService', () => {
     });
     auth.onLogin.next();
     await expect(isReady).toEqual(true);
+  });
+
+  it('should set storage prefix after login', async () => {
+    spyOn(preferencesService, 'setStoragePrefix');
+    spyOn(auth, 'getUsername').and.returnValue('test-username');
+    auth.onLogin.next();
+
+    expect(preferencesService.setStoragePrefix).toHaveBeenCalledWith('test-username');
   });
 
   it('should reset search to defaults upon logout', async () => {

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -98,6 +98,7 @@ export class AppService implements OnDestroy {
 
     this.authenticationService.onLogin.subscribe(() => {
       this.ready.next(true);
+      this.preferencesService.setStoragePrefix(this.authenticationService.getUsername());
     });
 
     this.authenticationService.onLogout.subscribe(() => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6576

Local storage prefix is created/updated only with basic authentication. So, user preferences are saved as for GUEST user. 

**What is the new behaviour?**

In ADW local storage prefix is now correctly created & updated when user changes, which allows to properly save user preferences for separate users.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
