### PR TITLE
A percentage sign (%) in the search breaks the app

### DIFF
--- a/projects/aca-content/src/lib/store/effects/search.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/search.effects.spec.ts
@@ -76,6 +76,14 @@ describe('SearchEffects', () => {
 
       expect(router.navigateByUrl).toHaveBeenCalledWith('/search;q=%2528test%2529');
     }));
+
+    it('should encode %', fakeAsync(() => {
+      store.dispatch(new SearchByTermAction('%test%', []));
+
+      tick();
+
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/search;q=%2525test%2525');
+    }));
   });
 
   describe('search$', () => {

--- a/projects/aca-content/src/lib/store/effects/search.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/search.effects.ts
@@ -49,7 +49,7 @@ export class SearchEffects {
       this.actions$.pipe(
         ofType<SearchByTermAction>(SearchActionTypes.SearchByTerm),
         map((action) => {
-          const query = action.payload.replace(/[(]/g, '%28').replace(/[)]/g, '%29');
+          const query = action.payload.replace(/%/g, '%25').replace(/[(]/g, '%28').replace(/[)]/g, '%29');
 
           const libItem = action.searchOptions.find((item) => item.id === SearchOptionIds.Libraries);
           const librarySelected = !!libItem && libItem.value;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- support `%` for search terms within the browser url
- fixes: #3886

encoding used: https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
