### PR TITLE
[ACS-7303] beforeEach and afterAll updated for share-action tests

### DIFF
--- a/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
@@ -36,7 +36,7 @@ import {
 } from '@alfresco/playwright-shared';
 import { expect } from '@playwright/test';
 
-test.describe.only('Unshare a file from Search Results', () => {
+test.describe('Unshare a file from Search Results', () => {
   const random = Utils.random();
   let nodesApi: NodesApi;
   let trashcanApi: TrashcanApi;

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/share-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/share-dialog.component.ts
@@ -63,7 +63,7 @@ export class ShareDialogComponent extends BaseComponent {
   }
 
   async getLinkUrl(): Promise<string> {
-    return await this.url.inputValue();
+    return await this.url.first().inputValue();
   }
 
   async isUrlReadOnly(): Promise<boolean> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7303


**What is the new behaviour?**
[ACS-7303] beforeEach and afterAll updated for share-action tests


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-7303]: https://hyland.atlassian.net/browse/ACS-7303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ