### PR TITLE
[ACS-7298] beforeEach and afterAll updated for list-views

### DIFF
--- a/e2e/playwright/list-views/src/tests/file-libraries.spec.ts
+++ b/e2e/playwright/list-views/src/tests/file-libraries.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { expect } from '@playwright/test';
-import { ApiClientFactory, FavoritesPageApi, LoginPage, SitesApi, Utils, test, timeouts } from '@alfresco/playwright-shared';
+import { ApiClientFactory, FavoritesPageApi, SitesApi, Utils, test, timeouts } from '@alfresco/playwright-shared';
 import { Site } from '@alfresco/js-api';
 
 test.describe('File Libraries', () => {
@@ -88,15 +88,8 @@ test.describe('File Libraries', () => {
   });
 
   test.describe('My Libraries', () => {
-    test.beforeEach(async ({ page, myLibrariesPage }) => {
-      const loginPage = new LoginPage(page);
-      await loginPage.loginUser(
-        { username, password: username },
-        {
-          withNavigation: true,
-          waitForLoading: true
-        }
-      );
+    test.beforeEach(async ({ loginPage, myLibrariesPage }) => {
+      await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
       await myLibrariesPage.navigate();
     });
 
@@ -142,15 +135,8 @@ test.describe('File Libraries', () => {
   });
 
   test.describe('Favorite Libraries', () => {
-    test.beforeEach(async ({ page, favoritesLibrariesPage }) => {
-      const loginPage = new LoginPage(page);
-      await loginPage.loginUser(
-        { username, password: username },
-        {
-          withNavigation: true,
-          waitForLoading: true
-        }
-      );
+    test.beforeEach(async ({ loginPage, favoritesLibrariesPage }) => {
+      await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
       await favoritesLibrariesPage.navigate();
     });
 

--- a/e2e/playwright/list-views/src/tests/generic-errors.spec.ts
+++ b/e2e/playwright/list-views/src/tests/generic-errors.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { expect } from '@playwright/test';
-import { ApiClientFactory, LoginPage, NodesApi, TrashcanApi, Utils, test } from '@alfresco/playwright-shared';
+import { ApiClientFactory, NodesApi, TrashcanApi, Utils, test } from '@alfresco/playwright-shared';
 
 test.describe('Generic errors', () => {
   const username = `user-${Utils.random()}`;
@@ -52,15 +52,8 @@ test.describe('Generic errors', () => {
     }
   });
 
-  test.beforeEach(async ({ page }) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.loginUser(
-      { username, password: username },
-      {
-        withNavigation: true,
-        waitForLoading: true
-      }
-    );
+  test.beforeEach(async ({ loginPage }) => {
+    await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
   });
 
   test.afterAll(async () => {

--- a/e2e/playwright/list-views/src/tests/permissions.spec.ts
+++ b/e2e/playwright/list-views/src/tests/permissions.spec.ts
@@ -74,15 +74,8 @@ test.describe('Special permissions', () => {
       await shareApiUser.waitForFilesToBeShared([fileId]);
     });
 
-    test.beforeEach(async ({ page }) => {
-      const loginPage = new LoginPage(page);
-      await loginPage.loginUser(
-        { username, password: username },
-        {
-          withNavigation: true,
-          waitForLoading: true
-        }
-      );
+    test.beforeEach(async ({ loginPage }) => {
+      await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
     });
 
     test.afterEach(async () => {

--- a/e2e/playwright/list-views/src/tests/recent-files.spec.ts
+++ b/e2e/playwright/list-views/src/tests/recent-files.spec.ts
@@ -26,7 +26,7 @@ import { expect } from '@playwright/test';
 import { ApiClientFactory, NodesApi, SearchPageApi, SitesApi, TrashcanApi, Utils, test, timeouts } from '@alfresco/playwright-shared';
 import { Site } from '@alfresco/js-api';
 
-test.describe.only('Recent Files', () => {
+test.describe('Recent Files', () => {
   let nodeActionsUser: NodesApi;
   let siteActionsUser: SitesApi;
   let trashcanApi: TrashcanApi;

--- a/e2e/playwright/list-views/src/tests/recent-files.spec.ts
+++ b/e2e/playwright/list-views/src/tests/recent-files.spec.ts
@@ -23,19 +23,18 @@
  */
 
 import { expect } from '@playwright/test';
-import { ApiClientFactory, LoginPage, NodesApi, SearchPageApi, SitesApi, TrashcanApi, Utils, test, timeouts } from '@alfresco/playwright-shared';
+import { ApiClientFactory, NodesApi, SearchPageApi, SitesApi, TrashcanApi, Utils, test, timeouts } from '@alfresco/playwright-shared';
 import { Site } from '@alfresco/js-api';
 
-test.describe('Recent Files', () => {
+test.describe.only('Recent Files', () => {
   let nodeActionsUser: NodesApi;
   let siteActionsUser: SitesApi;
+  let trashcanApi: TrashcanApi;
   const username = `user-${Utils.random()}`;
 
   const folderName = `folder-${Utils.random()}`;
-  let folderId: string;
   const fileName1 = `file-${Utils.random()}.txt`;
   const fileName2 = `file-${Utils.random()}.txt`;
-  let file2Id: string;
   const fileName3 = `file-${Utils.random()}.txt`;
 
   const siteName = `site-${Utils.random()}`;
@@ -49,10 +48,11 @@ test.describe('Recent Files', () => {
     await apiClientFactory.createUser({ username });
     nodeActionsUser = await NodesApi.initialize(username, username);
     siteActionsUser = await SitesApi.initialize(username, username);
+    trashcanApi = await TrashcanApi.initialize(username, username);
 
-    folderId = (await nodeActionsUser.createFolder(folderName)).entry.id;
+    await nodeActionsUser.createFolder(folderName);
     await nodeActionsUser.createFiles([fileName1], folderName);
-    file2Id = (await nodeActionsUser.createFile(fileName2)).entry.id;
+    await nodeActionsUser.createFile(fileName2);
     const id = (await nodeActionsUser.createFile(fileName3)).entry.id;
 
     await nodeActionsUser.deleteNodes([id], false);
@@ -66,23 +66,13 @@ test.describe('Recent Files', () => {
     await searchApi.waitForApi(username, { expect: 3 });
   });
 
-  test.beforeEach(async ({ page, recentFilesPage }) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.loginUser(
-      { username, password: username },
-      {
-        withNavigation: true,
-        waitForLoading: true
-      }
-    );
+  test.beforeEach(async ({ loginPage, recentFilesPage }) => {
+    await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
     await recentFilesPage.navigate();
   });
 
   test.afterAll(async () => {
-    await nodeActionsUser.deleteNodes([folderId, file2Id]);
-    await siteActionsUser.deleteSites([siteName]);
-    const trashcanApi = await TrashcanApi.initialize(username, username);
-    await trashcanApi.emptyTrashcan();
+    await Utils.deleteNodesSitesEmptyTrashcan(nodeActionsUser, trashcanApi, 'afterAll failed', siteActionsUser, [siteName]);
   });
 
   test('[C213168] has the correct columns', async ({ recentFilesPage }) => {

--- a/projects/aca-playwright-shared/src/utils/utils.ts
+++ b/projects/aca-playwright-shared/src/utils/utils.ts
@@ -24,7 +24,7 @@
 
 const crypto = require('crypto');
 import * as path from 'path';
-import { LoginPage, MyLibrariesPage, PersonalFilesPage, FavoritesLibrariesPage, SearchPage, SharedPage } from '../';
+import { LoginPage, MyLibrariesPage, PersonalFilesPage, FavoritesLibrariesPage, SearchPage, SharedPage, TrashPage } from '../';
 import { NodesApi, TrashcanApi, SitesApi } from '@alfresco/playwright-shared';
 
 export class Utils {
@@ -102,12 +102,25 @@ export class Utils {
   static async reloadPageIfRowNotVisible(
     pageContext: PersonalFilesPage | MyLibrariesPage | FavoritesLibrariesPage | SearchPage | SharedPage,
     nodeName: string,
-    errorMessage = 'Error '
+    errorMessage = 'reloadPageIfRowNotVisible Error '
   ): Promise<void> {
     try {
       if (!await pageContext.dataTable.getRowByName(nodeName).isVisible()) {
         await pageContext.page.reload({ waitUntil: 'load' });
       };
+    } catch (error) {
+      console.error(`${errorMessage}: ${error}`);
+    }
+  }
+
+  static async reloadPageIfDatatableEmpty(
+    pageContext: PersonalFilesPage | MyLibrariesPage | FavoritesLibrariesPage | SearchPage | SharedPage | TrashPage,
+    errorMessage = 'reloadPageIfDatatableEmpty Error '
+  ): Promise<void> {
+    try {
+      if (await pageContext.dataTable.getEmptyFolderLocator.isVisible() || await pageContext.dataTable.emptyListTitle.isVisible()) {
+        await pageContext.page.reload({ waitUntil: 'load' });
+      }
     } catch (error) {
       console.error(`${errorMessage}: ${error}`);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7298


**What is the new behaviour?**
[ACS-7298] beforeEach and afterAll updated for list-views


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-7298]: https://hyland.atlassian.net/browse/ACS-7298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ