### PR TITLE
Fix LoginComponent naming conficts

### DIFF
--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -63,7 +63,6 @@ import { STORE_INITIAL_APP_DATA } from '@alfresco/aca-shared/store';
 import { ShellModule, SHELL_APP_SERVICE, SHELL_AUTH_TOKEN } from '@alfresco/adf-core/shell';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { APP_ROUTES } from './app.routes';
-import { LoginComponent } from './components/login/login.component';
 import { MatIconRegistry } from '@angular/material/icon';
 
 registerLocaleData(localeFr);
@@ -89,7 +88,6 @@ registerLocaleData(localeSv);
     TranslateModule.forRoot(),
     CoreModule.forRoot(),
     CoreExtensionsModule.forRoot(),
-    LoginComponent,
     environment.e2e ? NoopAnimationsModule : BrowserAnimationsModule,
     !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 25 }) : [],
     RouterModule.forRoot(APP_ROUTES, {

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -23,7 +23,7 @@
  */
 
 import { BlankPageComponent } from '@alfresco/adf-core';
-import { LoginComponent } from './components/login/login.component';
+import { AppLoginComponent } from './components/login/app-login.component';
 
 export const APP_ROUTES = [
   {
@@ -32,7 +32,7 @@ export const APP_ROUTES = [
   },
   {
     path: 'login',
-    component: LoginComponent,
+    component: AppLoginComponent,
     data: {
       title: 'APP.SIGN_IN'
     }

--- a/app/src/app/components/login/app-login.component.html
+++ b/app/src/app/components/login/app-login.component.html
@@ -1,6 +1,5 @@
 <adf-login
   [copyrightText]="'application.copyright' | adfAppConfig | translate"
-  providers="ECM"
   successRoute="/personal-files"
   logoImageUrl="./assets/images/alfresco-logo.svg"
   backgroundImageUrl="./assets/images/Wallpaper-BG-generic.svg"

--- a/app/src/app/components/login/app-login.component.ts
+++ b/app/src/app/components/login/app-login.component.ts
@@ -22,14 +22,14 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppConfigModule, LoginModule } from '@alfresco/adf-core';
+import { AppConfigModule, LoginComponent } from '@alfresco/adf-core';
 import { Component, ViewEncapsulation } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   standalone: true,
-  imports: [LoginModule, AppConfigModule, TranslateModule],
-  templateUrl: './login.component.html',
+  imports: [LoginComponent, AppConfigModule, TranslateModule],
+  templateUrl: './app-login.component.html',
   encapsulation: ViewEncapsulation.None
 })
-export class LoginComponent {}
+export class AppLoginComponent {}

--- a/docs/extending/custom-extension-loaders.md
+++ b/docs/extending/custom-extension-loaders.md
@@ -14,7 +14,7 @@ The extension loader callbacks are invoked when hitting the `root logged-in rout
 export const APP_ROUTES: Routes = [
   {
     path: 'login',
-    component: LoginComponent,
+    component: AppLoginComponent,
     data: {
       title: 'APP.SIGN_IN'
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- rename LoginComponent to AppLoginComponent
- remove unsupported `providers` property from the app login
- do not import the whole LoginModule from ADF, just the LoginComponent 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
