### PR TITLE
[MNT-24334] from the search result page in ADW, we can not multi select result to delete or move

### DIFF
--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -793,18 +793,15 @@ describe('app.evaluators', () => {
       expect(app.canDeleteSelection(context)).toBeFalse();
     });
 
-    it('should return false when user is in trashcan, library or search results page', () => {
+    it('should return false when user is in trashcan or library', () => {
       context.selection.isEmpty = false;
-      context.navigation.url = '/trashcan/tets';
+      context.navigation.url = '/trashcan/test';
       expect(app.canDeleteSelection(context)).toBeFalse();
 
       context.navigation.url = '/test/libraries';
       expect(app.canDeleteSelection(context)).toBeFalse();
 
-      context.navigation.url = '/search-libraries/tets';
-      expect(app.canDeleteSelection(context)).toBeFalse();
-
-      context.navigation.url = '/search/tets';
+      context.navigation.url = '/search-libraries/test';
       expect(app.canDeleteSelection(context)).toBeFalse();
     });
 
@@ -813,6 +810,12 @@ describe('app.evaluators', () => {
       context.navigation.url = '/personal-files';
       context.selection.nodes = [{ entry: { isFile: true, isLocked: true } } as any];
       expect(app.canDeleteSelection(context)).toBeFalse();
+    });
+
+    it('should return true when user is in search result page', () => {
+      context.selection.isEmpty = false;
+      context.navigation.url = '/search/test';
+      expect(app.canDeleteSelection(context)).toBeTrue();
     });
 
     it('should return true when user is in favorites', () => {

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -67,6 +67,7 @@ export const supportedExtensions = {
   vstx: 'ms-visio',
   vstm: 'ms-visio'
 };
+
 /* cspell:enable */
 
 export function getFileExtension(fileName: string): string | null {
@@ -182,7 +183,7 @@ export function isShared(context: RuleContext): boolean {
  * JSON ref: `app.selection.canDelete`
  */
 export function canDeleteSelection(context: RuleContext): boolean {
-  if (navigation.isNotTrashcan(context) && navigation.isNotLibraries(context) && navigation.isNotSearchResults(context) && hasSelection(context)) {
+  if (navigation.isNotTrashcan(context) && navigation.isNotLibraries(context) && hasSelection(context)) {
     if (hasLockedFiles(context)) {
       return false;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
In ADW we do not have the option to multi move/delete items in the result page


**What is the new behaviour?**
In ADW, we do have the option to multi move/delete items in the result page.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
