### PR TITLE
[ACS-6831] Correctly pass stored displayAspect to metadata component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "dependencies": {
-        "@alfresco/adf-content-services": "6.7.0-8009374031",
-        "@alfresco/adf-core": "6.7.0-8009374031",
-        "@alfresco/adf-extensions": "6.7.0-8009374031",
-        "@alfresco/eslint-plugin-eslint-angular": "6.7.0-8009374031",
-        "@alfresco/js-api": "7.6.0-8009374031",
+        "@alfresco/adf-content-services": "6.7.0-8045358395",
+        "@alfresco/adf-core": "6.7.0-8045358395",
+        "@alfresco/adf-extensions": "6.7.0-8045358395",
+        "@alfresco/eslint-plugin-eslint-angular": "6.7.0-8045358395",
+        "@alfresco/js-api": "7.6.0-8045358395",
         "@angular/animations": "14.1.3",
         "@angular/cdk": "14.1.3",
         "@angular/common": "14.1.3",
@@ -42,7 +42,7 @@
         "zone.js": "0.11.8"
       },
       "devDependencies": {
-        "@alfresco/adf-cli": "6.7.0-8009374031",
+        "@alfresco/adf-cli": "6.7.0-8045358395",
         "@angular-devkit/build-angular": "14.2.11",
         "@angular-devkit/core": "14.1.2",
         "@angular-devkit/schematics": "14.1.2",
@@ -123,12 +123,12 @@
       "dev": true
     },
     "node_modules/@alfresco/adf-cli": {
-      "version": "6.7.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-cli/-/adf-cli-6.7.0-8009374031.tgz",
-      "integrity": "sha512-LOqzbYRbnu8LjI0WRrMha9uyaQjRrBy30gW8a6oMIzHcXcZCulFeMjV9CRFcl1lmnJNdjj0HpjxhD+3txs1gtA==",
+      "version": "6.7.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-cli/-/adf-cli-6.7.0-8045358395.tgz",
+      "integrity": "sha512-i3ze7KD+6HXird+NeBh6WxsQCziJpXOeL3moE6ZeoXag2KnBFbdBlPjo0+X920sEvJhERonFnWsshwsxGZbU2w==",
       "dev": true,
       "dependencies": {
-        "@alfresco/js-api": ">=7.6.0-8009374031",
+        "@alfresco/js-api": ">=7.6.0-8045358395",
         "commander": "^6.2.1",
         "ejs": "^3.1.9",
         "license-checker": "^25.0.1",
@@ -143,15 +143,15 @@
       }
     },
     "node_modules/@alfresco/adf-content-services": {
-      "version": "6.7.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-6.7.0-8009374031.tgz",
-      "integrity": "sha512-Itm90fVYUTwFLwKHPY4qQXe7oZVscOcKvMsiDXtPWa/X1EMDr0CS0UHKoISxK4Ywd+dXmYtIwy1nDPVXix85VA==",
+      "version": "6.7.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-6.7.0-8045358395.tgz",
+      "integrity": "sha512-pXdcnCcIiNtR2ntgZdIGSTYry3ESBA3YY4kfGbHnoS+FsXD7r03TBQBQQErsj6FykcMyKCDVpWSh9AHlXxudOg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@alfresco/adf-core": ">=6.7.0-8009374031",
-        "@alfresco/js-api": ">=7.6.0-8009374031",
+        "@alfresco/adf-core": ">=6.7.0-8045358395",
+        "@alfresco/js-api": ">=7.6.0-8045358395",
         "@angular/animations": ">=14.1.3",
         "@angular/cdk": ">=14.1.2",
         "@angular/common": ">=14.1.3",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@alfresco/adf-core": {
-      "version": "6.7.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-6.7.0-8009374031.tgz",
-      "integrity": "sha512-qdi7DCYb5qvEBBwJgAzV0il5yJVRzR2mTJLNojbIO/Fw1xYnywXw5ftTtXtfxUKfGrB1yS2+QOn5E+GeKgRYLg==",
+      "version": "6.7.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-6.7.0-8045358395.tgz",
+      "integrity": "sha512-Y3UOh2+1fivbNE4pVVO9rHDTvNRWe+ZglysCbI+7vkzA7+MpC0eAqENBMAV/XKNXGDzvwSPTM+NZEfrns3lw+w==",
       "dependencies": {
         "angular-oauth2-oidc": "^13.0.1",
         "angular-oauth2-oidc-jwks": "^13.0.1",
@@ -176,8 +176,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@alfresco/adf-extensions": ">=6.7.0-8009374031",
-        "@alfresco/js-api": ">=7.6.0-8009374031",
+        "@alfresco/adf-extensions": ">=6.7.0-8045358395",
+        "@alfresco/js-api": ">=7.6.0-8045358395",
         "@angular/animations": ">=14.1.3",
         "@angular/cdk": ">=14.1.2",
         "@angular/common": ">=14.1.3",
@@ -192,27 +192,27 @@
       }
     },
     "node_modules/@alfresco/adf-extensions": {
-      "version": "6.7.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-6.7.0-8009374031.tgz",
-      "integrity": "sha512-2ECWJvACM5/4aAhvLBvIoB929qqTDzF+ROMjO+3e8NKrpe155AFFWh6+1jDLzSRhoxR7IC5YKSeTC6XQzLdM9Q==",
+      "version": "6.7.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-6.7.0-8045358395.tgz",
+      "integrity": "sha512-NQrB2DfCoyZPYoioWtY8awei23k6u+294nthEqy1Uq4WXrieuParrMhAmbzvu9Gkf7+0fppD4uvY5kVh+dwQvg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@alfresco/js-api": ">=7.6.0-8009374031",
+        "@alfresco/js-api": ">=7.6.0-8045358395",
         "@angular/common": ">=14.1.3",
         "@angular/core": ">=14.1.3"
       }
     },
     "node_modules/@alfresco/eslint-plugin-eslint-angular": {
-      "version": "6.7.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/eslint-plugin-eslint-angular/-/eslint-plugin-eslint-angular-6.7.0-8009374031.tgz",
-      "integrity": "sha512-qqNA9bB2tSEkt+xAU1Nc+07nKFgodVb5NLImKH6B51fHcwm9N9Kn2DWOdpFEPx4h3H4JeBrLgN8wtV0pior5rg=="
+      "version": "6.7.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/eslint-plugin-eslint-angular/-/eslint-plugin-eslint-angular-6.7.0-8045358395.tgz",
+      "integrity": "sha512-d2JpPLT1dv+6U/TeBblrsR2d5o1cPRk+vvoV7UuQwjjiMUWV72mBMvvntTBN6RhdJzgVtU82rcWzeQ6ZKQepOg=="
     },
     "node_modules/@alfresco/js-api": {
-      "version": "7.6.0-8009374031",
-      "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-7.6.0-8009374031.tgz",
-      "integrity": "sha512-Y+uoa8QfQE9ETIr+JmuXsdKXqTtZSqfMXHhXLWjqrntLLjjxcpO/urnvgMjAM7pjHBF+hugeDSo0sCnLsQBmOw==",
+      "version": "7.6.0-8045358395",
+      "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-7.6.0-8045358395.tgz",
+      "integrity": "sha512-nRZPx+lvFF6gsT3vYFIZHqG39uGOO2PapdIrIAkOrsKCEoujjSb6iqw6UehmmPYPYYoc0Zj25OgpQujQ4pvUiA==",
       "dependencies": {
         "event-emitter": "^0.3.5",
         "superagent": "^8.0.9",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "private": true,
   "dependencies": {
-    "@alfresco/adf-content-services": "6.7.0-8009374031",
-    "@alfresco/adf-core": "6.7.0-8009374031",
-    "@alfresco/adf-extensions": "6.7.0-8009374031",
-    "@alfresco/eslint-plugin-eslint-angular": "6.7.0-8009374031",
-    "@alfresco/js-api": "7.6.0-8009374031",
+    "@alfresco/adf-content-services": "6.7.0-8045358395",
+    "@alfresco/adf-core": "6.7.0-8045358395",
+    "@alfresco/adf-extensions": "6.7.0-8045358395",
+    "@alfresco/eslint-plugin-eslint-angular": "6.7.0-8045358395",
+    "@alfresco/js-api": "7.6.0-8045358395",
     "@angular/animations": "14.1.3",
     "@angular/cdk": "14.1.3",
     "@angular/common": "14.1.3",
@@ -66,7 +66,7 @@
     "zone.js": "0.11.8"
   },
   "devDependencies": {
-    "@alfresco/adf-cli": "6.7.0-8009374031",
+    "@alfresco/adf-cli": "6.7.0-8045358395",
     "@angular-devkit/build-angular": "14.2.11",
     "@angular-devkit/core": "14.1.2",
     "@angular-devkit/schematics": "14.1.2",

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -25,7 +25,7 @@
 import { Component, Input, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { NodePermissionService, isLocked, AppExtensionService } from '@alfresco/aca-shared';
-import { EditOfflineAction, NodeActionTypes } from '@alfresco/aca-shared/store';
+import { AppStore, EditOfflineAction, NodeActionTypes, infoDrawerMetadataAspect } from '@alfresco/aca-shared/store';
 import { AppConfigService, NotificationService } from '@alfresco/adf-core';
 import { Observable, Subject } from 'rxjs';
 import {
@@ -38,6 +38,7 @@ import {
 import { filter, map, takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { Actions, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
 
 @Component({
   standalone: true,
@@ -51,6 +52,7 @@ import { Actions, ofType } from '@ngrx/effects';
       [customPanels]="customPanels | async"
       [displayCategories]="displayCategories"
       [displayTags]="displayTags"
+      [displayAspect]="metadataAspect"
     >
     </adf-content-metadata>
   `,
@@ -67,6 +69,7 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
 
   readOnly = false;
   customPanels: Observable<ContentMetadataCustomPanel[]>;
+  metadataAspect: string;
 
   get displayCategories(): boolean {
     return this._displayCategories;
@@ -83,7 +86,8 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
     private contentMetadataService: ContentMetadataService,
     private actions$: Actions,
     private tagService: TagService,
-    private categoryService: CategoryService
+    private categoryService: CategoryService,
+    private store: Store<AppStore>
   ) {
     if (this.extensions.contentMetadata) {
       this.appConfig.config['content-metadata'].presets = this.extensions.contentMetadata.presets;
@@ -115,6 +119,10 @@ export class MetadataTabComponent implements OnInit, OnDestroy {
       }),
       takeUntil(this.onDestroy$)
     );
+    this.store
+      .select(infoDrawerMetadataAspect)
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((metadataAspect) => (this.metadataAspect = metadataAspect));
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Stored display aspect is not passed to metadata panel.

**What is the new behaviour?**

Stored display aspect is properly passed and expanded on change. https://alfresco.atlassian.net/browse/ACS-6831

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
