### PR TITLE
[ACS-7511] Subfont for dialogs, make it darker

### DIFF
--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -85,6 +85,8 @@ mat-slide-toggle {
   .mdc-dialog__content {
     padding: 16px 0;
     color: var(--adf-theme-foreground-text-color-087);
+
+    --mdc-dialog-supporting-text-color: var(--theme-primary-text);
   }
 
   .mdc-dialog__surface {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Subtexts were lighter


**What is the new behaviour?**
Subtexts are darker, as it was.

<img width="439" alt="image" src="https://github.com/Alfresco/alfresco-content-app/assets/16205492/2f18c1a9-f46d-489d-a5b6-010d1576e06e">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

