### PR TITLE
[ACA-4730] Bottom part of the letters "g", "y" and "j" are cut in the…

### DIFF
--- a/projects/aca-content/src/lib/ui/custom-theme.scss
+++ b/projects/aca-content/src/lib/ui/custom-theme.scss
@@ -9,19 +9,35 @@
 $mat-primary-palette: mat.define-palette($aca-primary-blue, A100);
 $mat-accent-palette: mat.define-palette($aca-accent-green, A200);
 $mat-warn-palette: mat.define-palette($aca-warn, A100);
-$app-typography: mat.define-typography-config($font-family: 'Open Sans');
+$app-typography: mat.define-typography-config(
+  $font-family: 'Open Sans',
+  $display-4: mat.define-typography-level(112px, 112px, 300),
+  $display-3: mat.define-typography-level(56px, 56px, 400),
+  $display-2: mat.define-typography-level(45px, 48px, 400),
+  $display-1: mat.define-typography-level(34px, 40px, 400),
+  $headline: mat.define-typography-level(24px, 32px, 400),
+  $title: mat.define-typography-level(20px, 32px, 500),
+  $subheading-2: mat.define-typography-level(16px, 28px, 400),
+  $subheading-1: mat.define-typography-level(15px, 24px, 400),
+  $body-2: mat.define-typography-level(14px, 24px, 500),
+  $body-1: mat.define-typography-level(14px, 20px, 400),
+  $caption: mat.define-typography-level(12px, 20px, 400),
+  $button: mat.define-typography-level(14px, 14px, 500),
+  // Line-height must be unit-less fraction of the font-size.
+  $input: mat.define-typography-level(inherit, 1.25, 400)
+);
 
 @include mat.core($app-typography);
 
 $custom-theme: mat.define-light-theme(
-      (
-          color: (
-              primary: $mat-primary-palette,
-              accent: $mat-accent-palette,
-              warn: $mat-warn-palette
-          ),
-          typography: $app-typography
-      )
+  (
+    color: (
+      primary: $mat-primary-palette,
+      accent: $mat-accent-palette,
+      warn: $mat-warn-palette
+    ),
+    typography: $app-typography
+  )
 );
 
 @mixin custom-theme($theme) {


### PR DESCRIPTION
… inputs

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4730


**What is the new behaviour?**
Line height 1.25 has been added to typography which fixed this issue.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
