### PR TITLE
Changed getRowsCount method not to count header row

### DIFF
--- a/e2e/playwright/list-views/src/tests/permissions.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/permissions.e2e.ts
@@ -88,7 +88,7 @@ test.describe('Special permissions', () => {
 
     test('[C213173] on Recent Files', async ({ recentFilesPage }) => {
       await recentFilesPage.navigate();
-      expect(await recentFilesPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await recentFilesPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
       await siteApiAdmin.deleteSiteMember(sitePrivate, username);
       await recentFilesPage.reload();
       expect(await recentFilesPage.dataTable.isEmpty(), 'Items are still displayed').toBe(true);
@@ -96,7 +96,7 @@ test.describe('Special permissions', () => {
 
     test('[C213227] on Favorites', async ({ favoritePage }) => {
       await favoritePage.navigate();
-      expect(await favoritePage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await favoritePage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
       await siteApiAdmin.deleteSiteMember(sitePrivate, username);
       await favoritePage.reload();
       expect(await favoritePage.dataTable.isEmpty(), 'Items are still displayed').toBe(true);
@@ -117,7 +117,7 @@ test.describe('Special permissions', () => {
       await searchPage.searchOverlay.searchFor(fileName);
       await searchPage.dataTable.spinnerWaitForReload();
 
-      expect(await searchPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await searchPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
 
       await siteApiAdmin.deleteSiteMember(sitePrivate, username);
 
@@ -168,13 +168,13 @@ test.describe('Special permissions', () => {
 
     test('[C213178] on Recent Files', async ({ recentFilesPage }) => {
       await recentFilesPage.navigate();
-      expect(await recentFilesPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await recentFilesPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
       expect(await recentFilesPage.dataTable.getItemLocationText(fileName)).toEqual('Unknown');
     });
 
     test('[C213672] on Favorites', async ({ favoritePage }) => {
       await favoritePage.navigate();
-      expect(await favoritePage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await favoritePage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
       expect(await favoritePage.dataTable.getItemLocationText(fileName)).toEqual('Unknown');
     });
 
@@ -190,7 +190,7 @@ test.describe('Special permissions', () => {
       await searchPage.searchOverlay.searchFor(fileName);
       await searchPage.dataTable.spinnerWaitForReload();
 
-      expect(await searchPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(2);
+      expect(await searchPage.dataTable.getRowsCount(), 'Incorrect number of items').toBe(1);
       expect(await searchPage.dataTable.getItemLocationText(fileName)).toEqual('Unknown');
     });
   });

--- a/e2e/playwright/search/src/tests/search-filters-logic.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-logic.e2e.ts
@@ -84,7 +84,7 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.dataTable.progressBarWaitForReload();
 
     await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeVisible();
-    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).not.toBeVisible();
+    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeHidden();
   });
 
   test('[C699501] Filter with Match Any', async ({ searchPage }) => {
@@ -94,8 +94,7 @@ test.describe('Search - Filters - Logic', () => {
     );
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
-
-    expect(await searchPage.dataTable.getRowsCount()).toBe(3);
+    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
     await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeVisible();
     await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeVisible();
   });
@@ -109,8 +108,8 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
 
-    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
-    await expect(searchPage.dataTable.getRowByName(logicFile1.name)).not.toBeVisible();
+    expect(await searchPage.dataTable.getRowsCount()).toBe(1);
+    await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeHidden();
     await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeVisible();
   });
 
@@ -120,8 +119,8 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
 
-    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
-    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).not.toBeVisible();
+    expect(await searchPage.dataTable.getRowsCount()).toBe(1);
+    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeHidden();
     await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeVisible();
 
     await searchPage.searchFilters.logicFilter.click();
@@ -129,8 +128,8 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
 
-    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
-    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).not.toBeVisible();
+    expect(await searchPage.dataTable.getRowsCount()).toBe(1);
+    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeHidden();
     await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeVisible();
 
     await searchPage.searchFilters.logicFilter.click();
@@ -138,8 +137,8 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
 
-    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
-    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).not.toBeVisible();
+    expect(await searchPage.dataTable.getRowsCount()).toBe(1);
+    await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeHidden();
     await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeVisible();
   });
 
@@ -154,8 +153,8 @@ test.describe('Search - Filters - Logic', () => {
     await searchPage.searchFiltersLogic.applyButton.click();
     await searchPage.dataTable.progressBarWaitForReload();
 
-    expect(await searchPage.dataTable.getRowsCount()).toBe(2);
-    await expect(searchPage.dataTable.getRowByName(logicFile1.name)).not.toBeVisible();
+    expect(await searchPage.dataTable.getRowsCount()).toBe(1);
+    await expect(searchPage.dataTable.getRowByName(logicFile1.name)).toBeHidden();
     await expect(searchPage.dataTable.getRowByName(logicFile2.name)).toBeVisible();
   });
 });

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
@@ -57,7 +57,8 @@ export class DataTableComponent extends BaseComponent {
   sitesRole = this.page.locator('.adf-datatable-body [data-automation-id*="datatable-row"] [aria-label="My Role"]');
 
   /** Locator for row (or rows) */
-  getRowLocator = this.getChild(`adf-datatable-row`);
+  //getRowLocator = this.getChild(`adf-datatable-row`);
+  getRowLocator = this.page.getByRole('rowgroup').nth(1).locator('adf-datatable-row');
 
   /** Locator to get "No results found" message */
   getNoResultsFoundMessage = this.getChild('adf-custom-empty-content-template', { hasText: 'No results found' });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
getRowsCount() method couns also header row; when used, expected rows had to be +1


**What is the new behaviour?**
getRowsCount() methos counts only search results rows


**Does this PR introduce a breaking change?** (check one with "x")

> - [X] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
All usages of the method has been updated in this PR.
**Other information**:
