### PR TITLE
[ACS-6445] Address #PT20471_7 Missing Access Control

### DIFF
--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -30,7 +30,7 @@ import { AppTestingModule } from '../../../testing/app-testing.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Site, SiteBodyCreate, SitePaging } from '@alfresco/js-api';
 import { Actions } from '@ngrx/effects';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 describe('LibraryMetadataFormComponent', () => {
   let fixture: ComponentFixture<LibraryMetadataFormComponent>;
@@ -51,7 +51,8 @@ describe('LibraryMetadataFormComponent', () => {
         {
           provide: Store,
           useValue: {
-            dispatch: jasmine.createSpy('dispatch')
+            dispatch: jasmine.createSpy('dispatch'),
+            select: () => of()
           }
         }
       ],
@@ -208,6 +209,18 @@ describe('LibraryMetadataFormComponent', () => {
     component.update();
 
     expect(store.dispatch).not.toHaveBeenCalledWith(new UpdateLibraryAction(siteEntryModel));
+  });
+
+  it('should update library node when the user is an admin but has consumer rights', () => {
+    component.node.entry.role = Site.RoleEnum.SiteConsumer;
+    component.isAdmin = true;
+
+    fixture.detectChanges();
+    component.toggleEdit();
+
+    component.update();
+
+    expect(store.dispatch).toHaveBeenCalledWith(new UpdateLibraryAction(siteEntryModel));
   });
 
   it('should not call markAsPristine on form when updating valid form but has not permission to update', () => {

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -42,7 +42,8 @@ import {
   SnackbarActionTypes,
   SnackbarErrorAction,
   SnackbarInfoAction,
-  UpdateLibraryAction
+  UpdateLibraryAction,
+  isAdmin
 } from '@alfresco/aca-shared/store';
 import { debounceTime, filter, mergeMap, takeUntil } from 'rxjs/operators';
 import { AlfrescoApiService } from '@alfresco/adf-core';
@@ -118,6 +119,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
 
   matcher = new InstantErrorStateMatcher();
   canUpdateLibrary = false;
+  isAdmin = false;
 
   onDestroy$: Subject<boolean> = new Subject<boolean>();
 
@@ -172,7 +174,13 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
           this.libraryTitleExists = false;
         }
       });
-    this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager';
+    this.store
+      .select(isAdmin)
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((value) => {
+        this.isAdmin = value;
+      });
+    this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager' || this.isAdmin;
     this.handleUpdatingEvent<SnackbarInfoAction>(SnackbarActionTypes.Info, 'LIBRARY.SUCCESS.LIBRARY_UPDATED', () =>
       Object.assign(this.node.entry, this.form.value)
     );
@@ -186,7 +194,7 @@ export class LibraryMetadataFormComponent implements OnInit, OnChanges, OnDestro
 
   ngOnChanges() {
     this.updateForm(this.node);
-    this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager';
+    this.canUpdateLibrary = this.node?.entry?.role === 'SiteManager' || this.isAdmin;
   }
 
   update() {

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -556,7 +556,7 @@ describe('app.evaluators', () => {
       expect(app.isLibraryManager(context)).toBe(true);
     });
 
-    it('should return false when role is different than SiteManager', () => {
+    it('should return false when role is different than SiteManager and user is not an admin', () => {
       const context: any = {
         selection: {
           library: {
@@ -564,10 +564,26 @@ describe('app.evaluators', () => {
               role: 'SiteCollaborator'
             }
           }
-        }
+        },
+        profile: { isAdmin: false }
       };
 
       expect(app.isLibraryManager(context)).toBe(false);
+    });
+
+    it('should return true if user is an admin no matter what the role is', () => {
+      const context: any = {
+        selection: {
+          library: {
+            entry: {
+              role: null
+            }
+          }
+        },
+        profile: { isAdmin: true }
+      };
+
+      expect(app.isLibraryManager(context)).toBe(true);
     });
   });
 

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -554,7 +554,7 @@ export const canShowLogout = (context: AcaRuleContext): boolean => !context.with
  * @param context Rule execution context
  */
 export const isLibraryManager = (context: RuleContext): boolean =>
-  hasLibrarySelected(context) && context.selection.library?.entry.role === 'SiteManager';
+  hasLibrarySelected(context) && (context.selection.library?.entry.role === 'SiteManager' || isAdmin(context));
 
 /**
  * Checks if the preview button for search results can be showed


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6445

When a user is a member of the ALFRESCO_ADMINISTRATOR group and has consumer access to the site, user is not able to modify the site from the ACA UI, while from the API it is possible. The problem here is how the UI is handling the conflict between a users explicitly declared permissions and the overriding ALFRESCO_ADMINISTRATOR group permission

**What is the new behaviour?**

Admin user is able to edit the site from the UI no matter what access type he has. Changes made to align UI along with the API as the alfresco admin group (ALFRESCO_ADMINISTRATOR) permission will override any permissions explicitly set

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
