### PR TITLE
[ACS-4103] Clear empty parameters for folder rules actions

### DIFF
--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -47,6 +47,13 @@ describe('RuleActionUiComponent', () => {
 
   const getPropertiesCardView = (): CardViewComponent => fixture.debugElement.query(By.directive(CardViewComponent)).componentInstance;
 
+  function setInputValue(value: string) {
+    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [CoreTestingModule, RuleActionUiComponent]
@@ -54,6 +61,24 @@ describe('RuleActionUiComponent', () => {
 
     fixture = TestBed.createComponent(RuleActionUiComponent);
     component = fixture.componentInstance;
+  });
+
+  it('should clear empty parameters', async () => {
+    component.actionDefinitions = actionsTransformedListMock;
+    component.parameterConstraints = dummyConstraints;
+    fixture.detectChanges();
+
+    changeMatSelectValue('mock-action-1-definition');
+
+    setInputValue('test');
+    await fixture.whenStable();
+
+    expect(component.parameters).toEqual({ 'mock-action-parameter-boolean': false, 'mock-action-parameter-text': 'test' });
+
+    setInputValue('');
+    await fixture.whenStable();
+
+    expect(component.parameters).toEqual({ 'mock-action-parameter-boolean': false });
   });
 
   it('should populate the dropdown selector with the action definitions', () => {

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
@@ -159,10 +159,10 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
     });
 
     this.cardViewUpdateService.itemUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe((updateNotification: UpdateNotification) => {
-      this.parameters = {
+      this.parameters = this.clearEmptyParameters({
         ...this.parameters,
         ...updateNotification.changed
-      };
+      });
       this.onChange({
         actionDefinitionId: this.selectedActionDefinitionId,
         params: this.parameters
@@ -291,7 +291,9 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
   setDefaultParameters() {
     this.parameters = {};
     (this.selectedActionDefinition?.parameterDefinitions ?? []).forEach((paramDef: ActionParameterDefinition) => {
-      this.parameters[paramDef.name] = paramDef.type === 'd:boolean' ? false : '';
+      if (paramDef.type === 'd:boolean') {
+        this.parameters[paramDef.name] = false;
+      }
     });
   }
 
@@ -320,5 +322,10 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
         key: constraint.value,
         label: constraint.label ? `${constraint.label} [${constraint.value}]` : constraint.value
       }));
+  }
+
+  private clearEmptyParameters(params: { [key: string]: unknown }): { [key: string]: unknown } {
+    Object.keys(params).forEach((key) => (params[key] === null || params[key] === undefined || params[key] === '') && delete params[key]);
+    return params;
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

UI sends empty parameters, which results to the failure from API. Some rules are not created without params.
https://alfresco.atlassian.net/browse/ACS-4103

**What is the new behaviour?**

Empty action parameters cleared, so request being processed properly on BE. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
