### PR TITLE
[ACS-6891] The user is not redirected to the library page after deleting the library from the Manage Members view

### DIFF
--- a/projects/aca-content/src/lib/services/content-management.service.spec.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.spec.ts
@@ -22,28 +22,29 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
-import { of, throwError, Subject, BehaviorSubject, EMPTY } from 'rxjs';
-import { Actions, ofType, EffectsModule } from '@ngrx/effects';
+import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { BehaviorSubject, EMPTY, of, Subject, throwError } from 'rxjs';
+import { Actions, EffectsModule, ofType } from '@ngrx/effects';
 import {
   AppStore,
-  SnackbarWarningAction,
-  SnackbarInfoAction,
-  SnackbarErrorAction,
-  PurgeDeletedNodesAction,
-  RestoreDeletedNodesAction,
-  NavigateToParentFolder,
+  CopyNodesAction,
   DeleteNodesAction,
   MoveNodesAction,
-  CopyNodesAction,
-  ShareNodeAction,
-  SetSelectedNodesAction,
-  UnlockWriteAction,
-  SnackbarActionTypes,
+  NavigateRouteAction,
+  NavigateToParentFolder,
   NodeActionTypes,
+  PurgeDeletedNodesAction,
   ReloadDocumentListAction,
-  ViewNodeVersionAction,
-  ViewNodeExtras
+  RestoreDeletedNodesAction,
+  SetSelectedNodesAction,
+  ShareNodeAction,
+  SnackbarActionTypes,
+  SnackbarErrorAction,
+  SnackbarInfoAction,
+  SnackbarWarningAction,
+  UnlockWriteAction,
+  ViewNodeExtras,
+  ViewNodeVersionAction
 } from '@alfresco/aca-shared/store';
 import { map } from 'rxjs/operators';
 import { NodeEffects } from '../store/effects/node.effects';
@@ -52,17 +53,17 @@ import { AppHookService, ContentApiService } from '@alfresco/aca-shared';
 import { Store } from '@ngrx/store';
 import { ContentManagementService } from './content-management.service';
 import { NodeActionsService } from './node-actions.service';
-import { TranslationService, NotificationService } from '@alfresco/adf-core';
+import { NotificationService, TranslationService } from '@alfresco/adf-core';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBarModule, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
-import { NodeEntry, Node, VersionPaging } from '@alfresco/js-api';
+import { Node, NodeEntry, VersionPaging } from '@alfresco/js-api';
 import {
+  FileModel,
   NewVersionUploaderDataAction,
   NewVersionUploaderService,
   NodeAspectService,
-  ViewVersion,
   NodesApiService,
-  FileModel
+  ViewVersion
 } from '@alfresco/adf-content-services';
 
 describe('ContentManagementService', () => {
@@ -1768,5 +1769,19 @@ describe('ContentManagementService', () => {
       afterClosed$.next();
       expect(document.querySelector).not.toHaveBeenCalled();
     });
+  });
+
+  describe('deleteLibrary', () => {
+    it('should dispatch NavigateRouteAction to /libraries after successful deletion', fakeAsync(() => {
+      const libraryId = 'test-library-id';
+      spyOn(contentApi, 'deleteSite').and.returnValue(of(null));
+      spyOn(store, 'dispatch').and.callThrough();
+
+      contentManagementService.deleteLibrary(libraryId);
+      tick();
+
+      expect(store.dispatch).toHaveBeenCalledWith(new SnackbarInfoAction('APP.MESSAGES.INFO.LIBRARY_DELETED'));
+      expect(store.dispatch).toHaveBeenCalledWith(new NavigateRouteAction(['/libraries']));
+    }));
   });
 });

--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -48,15 +48,15 @@ import {
   ConfirmDialogComponent,
   FolderDialogComponent,
   LibraryDialogComponent,
-  ShareDialogComponent,
-  NodeAspectService,
-  NewVersionUploaderService,
-  NewVersionUploaderDialogData,
   NewVersionUploaderData,
   NewVersionUploaderDataAction,
-  NodesApiService
+  NewVersionUploaderDialogData,
+  NewVersionUploaderService,
+  NodeAspectService,
+  NodesApiService,
+  ShareDialogComponent
 } from '@alfresco/adf-content-services';
-import { TranslationService, NotificationService } from '@alfresco/adf-core';
+import { NotificationService, TranslationService } from '@alfresco/adf-core';
 import { DeletedNodesPaging, Node, NodeEntry, PathInfo, SiteBodyCreate, SiteEntry } from '@alfresco/js-api';
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
@@ -289,6 +289,7 @@ export class ContentManagementService {
       () => {
         this.appHookService.libraryDeleted.next(id);
         this.store.dispatch(new SnackbarInfoAction('APP.MESSAGES.INFO.LIBRARY_DELETED'));
+        this.store.dispatch(new NavigateRouteAction(['/libraries']));
       },
       () => {
         this.store.dispatch(new SnackbarErrorAction('APP.MESSAGES.ERRORS.DELETE_LIBRARY_FAILED'));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6891
After deleting a library, user stays on the library page.


**What is the new behaviour?**
After deleting a library, user is redirected to libraries page.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
