### PR TITLE
[ACS-6926] Fix plugins routing

### DIFF
--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -204,19 +204,13 @@
             "order": 100,
             "title": "APP.BROWSE.FILE.SIDENAV_LINK.LABEL",
             "description": "APP.BROWSE.FILE.SIDENAV_LINK.TOOLTIP",
-            "rules": {
-              "visible": "app.isContentServiceEnabled"
-            },
             "children": [
               {
                 "id": "app.navbar.personalFiles",
                 "order": 100,
                 "title": "APP.BROWSE.PERSONAL.SIDENAV_LINK.LABEL",
                 "description": "APP.BROWSE.PERSONAL.SIDENAV_LINK.TOOLTIP",
-                "route": "personal-files",
-                "rules": {
-                  "visible": "app.isContentServiceEnabled"
-                }
+                "route": "personal-files"
               },
               {
                 "id": "app.navbar.libraries.files",

--- a/projects/aca-content/folder-rules/src/folder-rules.module.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.module.ts
@@ -40,11 +40,16 @@ import { RuleActionListUiComponent } from './rule-details/actions/rule-action-li
 import { RuleActionUiComponent } from './rule-details/actions/rule-action.ui-component';
 import { RuleListUiComponent } from './rule-list/rule-list/rule-list.ui-component';
 import { RuleSetPickerSmartComponent } from './rule-set-picker/rule-set-picker.smart-component';
+import { PluginEnabledGuard } from '@alfresco/aca-shared';
 
 const routes: Routes = [
   {
     path: 'rules',
-    component: ManageRulesSmartComponent
+    component: ManageRulesSmartComponent,
+    canActivate: [PluginEnabledGuard],
+    data: {
+      plugin: 'plugins.folderRules'
+    }
   }
 ];
 

--- a/projects/aca-shared/src/lib/routing/plugin-enabled.guard.spec.ts
+++ b/projects/aca-shared/src/lib/routing/plugin-enabled.guard.spec.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AppConfigService } from '@alfresco/adf-core';
+import { TestBed } from '@angular/core/testing';
+import { PluginEnabledGuard } from './plugin-enabled.guard';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('PluginEnabledGuard', () => {
+  let service: PluginEnabledGuard;
+  let getSpy: jasmine.Spy<(key: string, defaultValue?: boolean) => boolean>;
+  let route: ActivatedRouteSnapshot;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(PluginEnabledGuard);
+    getSpy = spyOn(TestBed.inject(AppConfigService), 'get');
+    route = new ActivatedRouteSnapshot();
+    route.data = {
+      plugin: 'some plugin'
+    };
+  });
+
+  describe('canActivate', () => {
+    it('should call appConfigService.get with correct parameters', () => {
+      service.canActivate(route);
+      expect(getSpy).toHaveBeenCalledWith(route.data.plugin, true);
+    });
+
+    it('should return true if appConfigService.get returns true', () => {
+      getSpy.and.returnValue(true);
+
+      expect(service.canActivate(route)).toBeTrue();
+    });
+
+    it('should return false if appConfigService.get returns false', () => {
+      getSpy.and.returnValue(true);
+
+      expect(service.canActivate(route)).toBeTrue();
+    });
+
+    it('should navigate to root if plugin is not enabled', () => {
+      getSpy.and.returnValue(false);
+      const routerSpy = spyOn(TestBed.inject(Router), 'navigate');
+
+      service.canActivate(route);
+
+      expect(routerSpy).toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('canActivateChild', () => {
+    it('should call canActivate with the same route and return its result', () => {
+      spyOn(service, 'canActivate').and.callThrough();
+      const result = service.canActivateChild(route);
+
+      expect(service.canActivate).toHaveBeenCalledWith(route);
+      expect(result).toBe(service.canActivate(route));
+    });
+  });
+});

--- a/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
+++ b/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { AppConfigService } from '@alfresco/adf-core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PluginEnabledGuard implements CanActivate {
+  constructor(private appConfigService: AppConfigService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot): boolean {
+    const isPluginEnabled = this.appConfigService.get(route.data.plugin, true);
+
+    if (!isPluginEnabled) {
+      this.router.navigate(['/']);
+    }
+
+    return isPluginEnabled;
+  }
+
+  canActivateChild(route: ActivatedRouteSnapshot): boolean {
+    return this.canActivate(route);
+  }
+}

--- a/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
+++ b/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
@@ -22,14 +22,14 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router } from '@angular/router';
 import { AppConfigService } from '@alfresco/adf-core';
 import { Injectable } from '@angular/core';
 
 @Injectable({
   providedIn: 'root'
 })
-export class PluginEnabledGuard implements CanActivate {
+export class PluginEnabledGuard implements CanActivate, CanActivateChild {
   constructor(private appConfigService: AppConfigService, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot): boolean {

--- a/projects/aca-shared/src/public-api.ts
+++ b/projects/aca-shared/src/public-api.ts
@@ -48,6 +48,7 @@ export * from './lib/models/viewer.rules';
 export * from './lib/models/modal-configuration';
 
 export * from './lib/routing/shared.guard';
+export * from './lib/routing/plugin-enabled.guard';
 
 export * from './lib/services/app.service';
 export * from './lib/services/content-api.service';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

User can open page for specific plugin by typing url even if plugin is disabled
https://hyland.atlassian.net/browse/ACS-6926

**What is the new behaviour?**
 
- PluginEnabledGuard moved to aca-shared
- Routing for disabled plugins restricted
- Removed the rule that caused the “Files” section to be hidden in the navigation bar when contentService=false.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
