### PR TITLE
[ACA-4732] Update JS-API version first to fix upstream workflow

### DIFF
--- a/.github/workflows/upstream-adf.yml
+++ b/.github/workflows/upstream-adf.yml
@@ -127,7 +127,7 @@ jobs:
               echo "Migration JS done"
           }
           migrateAllDependencies() {
-              echo "Update ADF dependencies to: ${PACKAGE_VERSION_JS} and JS dependencies to: ${PACKAGE_VERSION_JS}"
+              echo "Update ADF dependencies to: ${PACKAGE_VERSION_ADF} and JS dependencies to: ${PACKAGE_VERSION_JS}"
               ./scripts/update-version.sh -v ${PACKAGE_VERSION_ADF} -vj ${PACKAGE_VERSION_JS}
               echo "Migration done"
           }

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -63,12 +63,11 @@ fi
 
 libslength=${#libs[@]}
 
-echo "====== Updating dependencies ======"
-update
-
 if [[ "${JS_VERSION}" == "" ]]
 then
   JS_VERSION=$VERSION
 fi
 
+echo "====== Updating dependencies ======"
 update_js_api
+update


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Upstream workflow right now correctly updates JS-API version first which is followed by ADF version update. https://alfresco.atlassian.net/browse/ACA-4732

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
