### PR TITLE
[ACS-7300] beforeEach and afterAll refactored for navigation tests

### DIFF
--- a/e2e/playwright/navigation/src/tests/breadcrumb-admin.spec.ts
+++ b/e2e/playwright/navigation/src/tests/breadcrumb-admin.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { expect } from '@playwright/test';
-import { ApiClientFactory, LoginPage, NodesApi, test, users, Utils } from '@alfresco/playwright-shared';
+import { ApiClientFactory, NodesApi, test, users, Utils } from '@alfresco/playwright-shared';
 
 test.describe('as admin', () => {
   test.describe.configure({ mode: 'serial' });
@@ -39,16 +39,9 @@ test.describe('as admin', () => {
     userFolderId = node.entry.id;
   });
 
-  test.beforeEach(async ({ page, personalFiles }) => {
-    const loginPage = new LoginPage(page);
+  test.beforeEach(async ({ loginPage, personalFiles }) => {
+    await Utils.tryLoginUser(loginPage, users.admin.username, users.admin.password, 'beforeEach failed');
     await personalFiles.navigate();
-    await loginPage.loginUser(
-      { username: users.admin.username, password: users.admin.password },
-      {
-        withNavigation: true,
-        waitForLoading: true
-      }
-    );
   });
 
   test.afterAll(async () => {

--- a/e2e/playwright/navigation/src/tests/sidebar.spec.ts
+++ b/e2e/playwright/navigation/src/tests/sidebar.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { expect } from '@playwright/test';
-import { ApiClientFactory, APP_ROUTES, LoginPage, SIDEBAR_LABELS, test, Utils } from '@alfresco/playwright-shared';
+import { ApiClientFactory, APP_ROUTES, SIDEBAR_LABELS, test, Utils } from '@alfresco/playwright-shared';
 
 test.describe('Sidebar', () => {
   const username = `user-${Utils.random()}`;
@@ -34,15 +34,8 @@ test.describe('Sidebar', () => {
     await apiClientFactory.createUser({ username });
   });
 
-  test.beforeEach(async ({ page }) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.loginUser(
-      { username, password: username },
-      {
-        withNavigation: true,
-        waitForLoading: true
-      }
-    );
+  test.beforeEach(async ({ loginPage }) => {
+    await Utils.tryLoginUser(loginPage, username, username, 'beforeEach failed');
   });
 
   test('[C289901] navigate to My Libraries', async ({ personalFiles, myLibrariesPage }) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7300


**What is the new behaviour?**
[ACS-7300] beforeEach and afterAll refactored for navigation tests


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-7300]: https://hyland.atlassian.net/browse/ACS-7300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ