### PR TITLE
[ACS-8190] Change node selection to single for rule actions

### DIFF
--- a/projects/aca-content/folder-rules/src/mock/actions.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/actions.mock.ts
@@ -202,6 +202,16 @@ export const securityActionTransformedMock: ActionDefinitionTransformed = {
   parameterDefinitions: [actionParamSecurityGroup, actionParamSecurityMark]
 };
 
+export const actionNodeTransformedMock: ActionDefinitionTransformed = {
+  id: 'mock-action-5-definition',
+  name: 'mock-action-5-definition',
+  description: '',
+  title: 'mock-action-5-definition',
+  applicableTypes: [],
+  trackStatus: false,
+  parameterDefinitions: [actionParam5TransformedMock]
+};
+
 export const actionsTransformedListMock: ActionDefinitionTransformed[] = [action1TransformedMock, action2TransformedMock];
 
 export const validActionMock: RuleAction = {

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -25,15 +25,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CardViewBoolItemModel, CardViewComponent, CardViewSelectItemModel, CardViewTextItemModel, CoreTestingModule } from '@alfresco/adf-core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
-import { actionLinkToCategoryTransformedMock, actionsTransformedListMock, securityActionTransformedMock } from '../../mock/actions.mock';
+import {
+  actionLinkToCategoryTransformedMock,
+  actionNodeTransformedMock,
+  actionsTransformedListMock,
+  securityActionTransformedMock
+} from '../../mock/actions.mock';
 import { By } from '@angular/platform-browser';
 import { dummyCategoriesConstraints, dummyConstraints, dummyTagsConstraints } from '../../mock/action-parameter-constraints.mock';
 import { securityMarksResponseMock, updateNotificationMock } from '../../mock/security-marks.mock';
-import { CategoryService, TagService } from '@alfresco/adf-content-services';
-import { MatDialog } from '@angular/material/dialog';
+import { CategoryService, NodeAction, TagService } from '@alfresco/adf-content-services';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
+import { of, Subject } from 'rxjs';
 
 describe('RuleActionUiComponent', () => {
   let fixture: ComponentFixture<RuleActionUiComponent>;
@@ -142,6 +148,27 @@ describe('RuleActionUiComponent', () => {
 
     expect(dialog.open).toHaveBeenCalledTimes(1);
     expect(dialog.open['calls'].argsFor(0)[0].name).toBe('CategorySelectorDialogComponent');
+  });
+
+  it('should open node selector dialog with correct parameters', async () => {
+    const dialog = fixture.debugElement.injector.get(MatDialog);
+    component.actionDefinitions = [actionNodeTransformedMock];
+    const expectedData = {
+      selectionMode: 'single',
+      title: 'ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER',
+      actionName: NodeAction.CHOOSE,
+      currentFolderId: component.nodeId,
+      select: jasmine.any(Subject)
+    };
+    const dialogSpy = spyOn(dialog, 'open').and.returnValue({ afterClosed: () => of({}) } as MatDialogRef<any>);
+    fixture.detectChanges();
+
+    await changeMatSelectValue('mock-action-5-definition');
+    fixture.debugElement.query(By.css('.adf-textitem-action')).nativeElement.click();
+
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+    expect(dialogSpy.calls.mostRecent().args[1].data).toEqual(expectedData);
+    expect(dialog.open['calls'].argsFor(0)[0].name).toBe('ContentNodeSelectorComponent');
   });
 
   describe('Select options', () => {

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
@@ -283,6 +283,7 @@ export class RuleActionUiComponent implements ControlValueAccessor, OnInit, OnCh
 
   private openSelectorDialog(paramDefName) {
     const data: ContentNodeSelectorComponentData = {
+      selectionMode: 'single',
       title: this.translate.instant('ACA_FOLDER_RULES.RULE_DETAILS.PLACEHOLDER.CHOOSE_FOLDER'),
       actionName: NodeAction.CHOOSE,
       currentFolderId: this.nodeId,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8190
Marking folders in Choose destination folder component does not select them.

**What is the new behaviour?**

Marking folders in Choose destination folder component selects them.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
