### PR TITLE
[ACS-6828] Clicking on search input when it has some content inside it does not allow user to edit search term

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.scss
@@ -29,7 +29,7 @@ $top-margin: 12px;
     display: none;
   }
 
-  label {
+  .app-input-form-field-input + span {
     cursor: text;
     pointer-events: auto;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Search input is not clickable when filled.


**What is the new behaviour?**
Search input is always clickable.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
