### PR TITLE
[ACS-6595] Add security marks for Folder Rules

### DIFF
--- a/projects/aca-content/folder-rules/src/mock/actions.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/actions.mock.ts
@@ -140,6 +140,22 @@ const actionParamLinkToCategoryTransformedMock = {
   displayLabel: 'Category value'
 };
 
+const actionParamSecurityGroup = {
+  name: 'securityGroupId',
+  type: 'd:text',
+  multiValued: false,
+  mandatory: true,
+  displayLabel: 'Security Group Id'
+};
+
+const actionParamSecurityMark = {
+  name: 'securityMarkId',
+  type: 'd:text',
+  multiValued: false,
+  mandatory: true,
+  displayLabel: 'Security Mark Id'
+};
+
 const action1TransformedMock: ActionDefinitionTransformed = {
   id: 'mock-action-1-definition',
   name: 'mock-action-1-definition',
@@ -174,6 +190,16 @@ export const actionLinkToCategoryTransformedMock: ActionDefinitionTransformed = 
   applicableTypes: [],
   trackStatus: false,
   parameterDefinitions: [actionParamLinkToCategoryTransformedMock]
+};
+
+export const securityActionTransformedMock: ActionDefinitionTransformed = {
+  id: 'mock-action-4-definition',
+  name: 'mock-action-4-definition',
+  description: '',
+  title: 'mock-action-4-definition',
+  applicableTypes: [],
+  trackStatus: false,
+  parameterDefinitions: [actionParamSecurityGroup, actionParamSecurityMark]
 };
 
 export const actionsTransformedListMock: ActionDefinitionTransformed[] = [action1TransformedMock, action2TransformedMock];

--- a/projects/aca-content/folder-rules/src/mock/actions.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/actions.mock.ts
@@ -140,7 +140,7 @@ const actionParamLinkToCategoryTransformedMock = {
   displayLabel: 'Category value'
 };
 
-const actionParamSecurityGroup = {
+const actionParamSecurityGroup: ActionParameterDefinitionTransformed = {
   name: 'securityGroupId',
   type: 'd:text',
   multiValued: false,
@@ -148,7 +148,7 @@ const actionParamSecurityGroup = {
   displayLabel: 'Security Group Id'
 };
 
-const actionParamSecurityMark = {
+const actionParamSecurityMark: ActionParameterDefinitionTransformed = {
   name: 'securityMarkId',
   type: 'd:text',
   multiValued: false,

--- a/projects/aca-content/folder-rules/src/mock/security-marks.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/security-marks.mock.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SecurityControlsMarkResponse } from '@alfresco/adf-content-services/lib/security/services/models/security-controls-mark-response.interface';
+import { UpdateNotification } from '@alfresco/adf-core';
+
+export const securityMarksResponseMock: SecurityControlsMarkResponse = {
+  pagination: {
+    count: 2,
+    hasMoreItems: false,
+    totalItems: 2,
+    skipCount: 0,
+    maxItems: 100
+  },
+  entries: [
+    {
+      id: 'mark-1-id',
+      name: 'mark-1-name',
+      groupId: 'group-1'
+    },
+    {
+      id: 'mark-2-id',
+      name: 'mark-2-name',
+      groupId: 'group-1'
+    }
+  ]
+};
+
+export const updateNotificationMock = (value: string): UpdateNotification => {
+  return {
+    changed: { securityGroupId: value },
+    target: {
+      label: 'Security Group Id *',
+      value: '',
+      key: 'securityGroupId',
+      default: undefined,
+      editable: true,
+      clickable: true,
+      isEmpty: () => true,
+      isValid: () => true,
+      getValidationErrors: () => []
+    }
+  };
+};

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -25,9 +25,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CardViewBoolItemModel, CardViewComponent, CardViewSelectItemModel, CardViewTextItemModel, CoreTestingModule } from '@alfresco/adf-core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
-import { actionLinkToCategoryTransformedMock, actionsTransformedListMock } from '../../mock/actions.mock';
+import { actionLinkToCategoryTransformedMock, actionsTransformedListMock, securityActionTransformedMock } from '../../mock/actions.mock';
 import { By } from '@angular/platform-browser';
 import { dummyCategoriesConstraints, dummyConstraints, dummyTagsConstraints } from '../../mock/action-parameter-constraints.mock';
+import { securityMarksResponseMock, updateNotificationMock } from '../../mock/security-marks.mock';
 import { CategoryService, TagService } from '@alfresco/adf-content-services';
 import { MatDialog } from '@angular/material/dialog';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -217,6 +218,37 @@ describe('RuleActionUiComponent', () => {
             label: 'Label 2 [cm:notCategoryRelated]'
           }
         ]);
+      });
+    });
+  });
+
+  describe('Security mark actions', () => {
+    beforeEach(async () => {
+      component.actionDefinitions = [securityActionTransformedMock];
+      await changeMatSelectValue('mock-action-4-definition');
+    });
+
+    it('should create dropdown selector for security mark action parameter', () => {
+      expect(getPropertiesCardView().properties[1]).toBeInstanceOf(CardViewSelectItemModel);
+    });
+
+    it('should load security marks on security group select and remove them on unselect', async () => {
+      spyOn(component['securityControlsService'], 'getSecurityMark').and.returnValue(Promise.resolve(securityMarksResponseMock));
+      component['cardViewUpdateService'].itemUpdated$.next(updateNotificationMock('group-1'));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      (getPropertiesCardView().properties[1] as CardViewSelectItemModel<string>).options$.subscribe((options) => {
+        expect(options).toEqual([
+          { key: 'mark-1-id', label: 'mark-1-name [mark-1-id]' },
+          { key: 'mark-2-id', label: 'mark-2-name [mark-2-id]' }
+        ]);
+      });
+
+      component['cardViewUpdateService'].itemUpdated$.next(updateNotificationMock(''));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      (getPropertiesCardView().properties[1] as CardViewSelectItemModel<string>).options$.subscribe((options) => {
+        expect(options).toEqual([]);
       });
     });
   });

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
@@ -97,6 +97,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
 
   private readonly tagsRelatedPropertiesAndAspects = ['cm:tagscope', 'cm:tagScopeCache', 'cm:taggable'];
   private readonly categoriesRelatedPropertiesAndAspects = ['cm:categories', 'cm:generalclassifiable'];
+  private readonly paramsToFormatDisplayedValue = ['securityMarkId', 'securityGroupId'];
 
   isFullWidth = false;
 
@@ -137,7 +138,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
       ...action.params
     };
     this.setCardViewProperties();
-    if (!this.readOnly && this.parameters?.securityGroupId) {
+    if (this.parameters?.securityGroupId) {
       this.loadSecurityMarkOptions();
     }
   }
@@ -271,7 +272,10 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
           }
           return new CardViewTextItemModel({
             ...cardViewPropertiesModel,
-            value: this.parameters[paramDef.name] ?? ''
+            value:
+              constraintsForDropdownBox && this.readOnly && this.paramsToFormatDisplayedValue.includes(paramDef.name)
+                ? constraintsForDropdownBox.constraints.find((constraint) => constraint.key === this.parameters[paramDef.name])?.label ?? ''
+                : this.parameters[paramDef.name] ?? ''
           });
       }
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?**
https://hyland.atlassian.net/browse/ACS-6595
Security Mark Id Action Parameter in Folder Rules has input in the form of textbox, no values are fetched.


**What is the new behaviour?**
Input for Security Mark Id Action Parameter is a dropdown select box.
Values for the dropdown box are now updated on Security Group Id parameter selection change.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
