### PR TITLE
[ACS-8191] Updated codebase to use variables from mat-selectors.scss file

### DIFF
--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.scss
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.scss
@@ -1,10 +1,11 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 .aca-manage-rules {
-  /* stylelint-disable selector-class-pattern */
-  .mat-mdc-slide-toggle:is(mat-slide-toggle) .mdc-switch:enabled .mdc-switch__track::after {
+  #{$mat-slide-toggle}:is(mat-slide-toggle) #{$mat-switch}:enabled #{$mat-switch-track}::after {
     background: var(--mdc-switch-selected-track-color);
   }
 
-  .mat-mdc-slide-toggle .mdc-switch .mdc-switch__handle::before {
+  #{$mat-slide-toggle} #{$mat-switch} #{$mat-switch-handle}::before {
     background: var(--mdc-switch-selected-pressed-handle-color);
   }
 

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.scss
@@ -1,3 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 .aca-rule-details {
   .aca-rule-details__form__triggers {
     margin-top: 10px;
@@ -80,16 +82,15 @@
       }
     }
 
-    /* stylelint-disable selector-class-pattern */
     &.aca-read-only,
-    .mat-form-field-disabled {
-      .mdc-notched-outline__leading,
-      .mdc-notched-outline__trailing,
-      .mdc-notched-outline__notch {
+    #{$mat-form-field-disabled} {
+      #{$mat-notched-outline-leading},
+      #{$mat-notched-outline-trailing},
+      #{$mat-notched-outline-notch} {
         border: none;
       }
 
-      .mdc-line-ripple {
+      #{$mat-line-ripple} {
         &::before,
         &::after {
           display: none;
@@ -97,21 +98,21 @@
       }
 
       *:disabled,
-      .mat-mdc-select-disabled .mat-mdc-select-value {
+      #{$mat-select-disabled} #{$mat-select-value} {
         color: inherit;
       }
 
-      .mat-mdc-select-arrow-wrapper {
+      #{$mat-select-arrow-wrapper} {
         display: none;
       }
     }
 
-    .aca-rule-details__form__row .mat-mdc-form-field-flex .mat-mdc-form-field-infix {
+    .aca-rule-details__form__row #{$mat-form-field-flex} #{$mat-form-field-infix} {
       padding-top: 0.375em;
       padding-bottom: 0.375em;
     }
 
-    .aca-rule-details__form__row aca-rule-action .mat-mdc-form-field-flex .mat-mdc-form-field-infix {
+    .aca-rule-details__form__row aca-rule-action #{$mat-form-field-flex} #{$mat-form-field-infix} {
       padding-top: 0.1em;
       padding-bottom: 0.1em;
     }

--- a/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.scss
@@ -1,8 +1,9 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 .aca-rule-set-picker-container {
   --rule-set-picker-padding: 8px 20px;
 
-  /* stylelint-disable-next-line selector-class-pattern */
-  .mdc-dialog .mdc-dialog__surface {
+  #{$mdc-dialog} #{$mat-dialog-surface} {
     padding: 0;
   }
 }

--- a/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.scss
@@ -1,3 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 .app-suffix-search-icon-wrapper {
   display: flex;
   align-items: center;
@@ -37,33 +39,31 @@
       letter-spacing: -0.7px;
     }
 
-    /* stylelint-disable selector-class-pattern */
-    .mdc-line-ripple {
+    #{$mat-line-ripple} {
       &::before,
       &::after {
         display: none;
       }
     }
 
-    /* stylelint-disable selector-class-pattern */
-    .mat-mdc-form-field-icon-suffix {
+    #{$mat-form-field-icon-suffix} {
       position: relative;
       right: -14px;
     }
   }
 
-  .mat-mdc-form-field-flex {
+  #{$mat-form-field-flex} {
     background: #fff;
   }
 
-  .mat-mdc-text-field-wrapper {
+  #{$mat-form-field-wrapper} {
     height: 44px;
     padding-left: 0;
   }
 
   .app-input-form-field-readonly {
-    .mat-mdc-text-field-wrapper,
-    .mat-mdc-form-field-flex {
+    #{$mat-form-field-wrapper},
+    #{$mat-form-field-flex} {
       background-color: var(--theme-search-background-color);
     }
   }

--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
@@ -1,3 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 $search-width: 594px;
 $search-height: 32px;
 $search-background: var(--theme-search-background-color);
@@ -44,8 +46,7 @@ $top-margin: 12px;
   }
 }
 
-/* stylelint-disable-next-line */
-.app-search-options-menu.mat-mdc-menu-panel {
+.app-search-options-menu#{$mat-menu-panel} {
   position: relative;
   top: -5px;
   margin-top: 2px;
@@ -54,8 +55,7 @@ $top-margin: 12px;
   max-width: unset;
   border-radius: $search-border-radius;
 
-  /* stylelint-disable-next-line */
-  .mdc-list {
+  #{$mdc-list} {
     padding-top: 10px;
     padding-right: 10px;
   }
@@ -71,7 +71,7 @@ $top-margin: 12px;
   padding-bottom: 26px;
 
   .app-search-container {
-    margin: 10px 0 0 0;
+    margin: 10px 0 0;
   }
 }
 
@@ -87,30 +87,29 @@ $top-margin: 12px;
   letter-spacing: -0.7px;
   margin-bottom: -8px;
 
-  /* stylelint-disable-next-line */
- .mat-mdc-checkbox {
-   .mdc-form-field {
-     .mdc-checkbox {
-       .mdc-checkbox__background {
-         height: 18px;
-         width: 18px;
-       }
-     }
-   }
- }
+  #{$mat-checkbox} {
+    #{$mdc-form-field} {
+      #{$mat-checkbox-box} {
+        #{$mat-checkbox-background} {
+          height: 18px;
+          width: 18px;
+        }
+      }
+    }
+  }
 
- .app-search-options-checkbox label {
-   max-width: 155px;
-   font-size: 16px;
-   padding-left: 6px;
-   padding-top: 2px;
-   letter-spacing: -1px;
- }
+  .app-search-options-checkbox label {
+    max-width: 155px;
+    font-size: 16px;
+    padding-left: 6px;
+    padding-top: 2px;
+    letter-spacing: -1px;
+  }
 
- &-checkbox {
-   padding: 3px 36px 3px 20px;
+  &-checkbox {
+    padding: 3px 36px 3px 20px;
 
-   /* stylelint-disable-next-line no-descending-specificity */
+    /* stylelint-disable-next-line no-descending-specificity */
     label {
       padding: 0 0 0 11px;
       overflow: hidden;

--- a/projects/aca-content/src/lib/ui/overrides/adf-about.theme.scss
+++ b/projects/aca-content/src/lib/ui/overrides/adf-about.theme.scss
@@ -1,9 +1,10 @@
-/* stylelint-disable selector-class-pattern */
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 @mixin adf-about-theme($theme) {
   adf-about {
     /* custom ADF About Component Theme */
 
-    .mdc-data-table__header-cell {
+    #{$mat-data-table-header-cell} {
       color: var(--adf-theme-foreground-text-color-054);
       font-size: 12px;
       font-weight: 500;
@@ -12,12 +13,12 @@
     background-color: var(--theme-about-panel-background-color);
     overflow: auto;
 
-    .mat-accordion {
+    #{$mat-accordion} {
       box-shadow: none;
       border: none;
 
       &.adf-about-panel {
-        .mat-expansion-panel {
+        #{$mat-expansion-panel} {
           box-shadow: none;
           border-radius: 12px;
           margin: 24px;
@@ -27,7 +28,7 @@
       }
     }
 
-    .mat-expansion-panel-header {
+    #{$mat-expansion-panel-header} {
       height: 80px;
       line-height: 32px;
     }

--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -1,6 +1,6 @@
-/* stylelint-disable selector-class-pattern */
 @use '@angular/material' as mat;
 @import '@alfresco/adf-core/theming';
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
 @import 'custom-theme';
 @import 'variables/variables';
 @include custom-theme($custom-theme);
@@ -18,51 +18,51 @@ mat-icon {
   color: var(--theme-secondary-text);
 }
 
-.mdc-text-field--filled:not(.mdc-text-field--disabled) {
+#{$mat-text-field-filled}:not(#{$mat-text-field-disabled}) {
   background-color: transparent;
   padding: 0;
 }
 
-.mat-mdc-button > .mat-icon {
+#{$mat-button} > #{$mat-icon} {
   padding: 0;
 }
 
-.mdc-button {
-  .mdc-button__label {
+#{$mat-button} {
+  #{$mat-button-label} {
     -webkit-font-smoothing: subpixel-antialiased;
   }
 
-  &.mat-primary {
-    .mdc-button__label {
+  &#{$mat-primary} {
+    #{$mat-button-label} {
       -webkit-font-smoothing: initial;
       font-weight: 500;
     }
   }
 }
 
-.mdc-button:active {
+#{$mat-button}:active {
   outline: none;
 }
 
-.mat-mdc-form-field-error-wrapper:is(div) {
+#{$mat-form-field-error-wrapper}:is(div) {
   padding: 0;
   font-size: 10px;
 
-  .mat-mdc-form-field-error {
+  #{$mat-form-field-error} {
     position: relative;
     top: -3px;
   }
 }
 
-.mat-mdc-checkbox {
-  .mdc-checkbox:has(div) {
+#{$mat-checkbox} {
+  #{$mat-checkbox-box}:has(div) {
     padding-right: 2px;
   }
 
-  .mdc-form-field {
+  #{$mdc-form-field} {
     height: auto;
 
-    .mdc-checkbox {
+    #{$mat-checkbox-box} {
       padding: 0;
       margin-right: 2px;
 
@@ -72,7 +72,7 @@ mat-icon {
         position: relative;
       }
 
-      .mdc-checkbox__background {
+      #{$mat-checkbox-background} {
         top: 1px;
         left: 0;
         height: 16px;
@@ -81,57 +81,45 @@ mat-icon {
     }
   }
 
-  .mat-mdc-checkbox-touch-target {
+  #{$mat-checkbox-touch-target} {
     height: 24px;
     width: 24px;
   }
 }
 
-.mdc-switch:is(button).mdc-switch--selected.mdc-switch--checked .mdc-switch__handle-track .mdc-switch__handle::after {
+#{$mat-switch}:is(button)#{$mat-switch-selected}#{$mat-switch-checked} #{$mat-switch-handle-track} #{$mat-switch-handle}::after {
   background-color: transparent;
 }
 
-.mat-mdc-slide-toggle:is(mat-slide-toggle) .mdc-switch:enabled .mdc-switch__track::after {
+#{$mat-slide-toggle}:is(mat-slide-toggle) #{$mat-switch}:enabled #{$mat-switch-track}::after {
   background-color: var(--theme-blue-button-color);
 }
 
 mat-slide-toggle {
-  .mdc-switch__icons {
+  #{$mat-switch-icons} {
     display: none;
   }
 
-  .mdc-switch--unselected.mdc-switch:enabled .mdc-switch__track::before,
-  .mdc-switch--unselected.mdc-switch:enabled:active .mdc-switch__track::before,
-  .mdc-switch--unselected.mdc-switch:enabled:focus:not(:active) .mdc-switch__track::before,
-  .mdc-switch--unselected.mdc-switch:enabled:hover:not(:focus:active) .mdc-switch__track::before {
+  #{$mat-switch-unselected}#{$mat-switch}:enabled #{$mat-switch-track}::before,
+  #{$mat-switch-unselected}#{$mat-switch}:enabled:active #{$mat-switch-track}::before,
+  #{$mat-switch-unselected}#{$mat-switch}:enabled:focus:not(:active) #{$mat-switch-track}::before,
+  #{$mat-switch-unselected}#{$mat-switch}:enabled:hover:not(:focus:active) #{$mat-switch-track}::before {
     background: var(--adf-theme-foreground-disabled-text-color);
   }
 }
 
-.mdc-list-item__primary-text {
+#{$mat-list-item-primary-text} {
   color: var(--adf-theme-foreground-text-color-087);
 }
 
-.mat-mdc-button:is(button),
-.mat-mdc-icon-button:is(button),
-.mat-mdc-icon-button.mat-mdc-button-base:is(button) {
-  padding: 0;
-  height: 40px;
-  width: 40px;
-
-  .mat-mdc-button-touch-target {
-    display: none;
-  }
-}
-
-.mdc-evolution-chip__action.mat-mdc-chip-action {
-  .mdc-evolution-chip__graphic.mat-mdc-chip-graphic {
+#{$mat-evolution-chip-action}#{$mat-chip-action} {
+  #{$mat-evolution-chip-graphic}#{$mat-chip-graphic} {
     padding: 0;
   }
 }
 
-.mdc-dialog {
-  .mdc-dialog__title {
+#{$mdc-dialog} {
+  #{$mat-dialog-title} {
     margin-bottom: 20px;
     padding: 0;
 
@@ -140,43 +128,43 @@ mat-slide-toggle {
     }
   }
 
-  .mat-mdc-dialog-actions {
+  #{$mat-dialog-actions} {
     padding: 8px 0;
   }
 
-  .mat-mdc-slide-toggle .mdc-form-field {
+  #{$mat-slide-toggle} #{$mdc-form-field} {
     width: 36px;
   }
 
-  .mdc-data-table__row:last-child .mdc-data-table__cell {
+  #{$mat-data-table-row}:last-child #{$mat-data-table-cell} {
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   }
 
-  .mdc-dialog__content {
+  #{$mat-dialog-content} {
     padding: 16px 0;
     color: var(--adf-theme-foreground-text-color-087);
 
     --mdc-dialog-supporting-text-color: var(--theme-primary-text);
   }
 
-  .mdc-dialog__surface {
+  #{$mat-dialog-surface} {
     padding: 24px 24px 8px;
 
-    .mat-mdc-button {
+    #{$mat-button} {
       width: auto;
 
-      .mdc-button__label {
+      #{$mat-button-label} {
         padding: 0 16px;
       }
     }
   }
 }
 
-.mdc-floating-label,
-.mat-mdc-tab-list .mat-mdc-tab-labels .mdc-tab,
-.mat-mdc-checkbox label,
-mat-toolbar.mat-toolbar.mat-toolbar-multiple-row,
-mat-toolbar.mat-toolbar.mat-toolbar-single-row {
+#{$mat-floating-label},
+#{$mat-tab-list} #{$mat-tab-labels} #{$mat-tab-label},
+#{$mat-checkbox} label,
+mat-toolbar#{$mat-toolbar}#{$mat-toolbar-multiple-row},
+mat-toolbar#{$mat-toolbar}#{$mat-toolbar-single-row} {
   color: var(--theme-secondary-text);
   opacity: 1;
 }
@@ -199,7 +187,7 @@ mat-toolbar.mat-toolbar.mat-toolbar-single-row {
 }
 
 .adf-property-field {
-  .adf-textitem-edit-icon.mat-icon {
+  .adf-textitem-edit-icon#{$mat-icon} {
     color: var(--theme-secondary-text);
   }
 }
@@ -213,13 +201,13 @@ mat-toolbar.mat-toolbar.mat-toolbar-single-row {
 }
 
 .aca-details-tabs {
-  .mdc-tab__text-label {
+  #{$mat-tab-label-text} {
     line-height: 19px;
   }
 }
 
 mat-snack-bar-container {
-  .mat-mdc-button.mat-unthemed {
+  #{$mat-button}#{$mat-unthemed} {
     --mdc-text-button-label-text-color: #fff;
   }
 }
@@ -244,8 +232,8 @@ mat-snack-bar-container {
   --mdc-snackbar-container-color: var(--theme-warn-color);
 }
 
-.mat-calendar {
-  .mat-calendar-period-button:is(button) {
+#{$mat-calendar} {
+  #{$mat-calendar-period-button}:is(button) {
     width: unset;
     height: unset;
     padding: 0 16px;
@@ -253,56 +241,56 @@ mat-snack-bar-container {
   }
 }
 
-.mat-mdc-radio-button .mdc-radio:is(div) {
+#{$mat-radio-button} #{$mat-radio}:is(div) {
   padding: 0 5px 0 0;
 }
 
-.mdc-form-field > label:is(label) {
+#{$mdc-form-field} > label:is(label) {
   padding-left: 3px;
 }
 
-.mdc-tab__ripple {
+#{$mat-tab-ripple} {
   display: none;
 }
 
-.mat-mdc-form-field-infix {
+#{$mat-form-field-infix} {
   min-height: unset;
 }
 
-.mat-mdc-tab-labels {
+#{$mat-tab-labels} {
   border-bottom: 1px solid var(--adf-theme-foreground-text-color-014);
 }
 
-.mat-mdc-tab-list {
-  .mat-mdc-tab-labels {
-    .mdc-tab--active {
+#{$mat-tab-list} {
+  #{$mat-tab-labels} {
+    #{$mat-tab-label-active} {
       color: var($selected-text-color);
     }
   }
 }
 
-.mat-mdc-tab:not(.mat-mdc-tab-disabled).mdc-tab--active .mdc-tab__text-label {
+#{$mat-tab-label}:not(#{$mat-tab-disabled})#{$mat-tab-label-active} #{$mat-tab-label-text} {
   color: var(--theme-sidenav-active-text-color);
 }
 
 adf-dynamic-component {
-  mat-icon.mat-icon.mat-menu-submenu-icon {
+  mat-icon#{$mat-icon}#{$mat-submenu-icon} {
     color: var(--theme-text-color);
   }
 }
 
-.mat-mdc-menu-item .mat-icon-no-color,
-.mat-mdc-menu-submenu-icon {
+#{$mat-menu-item} #{$mat-icon-no-color},
+#{$mat-mdc-submenu-icon} {
   color: var(--theme-text-color);
 }
 
-.mdc-notched-outline__trailing,
-.mdc-notched-outline__notch,
-.mdc-notched-outline__leading {
+#{$mat-notched-outline-trailing},
+#{$mat-notched-outline-notch},
+#{$mat-notched-outline-leading} {
   border-color: var(--adf-theme-foreground-text-color-014);
 }
 
-.mdc-menu-surface.mat-mdc-autocomplete-panel:is(div) {
+#{$mat-menu-surface}#{$mat-autocomplete-panel}:is(div) {
   padding: 0;
 
   span {
@@ -310,14 +298,14 @@ adf-dynamic-component {
   }
 }
 
-.mdc-list-item.mdc-list-item--disabled {
-  .mdc-list-item__primary-text:is(div) {
+#{$mat-list-item}#{$mat-list-item-disabled} {
+  #{$mat-list-item-primary-text}:is(div) {
     color: unset;
   }
 }
 
-.mat-mdc-tab-group.mat-mdc-tab-group-stretch-tabs > .mat-mdc-tab-header {
-  .mat-mdc-tab:is(div) {
+#{$mat-tab-group}#{$mat-tab-group-stretch} > #{$mat-tab-header} {
+  #{$mat-tab-label}:is(div) {
     flex-grow: unset;
     min-width: 160px;
   }

--- a/projects/aca-shared/project.json
+++ b/projects/aca-shared/project.json
@@ -25,7 +25,10 @@
         "codeCoverage": true,
         "main": "projects/aca-shared/test.ts",
         "tsConfig": "projects/aca-shared/tsconfig.spec.json",
-        "karmaConfig": "projects/aca-shared/karma.conf.js"
+        "karmaConfig": "projects/aca-shared/karma.conf.js",
+        "stylePreprocessorOptions": {
+          "includePaths": ["node_modules"]
+        }
       },
       "configurations": {
         "adfprod": {

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.scss
@@ -1,3 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 aca-open-in-app {
   .aca-open-in-app {
     .aca-open-in-app-button-container {
@@ -55,7 +57,7 @@ aca-open-in-app {
       }
     }
 
-    .mat-mdc-button {
+    #{$mat-button} {
       --mat-mdc-button-persistent-ripple-color: unset;
       --mat-mdc-button-ripple-color: unset;
     }

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.scss
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.scss
@@ -1,0 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
+.app-toolbar-menu-item:last-child > #{$mat-divider-horizontal} {
+  display: none;
+}

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -36,13 +36,7 @@ import { MatDividerModule } from '@angular/material/divider';
   imports: [CommonModule, TranslateModule, IconModule, MatMenuModule, MatDividerModule, ExtensionsModule],
   selector: 'app-toolbar-menu-item',
   templateUrl: './toolbar-menu-item.component.html',
-  styles: [
-    `
-      .app-toolbar-menu-item:last-child > .mat-divider-horizontal {
-        display: none;
-      }
-    `
-  ],
+  styleUrls: ['./toolbar-menu-item.component.scss'],
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-toolbar-menu-item' }
 })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
A lot of the codebase was using hardcoded selectors for angular material classes


**What is the new behaviour?**
Migrated codebase to use variables from mat-selectors.scss file from adf-core


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8191