### PR TITLE
[ACS-6620] Use extensions instead of content key for viewer extensions

### DIFF
--- a/docs/extending/application-features.md
+++ b/docs/extending/application-features.md
@@ -33,7 +33,7 @@ All the customizations are stored in the `features` section of the configuration
     "viewer": {
       "toolbarActions:": [],
       "openWith": [],
-      "content": []
+      "extensions": []
     },
     "sidebar": [],
     "content-metadata-presets": []
@@ -397,7 +397,7 @@ declared in the `rules` section:
 
 Viewer component in ACA supports the following extension points:
 
-- Content Viewers
+- Viewer extensions
 - Toolbar actions
 - `More` toolbar actions
 - `Open With` actions
@@ -419,9 +419,9 @@ Viewer component in ACA supports the following extension points:
 }
 ```
 
-### Content View
+### Viewer extensions
 
-You can provide custom components that render a particular type of the content based on extensions.
+You can provide custom components that render a particular type of the content based on file extensions.
 
 ```json
 {
@@ -431,7 +431,7 @@ You can provide custom components that render a particular type of the content b
 
   "features": {
     "viewer": {
-      "content": [
+      "extensions": [
         {
           "id": "app.viewer.pdf",
           "fileExtension": "pdf",

--- a/docs/ja/extending/application-features.md
+++ b/docs/ja/extending/application-features.md
@@ -33,7 +33,7 @@ ACA は、次の拡張ポイントのセットをサポートします:
     "viewer": {
       "toolbarActions:": [],
       "openWith": [],
-      "content": []
+      "extensions": []
     },
     "sidebar": [],
     "content-metadata-presets": []
@@ -376,7 +376,7 @@ ACA の Viewer コンポーネントは、次の拡張ポイントをサポー�
 
   "features": {
     "viewer": {
-      "content": [],
+      "extensions": [],
       "toolbarActions:": [],
       "openWith": []
     }
@@ -396,7 +396,7 @@ ACA の Viewer コンポーネントは、次の拡張ポイントをサポー�
 
   "features": {
     "viewer": {
-      "content": [
+      "extensions": [
         {
           "id": "app.viewer.pdf",
           "fileExtension": "pdf",

--- a/docs/tutorials/custom-viewer.md
+++ b/docs/tutorials/custom-viewer.md
@@ -72,7 +72,7 @@ You also need to provide in your `app.extension.json` its details:
   "$description": "my viewer  plugin",
   "features": {
     "viewer": {
-      "content": [
+      "extensions": [
         {
           "id": "my.custom.viewer",
           "fileExtension": ["png", "jpg"],
@@ -93,7 +93,7 @@ You can also use the `*` wildcard symbol to make your custom viewer implementati
   "$description": "my viewer  plugin",
   "features": {
     "viewer": {
-      "content": [
+      "extensions": [
         {
           "id": "my.custom.viewer",
           "fileExtension": "*",

--- a/extension.schema.json
+++ b/extension.schema.json
@@ -807,7 +807,7 @@
               "items": { "$ref": "#/definitions/contentActionRef" },
               "minItems": 1
             },
-            "content": {
+            "extensions": {
               "description": "Viewer content extensions",
               "type": "array",
               "items": { "$ref": "#/definitions/viewerExtensionRef" },

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -1204,7 +1204,7 @@
           }
         ]
       },
-      "content": [
+      "extensions": [
         {
           "id": "app.viewer.pdf",
           "disabled": true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Viewer extension config uses `content` key to get viewer extensions.

**What is the new behaviour?**

Config, schema and dosc has been updated to use `extensions` key instead. https://alfresco.atlassian.net/browse/ACS-6620

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
