### PR TITLE
[ACS-8158] Resolved issue where long tag names were not getting word wrapped in ACA. Fixed alignment issue with tag chip cross button

### DIFF
--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable selector-class-pattern */
 @use '@angular/material' as mat;
 @import '@alfresco/adf-core/theming';
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
 @import 'custom-theme';
 @import 'variables/variables';
 @include custom-theme($custom-theme);
@@ -112,15 +113,11 @@ mat-slide-toggle {
   color: var(--adf-theme-foreground-text-color-087);
 }
 
-.mat-mdc-button:is(button),
-.mat-mdc-icon-button:is(button),
-.mat-mdc-icon-button.mat-mdc-button-base:is(button) {
-  padding: 0;
-  height: 40px;
-  width: 40px;
+#{$mat-chip}#{$mat-evolution-chip}#{$mat-standard-chip} {
+  height: auto;
 
-  .mat-mdc-button-touch-target {
-    display: none;
+  #{$mat-evolution-chip-text-label} {
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Long tag names were not getting word wrapped in ACA after angular upgrade. Tag delete X button was also misaligned



**What is the new behaviour?**
Long tag names are now word wrapped. Fixed alignment of X button


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8158.
See also, PR in ADF - https://github.com/Alfresco/alfresco-ng2-components/pull/9808