### PR TITLE
[ACS-6924] Rename tags and categories plugins to mitigate naming conflicts

### DIFF
--- a/app/src/app.config.json
+++ b/app/src/app.config.json
@@ -13,8 +13,8 @@
     "aosPlugin": true,
     "contentService": true,
     "folderRules": true,
-    "tags": true,
-    "categories": true
+    "tagsEnabled": true,
+    "categoriesEnabled": true
   },
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/docker/docker-entrypoint.d/30-sed-on-appconfig.sh
+++ b/docker/docker-entrypoint.d/30-sed-on-appconfig.sh
@@ -117,3 +117,13 @@ if [ -n "${APP_BASE_SHARE_URL}" ]; then
   sed -e "s/\"baseShareUrl\": \".*\"/\"baseShareUrl\": \"${encoded}\"/g" \
     -i "$APP_CONFIG_FILE"
 fi
+
+if [ -n "${APP_CONFIG_PLUGIN_TAGS}" ]; then
+  echo "SET APP_CONFIG_PLUGIN_TAGS"
+  sed -e "s/\"tagsEnabled\": [^,]*/\"tagsEnabled\": ${APP_CONFIG_PLUGIN_TAGS}/g" -i "$APP_CONFIG_FILE"
+fi
+
+if [ -n "${APP_CONFIG_PLUGIN_CATEGORIES}" ]; then
+  echo "SET APP_CONFIG_PLUGIN_CATEGORIES"
+  sed -e "s/\"categoriesEnabled\": [^,]*/\"categoriesEnabled\": ${APP_CONFIG_PLUGIN_CATEGORIES}/g" -i "$APP_CONFIG_FILE"
+fi

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -947,7 +947,7 @@ describe('app.evaluators', () => {
       };
 
       app.areTagsEnabled(context);
-      expect(context.appConfig.get).toHaveBeenCalledWith('plugins.tags', true);
+      expect(context.appConfig.get).toHaveBeenCalledWith('plugins.tagsEnabled', true);
     });
 
     it('should return true if get from appConfig returns true', () => {
@@ -980,7 +980,7 @@ describe('app.evaluators', () => {
       };
 
       app.areCategoriesEnabled(context);
-      expect(context.appConfig.get).toHaveBeenCalledWith('plugins.categories', true);
+      expect(context.appConfig.get).toHaveBeenCalledWith('plugins.categoriesEnabled', true);
     });
 
     it('should return true if get from appConfig returns true', () => {

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -647,6 +647,6 @@ export function isSmartFolder(context: RuleContext): boolean {
   return false;
 }
 
-export const areTagsEnabled = (context: AcaRuleContext): boolean => context.appConfig.get('plugins.tags', true);
+export const areTagsEnabled = (context: AcaRuleContext): boolean => context.appConfig.get('plugins.tagsEnabled', true);
 
-export const areCategoriesEnabled = (context: AcaRuleContext): boolean => context.appConfig.get('plugins.categories', true);
+export const areCategoriesEnabled = (context: AcaRuleContext): boolean => context.appConfig.get('plugins.categoriesEnabled', true);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Tags and categories plugins has been renamed to mitigate naming conflicts during docker variable substitution. https://alfresco.atlassian.net/browse/ACS-6924

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
