### PR TITLE
[ACS-6150] Folder rules - add category selector for link category action

### DIFF
--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -30,6 +30,7 @@ import { By } from '@angular/platform-browser';
 import { dummyCategoriesConstraints, dummyConstraints, dummyTagsConstraints } from '../../mock/action-parameter-constraints.mock';
 import { CategoryService, TagService } from '@alfresco/adf-content-services';
 import { MatSelect } from '@angular/material/select';
+import { MatDialog } from '@angular/material/dialog';
 
 describe('RuleActionUiComponent', () => {
   let fixture: ComponentFixture<RuleActionUiComponent>;
@@ -124,9 +125,23 @@ describe('RuleActionUiComponent', () => {
     const cardView = getPropertiesCardView();
 
     expect(cardView.properties.length).toBe(1);
-    expect(cardView.properties[0].icon).toBeFalsy();
+    expect(cardView.properties[0].icon).toBe('library_add');
     expect(cardView.properties[0].value).toBeFalsy();
     expect(cardView.properties[0]).toBeInstanceOf(CardViewTextItemModel);
+  });
+
+  it('should open category selector dialog on category-value action parameter clicked', () => {
+    const dialog = fixture.debugElement.injector.get(MatDialog);
+    component.actionDefinitions = [actionLinkToCategoryTransformedMock];
+    component.parameterConstraints = dummyConstraints;
+    spyOn(dialog, 'open');
+    fixture.detectChanges();
+
+    changeMatSelectValue('mock-action-3-definition');
+    fixture.debugElement.query(By.css('.adf-textitem-action')).nativeElement.click();
+
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+    expect(dialog.open['calls'].argsFor(0)[0].name).toBe('CategorySelectorDialogComponent');
   });
 
   describe('Select options', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Link to a category action has a text input, where user must type in category id.

**What is the new behaviour?**

Category selector dialog added.
<img width="1175" alt="Screenshot 2024-03-12 at 09 14 47" src="https://github.com/Alfresco/alfresco-content-app/assets/84377976/5ad5b496-d243-4c34-8558-d7fb264e1a30">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-6150