### PR TITLE
[ACS-6583] Fix flickering toolbar on folder upload

### DIFF
--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -227,6 +227,18 @@ describe('FilesComponent', () => {
       expect(component.reload).toHaveBeenCalled();
     }));
 
+    it('should not call reload on fileUploadComplete event if file parent folder already displayed', fakeAsync(() => {
+      spyOn(component.documentList.data, 'getRows').and.returnValue([{ node: { entry: { isFolder: true, name: 'files' } } }] as any);
+      const file: any = { file: { options: { parentId: 'parentId', path: '/files' } } };
+      component.node = { id: 'parentId' } as any;
+
+      uploadService.fileUploadComplete.next(file);
+
+      tick(500);
+
+      expect(component.reload).not.toHaveBeenCalled();
+    }));
+
     it('should not call refresh on fileUploadComplete event if parent mismatch', fakeAsync(() => {
       const file: any = { file: { options: { parentId: 'otherId' } } };
       component.node = { id: 'parentId' } as any;

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -257,7 +257,7 @@ export class FilesComponent extends PageComponent implements OnInit, OnDestroy {
   }
 
   displayFolderParent(index: number, filePath = '') {
-    const parentName = filePath.split('/')[index];
+    const parentName = filePath.split('/').filter((el) => el)[index];
     const currentFoldersDisplayed = (this.documentList.data.getRows() as ShareDataRow[]) || [];
 
     const alreadyDisplayedParentFolder = currentFoldersDisplayed.find((row) => row.node.entry.isFolder && row.node.entry.name === parentName);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6583

Folder uploaded with drag and drop has extra `/` in the path resulting to failing if statement so that reload being called multiple times when it is not needed. 

**What is the new behaviour?**

The file is selected and the toolbar is displayed as normal

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
