### PR TITLE
[ACS-7560] Corrected background color for info snackbar

### DIFF
--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -229,7 +229,7 @@ mat-snack-bar-container {
 }
 
 .adf-info-snackbar {
-  --mdc-snackbar-container-color: var(--theme-primary-color);
+  --mdc-snackbar-container-color: var(--theme-info-snackbar-background);
 }
 
 .adf-error-snackbar {

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -42,6 +42,7 @@ $search-chip-icon-color: #757575;
 $disabled-chip-background-color: #f5f5f5;
 $contrast-gray: mat.get-color-from-palette($foreground, 'secondary-tex');
 $search-highlight-background-color: #ffd180;
+$info-snackbar-background: #1f74db;
 
 // CSS Variables
 $defaults: (
@@ -67,6 +68,7 @@ $defaults: (
   --theme-grey-background-color: $grey-background,
   --theme-grey-hover-background-color: $grey-hover-background,
   --theme-blue-button-color: $blue-save-button-background,
+  --theme-info-snackbar-background: $info-snackbar-background,
   --theme-heading-color: $black-heading,
   --theme-dropdown-color: $theme-dropdown-background,
   --theme-dropdown-background-hover: $theme-dropdown-background-hover,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7560


**What is the new behaviour?**
Info notification has correct background color.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ADF PR: https://github.com/Alfresco/alfresco-ng2-components/pull/9632