### PR TITLE
[ACS-6642] Tags column and getTags API call is now dynamic on app.config.json for search page

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -75,7 +75,7 @@
               <data-column id="app.search.size" key="content.sizeInBytes" type="fileSize" title="APP.DOCUMENT_LIST.COLUMNS.SIZE" class="adf-no-grow-cell adf-ellipsis-cell" [sortable]="false" *ngIf="!isSmallScreen" [draggable]="true"></data-column>
               <data-column id="app.search.modifiedOn" key="modifiedAt" type="date" title="APP.DOCUMENT_LIST.COLUMNS.MODIFIED_ON" class="adf-no-grow-cell adf-ellipsis-cell" format="timeAgo" [sortable]="false" *ngIf="!isSmallScreen" [draggable]="true"></data-column>
               <data-column id="app.search.modifiedBy" key="modifiedByUser.displayName" title="APP.DOCUMENT_LIST.COLUMNS.MODIFIED_BY" class="adf-no-grow-cell adf-ellipsis-cell" [sortable]="false" *ngIf="!isSmallScreen" [draggable]="true"></data-column>
-              <data-column id="app.search.tags" key="$tags" type="text" title="APP.DOCUMENT_LIST.COLUMNS.TAGS" class="adf-full-width adf-expand-cell-4" [sortable]="false" [draggable]="true">
+              <data-column id="app.search.tags" key="$tags" type="text" title="APP.DOCUMENT_LIST.COLUMNS.TAGS" class="adf-full-width adf-expand-cell-4" [sortable]="false" [draggable]="true" *ngIf="isTagsEnabled">
                 <ng-template let-context>
                   <aca-tags-column [context]="context"></aca-tags-column>
                 </ng-template>

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
@@ -22,15 +22,15 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { SearchResultsComponent } from './search-results.component';
 import { AppConfigService, TranslationService } from '@alfresco/adf-core';
 import { Store } from '@ngrx/store';
 import { NavigateToFolder, SnackbarErrorAction } from '@alfresco/aca-shared/store';
-import { Pagination, SearchRequest } from '@alfresco/js-api';
-import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { Pagination, ResultSetPaging, SearchRequest } from '@alfresco/js-api';
+import { SearchQueryBuilderService, TagService } from '@alfresco/adf-content-services';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 import { AppService } from '@alfresco/aca-shared';
 
@@ -273,5 +273,81 @@ describe('SearchComponent', () => {
     queryBuilder.configUpdated.next({ 'aca:fields': ['cm:tag'] } as any);
     expect(queryBuilder.userQuery).toBe(`((=cm:tag:"orange"))`);
     expect(queryBuilder.update).toHaveBeenCalled();
+  });
+
+  describe('Dynamic Columns', () => {
+    let tagsService: TagService;
+
+    beforeEach(() => {
+      tagsService = TestBed.inject(TagService);
+
+      spyOn(queryBuilder['searchApi'], 'search').and.returnValue(
+        Promise.resolve({
+          list: {
+            pagination: {
+              count: 1,
+              hasMoreItems: false,
+              totalItems: 1,
+              skipCount: 0,
+              maxItems: 25
+            },
+            entries: [
+              {
+                entry: {
+                  isFile: true,
+                  nodeType: 'cm:content',
+                  isFolder: false,
+                  name: 'test-file.txt',
+                  id: '8dd4d319-ec9f-4ea0-8276-f3b195918477'
+                }
+              }
+            ]
+          }
+        } as ResultSetPaging)
+      );
+
+      spyOn(queryBuilder, 'buildQuery').and.returnValue(searchRequest);
+    });
+
+    it('should not show tags column if tags are disabled', fakeAsync(() => {
+      spyOn(tagsService, 'areTagsEnabled').and.returnValue(false);
+      fixture = TestBed.createComponent(SearchResultsComponent);
+      fixture.detectChanges();
+      queryBuilder.execute();
+      tick();
+      fixture.detectChanges();
+      const tagsColumnHeader = fixture.nativeElement.querySelector(`[data-automation-id='auto_id_$tags']`);
+      expect(tagsColumnHeader).toBeNull();
+    }));
+
+    it('should show tags column if tags are enabled', fakeAsync(() => {
+      spyOn(tagsService, 'areTagsEnabled').and.returnValue(true);
+      spyOn(tagsService, 'getTagsByNodeId').and.returnValue(
+        of({
+          list: {
+            pagination: {
+              count: 0,
+              hasMoreItems: false,
+              totalItems: 0,
+              skipCount: 0,
+              maxItems: 100
+            },
+            entries: []
+          }
+        })
+      );
+      fixture = TestBed.createComponent(SearchResultsComponent);
+      fixture.detectChanges();
+      queryBuilder.execute();
+      tick();
+      fixture.detectChanges();
+      const tagsColumnHeader = fixture.nativeElement.querySelector(`[data-automation-id='auto_id_$tags']`);
+      expect(tagsColumnHeader).not.toBeNull();
+      flush();
+    }));
+
+    afterEach(() => {
+      fixture.destroy();
+    });
   });
 });

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -25,7 +25,7 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { NodeEntry, Pagination, ResultSetPaging } from '@alfresco/js-api';
 import { ActivatedRoute, Params } from '@angular/router';
-import { AlfrescoViewerModule, DocumentListModule, SearchModule, SearchQueryBuilderService } from '@alfresco/adf-content-services';
+import { AlfrescoViewerModule, DocumentListModule, SearchModule, SearchQueryBuilderService, TagService } from '@alfresco/adf-content-services';
 import {
   infoDrawerPreview,
   NavigateToFolder,
@@ -102,9 +102,17 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
   sorting = ['name', 'asc'];
   isLoading = false;
   totalResults: number;
+  isTagsEnabled = false;
 
-  constructor(private queryBuilder: SearchQueryBuilderService, private route: ActivatedRoute, private translationService: TranslationService) {
+  constructor(
+    tagsService: TagService,
+    private queryBuilder: SearchQueryBuilderService,
+    private route: ActivatedRoute,
+    private translationService: TranslationService
+  ) {
     super();
+
+    this.isTagsEnabled = tagsService.areTagsEnabled();
 
     queryBuilder.paging = {
       skipCount: 0,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Tags column and getTags API was still being called from search page, even if the tags plugin was disabled from app.config.json
Link for [ACS-6642](https://alfresco.atlassian.net/browse/ACS-6642)

**What is the new behaviour?**
Tags column and getTags API is now dynamic for search page, from app.config.json


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-6642]: https://alfresco.atlassian.net/browse/ACS-6642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ