### PR TITLE
[MNT-24151] - ADW: Users can see some actions Edit Offline" and "Upload New Version" for the declared record

### DIFF
--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -28,30 +28,30 @@ import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { AppStore, getRuleContext } from '@alfresco/aca-shared/store';
 import {
-  SelectionState,
-  NavigationState,
-  ExtensionConfig,
-  RuleEvaluator,
   ContentActionRef,
   ContentActionType,
-  ExtensionLoaderService,
-  SidebarTabRef,
-  NavBarGroupRef,
-  sortByOrder,
-  reduceSeparators,
-  reduceEmptyMenus,
-  ExtensionService,
-  ProfileState,
-  mergeObjects,
-  ExtensionRef,
-  RuleContext,
   DocumentListPresetRef,
+  ExtensionConfig,
+  ExtensionLoaderService,
+  ExtensionRef,
+  ExtensionService,
   IconRef,
-  mergeArrays
+  mergeArrays,
+  mergeObjects,
+  NavBarGroupRef,
+  NavigationState,
+  ProfileState,
+  reduceEmptyMenus,
+  reduceSeparators,
+  RuleContext,
+  RuleEvaluator,
+  SelectionState,
+  SidebarTabRef,
+  sortByOrder
 } from '@alfresco/adf-extensions';
 import { AppConfigService, AuthenticationService, LogService } from '@alfresco/adf-core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { RepositoryInfo, NodeEntry } from '@alfresco/js-api';
+import { NodeEntry, RepositoryInfo } from '@alfresco/js-api';
 import { ViewerRules } from '../models/viewer.rules';
 import { Badge, SettingsGroupRef } from '../models/types';
 import { NodePermissionService } from '../services/node-permission.service';
@@ -496,6 +496,9 @@ export class AppExtensionService implements RuleContext {
 
   filterVisible(action: ContentActionRef | SettingsGroupRef | SidebarTabRef | DocumentListPresetRef | SearchCategory): boolean {
     if (action?.rules?.visible) {
+      if (Array.isArray(action.rules.visible)) {
+        return action.rules.visible.every((rule) => this.extensions.evaluateRule(rule, this));
+      }
       return this.extensions.evaluateRule(action.rules.visible, this);
     }
     return true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/MNT-24151
Extensions can't extend exsiting rules, they can only replace them. It's problem, when 2 extensions want to specify their own rules for the same element.
'Recent files' page doesn't have access to 'aspects' of nodes and because of that not all visibility rules can be applied.


**What is the new behaviour?**
If rule is passed in array form, it would be merged and all the rules will be applied.
'Recent files' page has access to 'aspects' of nodes.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
