### PR TITLE
ACS-8109: Upgrade to new adf-button, a11y fixes

### DIFF
--- a/projects/aca-content/about/src/about.component.html
+++ b/projects/aca-content/about/src/about.component.html
@@ -1,8 +1,6 @@
 <aca-page-layout>
   <div class="aca-page-layout-header">
-    <button mat-icon-button [routerLink]="landingPage">
-      <mat-icon class="app-profile-icon">arrow_back</mat-icon>
-    </button>
+    <adf-button [routerLink]="landingPage" variant="icon" icon="arrow_back"></adf-button>
     <h1>{{ 'APP.BROWSE.ABOUT.TITLE' | translate }}</h1>
   </div>
 

--- a/projects/aca-content/about/src/about.component.ts
+++ b/projects/aca-content/about/src/about.component.ts
@@ -41,7 +41,6 @@ import { PACKAGE_JSON } from './package-json.token';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppExtensionService, PageLayoutComponent } from '@alfresco/aca-shared';
 import { RouterModule } from '@angular/router';
-import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -50,7 +49,6 @@ import { CommonModule } from '@angular/common';
     CommonModule,
     TranslateModule,
     RouterModule,
-    MatIconModule,
     PageLayoutComponent,
     ButtonComponent,
     AboutPanelDirective,

--- a/projects/aca-content/about/src/about.component.ts
+++ b/projects/aca-content/about/src/about.component.ts
@@ -24,7 +24,18 @@
 
 import { Component, inject, OnInit, ViewEncapsulation } from '@angular/core';
 import { DEV_MODE_TOKEN } from './dev-mode.tokens';
-import { AboutModule, AppConfigService, AuthenticationService, RepositoryInfo } from '@alfresco/adf-core';
+import {
+  AboutComponent,
+  AboutExtensionListComponent,
+  AboutPanelDirective,
+  AboutRepositoryInfoComponent,
+  AboutServerSettingsComponent,
+  AppConfigService,
+  AuthenticationService,
+  ButtonComponent,
+  PackageListComponent,
+  RepositoryInfo
+} from '@alfresco/adf-core';
 import { DiscoveryApiService } from '@alfresco/adf-content-services';
 import { PACKAGE_JSON } from './package-json.token';
 import { TranslateModule } from '@ngx-translate/core';
@@ -32,17 +43,29 @@ import { AppExtensionService, PageLayoutComponent } from '@alfresco/aca-shared';
 import { RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, AboutModule, RouterModule, MatIconModule, MatButtonModule, PageLayoutComponent],
+  imports: [
+    CommonModule,
+    TranslateModule,
+    RouterModule,
+    MatIconModule,
+    PageLayoutComponent,
+    ButtonComponent,
+    AboutPanelDirective,
+    AboutServerSettingsComponent,
+    AboutRepositoryInfoComponent,
+    PackageListComponent,
+    AboutExtensionListComponent,
+    AboutComponent
+  ],
   selector: 'app-about-page',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class AboutComponent implements OnInit {
+export class AppAboutComponent implements OnInit {
   private authService = inject(AuthenticationService);
   private appExtensions = inject(AppExtensionService);
   private discovery = inject(DiscoveryApiService);

--- a/projects/aca-content/about/src/aca-about.module.ts
+++ b/projects/aca-content/about/src/aca-about.module.ts
@@ -23,17 +23,17 @@
  */
 
 import { NgModule } from '@angular/core';
-import { AboutComponent } from './about.component';
+import { AppAboutComponent } from './about.component';
 import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
 
 @NgModule({
-  imports: [AboutComponent],
+  imports: [AppAboutComponent],
   providers: [provideExtensionConfig(['about.plugin.json'])]
 })
 export class AcaAboutModule {
   constructor(extensions: ExtensionService) {
     extensions.setComponents({
-      'app.about.component': AboutComponent
+      'app.about.component': AppAboutComponent
     });
   }
 }

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
@@ -36,21 +36,22 @@
             <mat-divider vertical class="aca-manage-rules__actions-bar__vertical-divider"></mat-divider>
 
             <div class="aca-manage-rules__actions-bar__buttons">
-              <button
+              <adf-button
                 *ngIf="!(mainRuleSet$ | async)"
-                data-automation-id="manage-rules-link-button"
-                mat-stroked-button
+                testId="manage-rules-link-button"
+                variant="stroked"
                 (click)="openLinkRulesDialog()">
                 {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.LINK_RULES' | translate }}
-              </button>
+              </adf-button>
 
-              <button
+              <adf-button
                 *ngIf="canEditMainRule"
-                data-automation-id="manage-rules-create-button"
-                mat-flat-button color="primary"
+                testId="manage-rules-create-button"
+                variant="flat"
+                color="primary"
                 (click)="openCreateUpdateRuleDialog()">
                 {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.CREATE_RULE' | translate }}
-              </button>
+              </adf-button>
             </div>
 
           </adf-toolbar>
@@ -86,18 +87,18 @@
 
                 <div class="aca-manage-rules__container__rule-details__header__buttons">
                   <ng-container *ngIf="canEditSelectedRule; else goToFolderButton">
-                    <button mat-stroked-button (click)="onRuleDeleteButtonClicked(selectedRule)" id="delete-rule-btn">
+                    <adf-button variant="stroked" (click)="onRuleDeleteButtonClicked(selectedRule)" id="delete-rule-btn">
                       <mat-icon>delete_outline</mat-icon>
-                    </button>
-                    <button mat-stroked-button (click)="openCreateUpdateRuleDialog(selectedRule)" id="edit-rule-btn">
+                    </adf-button>
+                    <adf-button variant="stroked" (click)="openCreateUpdateRuleDialog(selectedRule)" id="edit-rule-btn">
                       {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.EDIT_RULE' | translate }}
-                    </button>
+                    </adf-button>
                   </ng-container>
 
                   <ng-template #goToFolderButton>
-                    <button mat-stroked-button [routerLink]="['/nodes', (selectedRuleSet$ | async).owningFolder.id, 'rules']">
+                    <adf-button variant="stroked" [routerLink]="['/nodes', (selectedRuleSet$ | async).owningFolder.id, 'rules']">
                       {{ 'ACA_FOLDER_RULES.MANAGE_RULES.TOOLBAR.ACTIONS.SEE_IN_FOLDER' | translate }}
-                    </button>
+                    </adf-button>
                   </ng-template>
                 </div>
               </div>

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
@@ -2,9 +2,7 @@
 
   <div class="aca-page-layout-header">
     <adf-toolbar class="adf-toolbar--inline">
-      <button mat-icon-button (click)="goBack()">
-        <mat-icon>arrow_back</mat-icon>
-      </button>
+      <adf-button (click)="goBack()" variant="icon" icon="arrow_back"></adf-button>
     </adf-toolbar>
     <h1 class="aca-page-title">{{ 'ACA_FOLDER_RULES.ACTIONS.MANAGE_RULES' | translate }}</h1>
   </div>

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
@@ -33,7 +33,7 @@ import { delay, takeUntil } from 'rxjs/operators';
 import { EditRuleDialogUiComponent } from '../rule-details/edit-rule-dialog.ui-component';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ConfirmDialogComponent } from '@alfresco/adf-content-services';
-import { ButtonComponent, NotificationService, TemplateModule, ToolbarModule } from '@alfresco/adf-core';
+import { ButtonComponent, EmptyContentComponent, NotificationService, ToolbarModule } from '@alfresco/adf-core';
 import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
@@ -43,7 +43,6 @@ import { MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/sl
 import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
 import { TranslateModule } from '@ngx-translate/core';
 import { GenericErrorComponent, PageLayoutComponent } from '@alfresco/aca-shared';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatDividerModule } from '@angular/material/divider';
@@ -57,18 +56,17 @@ import { RuleDetailsUiComponent } from '../rule-details/rule-details.ui-componen
     TranslateModule,
     PageLayoutComponent,
     ToolbarModule,
-    MatButtonModule,
     MatIconModule,
     MatProgressBarModule,
     MatSlideToggleModule,
     MatDividerModule,
     RuleListUiComponent,
     RouterModule,
-    TemplateModule,
     GenericErrorComponent,
     RuleDetailsUiComponent,
     MatDialogModule,
-    ButtonComponent
+    ButtonComponent,
+    EmptyContentComponent
   ],
   selector: 'aca-manage-rules',
   templateUrl: 'manage-rules.smart-component.html',

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
@@ -33,7 +33,7 @@ import { delay, takeUntil } from 'rxjs/operators';
 import { EditRuleDialogUiComponent } from '../rule-details/edit-rule-dialog.ui-component';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ConfirmDialogComponent } from '@alfresco/adf-content-services';
-import { NotificationService, TemplateModule, ToolbarModule } from '@alfresco/adf-core';
+import { ButtonComponent, NotificationService, TemplateModule, ToolbarModule } from '@alfresco/adf-core';
 import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
@@ -67,7 +67,8 @@ import { RuleDetailsUiComponent } from '../rule-details/rule-details.ui-componen
     TemplateModule,
     GenericErrorComponent,
     RuleDetailsUiComponent,
-    MatDialogModule
+    MatDialogModule,
+    ButtonComponent
   ],
   selector: 'aca-manage-rules',
   templateUrl: 'manage-rules.smart-component.html',

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
@@ -2,7 +2,7 @@
   <div class="aca-edit-rule-dialog__header__title" data-automation-id="edit-rule-dialog-title">
     {{ title | translate }}
   </div>
-  <adf-button variant="icon" icon="close" mat-dialog-close tabindex="-1" [iconSize]="'18px'"></adf-button>
+  <adf-button variant="icon" icon="close" mat-dialog-close tabindex="-1" iconSize="18px"></adf-button>
 </div>
 
 <mat-dialog-content class="aca-edit-rule-dialog__content">

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
@@ -2,9 +2,7 @@
   <div class="aca-edit-rule-dialog__header__title" data-automation-id="edit-rule-dialog-title">
     {{ title | translate }}
   </div>
-  <button mat-icon-button mat-dialog-close class="aca-edit-rule-dialog__header__close" tabindex="-1">
-    <mat-icon class="aca-edit-rule-dialog__header__icon">close</mat-icon>
-  </button>
+  <adf-button variant="icon" icon="close" mat-dialog-close tabindex="-1" [iconSize]="'18px'"></adf-button>
 </div>
 
 <mat-dialog-content class="aca-edit-rule-dialog__content">
@@ -19,6 +17,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="aca-edit-rule-dialog__footer">
-  <button mat-flat-button mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</button>
-  <button mat-flat-button color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</button>
+  <adf-button variant="flat" mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</adf-button>
+  <adf-button variant="flat" color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</adf-button>
 </mat-dialog-actions>

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.html
@@ -18,5 +18,5 @@
 
 <mat-dialog-actions align="end" class="aca-edit-rule-dialog__footer">
   <adf-button variant="flat" mat-dialog-close>{{ 'ACA_FOLDER_RULES.EDIT_RULE_DIALOG.CANCEL' | translate }}</adf-button>
-  <adf-button variant="flat" color="primary" [disabled]="!formValid" data-automation-id="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</adf-button>
+  <adf-button variant="flat" color="primary" [disabled]="!formValid" testId="edit-rule-dialog-submit" (click)="onSubmit()">{{ submitLabel | translate }}</adf-button>
 </mat-dialog-actions>

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.scss
@@ -18,12 +18,6 @@
       font-weight: bold;
       flex-grow: 1;
     }
-
-    &__close {
-      & .aca-edit-rule-dialog__header__icon {
-        font-size: 18px;
-      }
-    }
   }
 
   &__content {

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
@@ -30,9 +30,8 @@ import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { RuleDetailsUiComponent } from './rule-details.ui-component';
+import { ButtonComponent } from '@alfresco/adf-core';
 
 export interface EditRuleDialogOptions {
   model?: Partial<Rule>;
@@ -43,7 +42,7 @@ export interface EditRuleDialogOptions {
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, MatDialogModule, MatButtonModule, MatIconModule, RuleDetailsUiComponent],
+  imports: [CommonModule, TranslateModule, MatDialogModule, RuleDetailsUiComponent, ButtonComponent],
   selector: 'aca-edit-rule-dialog',
   templateUrl: './edit-rule-dialog.ui-component.html',
   styleUrls: ['./edit-rule-dialog.ui-component.scss'],

--- a/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.html
+++ b/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.html
@@ -9,16 +9,14 @@
   </ng-container>
 
   <ng-container *ngIf="data.iconButton">
-    <button
-      mat-icon-button
-      data-automation-id="share-action-button"
+    <adf-button
+      variant="icon"
+      icon="link"
+      testId="share-action-button"
       (click)="editSharedNode(selectionState, '#share-action-button')"
-      [attr.aria-label]="selectionLabel | translate"
-      [attr.title]="selectionLabel | translate"
-      id="share-action-button"
-    >
-      <mat-icon>link</mat-icon>
-    </button>
+      [tooltip]="selectionLabel | translate"
+      id="share-action-button">
+    </adf-button>
   </ng-container>
 </ng-container>
 

--- a/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
+++ b/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
@@ -33,10 +33,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { takeUntil } from 'rxjs/operators';
+import { ButtonComponent } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, MatMenuModule, MatIconModule, TranslateModule, MatButtonModule],
+  imports: [CommonModule, MatMenuModule, MatIconModule, TranslateModule, MatButtonModule, ButtonComponent],
   selector: 'app-toggle-shared',
   templateUrl: './toggle-shared.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/details/details.component.html
+++ b/projects/aca-content/src/lib/components/details/details.component.html
@@ -14,14 +14,14 @@
         </div>
         <div class="aca-details-buttons">
           <aca-toolbar [items]="aspectActions" info-drawer-buttons></aca-toolbar>
-          <button
+          <adf-button
                 class="aca-close-details-button"
-                mat-icon-button
-                data-automation-id="close-library"
-                title="{{ 'APP.INFO_DRAWER.REDUCE_PANEL' | translate }}"
+                variant="icon"
+                icon="fullscreen_exit"
+                testId="close-library"
+                [tooltip]="'APP.INFO_DRAWER.REDUCE_PANEL' | translate"
                 (click)="goBack()">
-                <mat-icon>fullscreen_exit</mat-icon>
-          </button>
+          </adf-button>
         </div>
       </div>
 

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -39,6 +39,7 @@ import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.c
 import { NodeEntry, PathElement } from '@alfresco/js-api';
 import { first, takeUntil } from 'rxjs/operators';
 import { ContentActionRef } from '@alfresco/adf-extensions';
+import { InfoDrawerModule } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
@@ -54,7 +55,8 @@ import { ContentActionRef } from '@alfresco/adf-extensions';
     MetadataTabComponent,
     CommentsTabComponent,
     PageLayoutComponent,
-    ToolbarComponent
+    ToolbarComponent,
+    InfoDrawerModule
   ],
   selector: 'app-details-manager',
   templateUrl: './details.component.html',

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -30,16 +30,14 @@ import { merge, Subject } from 'rxjs';
 import { BreadcrumbModule, ContentService, PermissionManagerModule } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatButtonModule } from '@angular/material/button';
 import { MetadataTabComponent } from '../info-drawer/metadata-tab/metadata-tab.component';
 import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.component';
 import { NodeEntry, PathElement } from '@alfresco/js-api';
 import { first, takeUntil } from 'rxjs/operators';
 import { ContentActionRef } from '@alfresco/adf-extensions';
-import { InfoDrawerModule } from '@alfresco/adf-core';
+import { ButtonComponent, InfoDrawerModule } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
@@ -48,15 +46,14 @@ import { InfoDrawerModule } from '@alfresco/adf-core';
     TranslateModule,
     PermissionManagerModule,
     BreadcrumbModule,
-    MatIconModule,
     MatTabsModule,
     MatProgressBarModule,
-    MatButtonModule,
     MetadataTabComponent,
     CommentsTabComponent,
     PageLayoutComponent,
     ToolbarComponent,
-    InfoDrawerModule
+    InfoDrawerModule,
+    ButtonComponent
   ],
   selector: 'app-details-manager',
   templateUrl: './details.component.html',

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.html
@@ -46,15 +46,15 @@
 
   <mat-card-actions align="end" *ngIf="canUpdateLibrary">
     <ng-container *ngIf="form.enabled">
-      <button mat-button (click)="cancel()">
+      <adf-button (click)="cancel()">
         {{ 'LIBRARY.DIALOG.CANCEL' | translate }}
-      </button>
-      <button mat-button color="primary" [disabled]="form.invalid || form.pristine" (click)="update()">
+      </adf-button>
+      <adf-button color="primary" [disabled]="form.invalid || form.pristine" (click)="update()">
         {{ 'LIBRARY.DIALOG.UPDATE' | translate }}
-      </button>
+      </adf-button>
     </ng-container>
-    <button mat-button color="primary" (click)="toggleEdit()" *ngIf="form.disabled">
+    <adf-button color="primary" (click)="toggleEdit()" *ngIf="form.disabled">
       {{ 'LIBRARY.DIALOG.EDIT' | translate }}
-    </button>
+    </adf-button>
   </mat-card-actions>
 </mat-card>

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -46,7 +46,7 @@ import {
   isAdmin
 } from '@alfresco/aca-shared/store';
 import { debounceTime, filter, mergeMap, takeUntil } from 'rxjs/operators';
-import { AlfrescoApiService } from '@alfresco/adf-core';
+import { AlfrescoApiService, ButtonComponent } from '@alfresco/adf-core';
 import { Observable, from, Subject } from 'rxjs';
 import { ErrorStateMatcher, MatOptionModule } from '@angular/material/core';
 import { CommonModule } from '@angular/common';
@@ -56,7 +56,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
 import { A11yModule } from '@angular/cdk/a11y';
-import { MatButtonModule } from '@angular/material/button';
 import { Actions, ofType } from '@ngrx/effects';
 
 export class InstantErrorStateMatcher implements ErrorStateMatcher {
@@ -79,7 +78,7 @@ export class InstantErrorStateMatcher implements ErrorStateMatcher {
     MatOptionModule,
     MatInputModule,
     A11yModule,
-    MatButtonModule
+    ButtonComponent
   ],
   selector: 'app-library-metadata-form',
   templateUrl: './library-metadata-form.component.html',

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -128,24 +128,9 @@
       >
         <adf-viewer-toolbar>
           <div class="adf-search-results--preview-toolbar">
-            <div>
-              <button mat-icon-button title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}" (click)="onDrawerClosed()">
-                <mat-icon>close</mat-icon>
-              </button>
-            </div>
-            <div>
-              <button
-                mat-icon-button
-                title="{{ 'ADF_VIEWER.ACTIONS.PREVIEW' | translate }}"
-                color="accent"
-                class="adf-search-results--visibility_button"
-              >
-                <mat-icon>visibility</mat-icon>
-              </button>
-              <button mat-icon-button title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}" (click)="onPreviewClosed()">
-                <mat-icon>info_outline</mat-icon>
-              </button>
-            </div>
+            <adf-button variant="icon" icon="close" [tooltip]="'ADF_VIEWER.ACTIONS.CLOSE' | translate" (click)="onDrawerClosed()"></adf-button>
+            <adf-button variant="icon" icon="visibility" [tooltip]="'ADF_VIEWER.ACTIONS.PREVIEW' | translate" color="accent"></adf-button>
+            <adf-button variant="icon" icon="info_outline" [tooltip]="'ADF_VIEWER.ACTIONS.CLOSE' | translate" (click)="onPreviewClosed()"></adf-button>
           </div>
         </adf-viewer-toolbar>
       </adf-alfresco-viewer>

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.scss
@@ -45,10 +45,10 @@ aca-search-results {
             color: var(--theme-search-chip-icon-color);
           }
 
-        .adf-search-filter-chip-icon {
-          color: var(--theme-search-chip-icon-color);
+          .adf-search-filter-chip-icon {
+            color: var(--theme-search-chip-icon-color);
+          }
         }
-      }
 
         .adf-search-filter-placeholder {
           color: var(--theme-selected-text-color);
@@ -82,13 +82,8 @@ aca-search-results {
     &--preview-toolbar {
       display: flex;
       align-items: flex-end;
-      justify-content: space-between;
       margin: 5px;
       padding-right: 24px;
-    }
-
-    &--visibility_button {
-      margin-right: 8px;
     }
 
     .adf-search-filter {

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -35,7 +35,7 @@ import {
   ShowInfoDrawerPreviewAction,
   SnackbarErrorAction
 } from '@alfresco/aca-shared/store';
-import { DataTableModule, PaginationComponent, TranslationService, ViewerModule } from '@alfresco/adf-core';
+import { ButtonComponent, DataTableModule, PaginationComponent, TranslationService, ViewerModule } from '@alfresco/adf-core';
 import { combineLatest } from 'rxjs';
 import {
   ContextActionsDirective,
@@ -57,7 +57,6 @@ import { DocumentListDirective } from '../../../directives/document-list.directi
 import { ThumbnailColumnComponent } from '../../dl-custom-components/thumbnail-column/thumbnail-column.component';
 import { SearchActionMenuComponent } from '../search-action-menu/search-action-menu.component';
 import { TagsColumnComponent } from '../../dl-custom-components/tags-column/tags-column.component';
-import { MatIconModule } from '@angular/material/icon';
 import { SearchResultsRowComponent } from '../search-results-row/search-results-row.component';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 
@@ -79,7 +78,6 @@ import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-ext
     SearchActionMenuComponent,
     TagsColumnComponent,
     PaginationComponent,
-    MatIconModule,
     InfoDrawerComponent,
     SearchResultsRowComponent,
     PaginationDirective,
@@ -87,7 +85,8 @@ import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-ext
     PageLayoutComponent,
     ToolbarComponent,
     AlfrescoViewerComponent,
-    DynamicColumnComponent
+    DynamicColumnComponent,
+    ButtonComponent
   ],
   selector: 'aca-search-results',
   templateUrl: './search-results.component.html',

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
@@ -27,36 +27,25 @@ import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { ToggleInfoDrawerAction, isInfoDrawerOpened } from '@alfresco/aca-shared/store';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatIconModule } from '@angular/material/icon';
+import { ButtonComponent } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, TranslateModule, ButtonComponent],
   selector: 'app-toggle-info-drawer',
   template: `
-    <button
-      mat-icon-button
+    <adf-button
+      variant="icon"
+      icon="view_sidebar"
       [color]="(infoDrawerOpened$ | async) ? 'primary' : null"
       [attr.aria-label]="'APP.ACTIONS.DETAILS' | translate"
       [attr.aria-expanded]="infoDrawerOpened$ | async"
       [attr.title]="'APP.ACTIONS.DETAILS' | translate"
       (click)="onClick()"
     >
-      <mat-icon>view_sidebar</mat-icon>
-    </button>
+    </adf-button>
   `,
-  styles: [
-    `
-      .app-toggle-info-drawer button:focus {
-        border: 2px solid var(--theme-blue-button-color);
-        border-radius: 6px;
-        outline: none;
-        background-color: var(--theme-selected-background-color);
-      }
-    `
-  ],
   encapsulation: ViewEncapsulation.None,
   host: { class: 'app-toggle-info-drawer' }
 })

--- a/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
@@ -35,21 +35,22 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ButtonComponent } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, MatMenuModule, MatDialogModule],
+  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, MatMenuModule, MatDialogModule, ButtonComponent],
   selector: 'app-view-node',
   template: `
-    <button
+    <adf-button
       *ngIf="data.iconButton"
-      mat-icon-button
+      variant="icon"
+      icon="visibility"
       [attr.aria-label]="data.title | translate"
       [attr.title]="data.title | translate"
       (click)="onClick()"
     >
-      <mat-icon>visibility</mat-icon>
-    </button>
+    </adf-button>
 
     <button *ngIf="data.menuButton" mat-menu-item (click)="onClick()">
       <mat-icon>visibility</mat-icon>

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.html
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.html
@@ -1,145 +1,175 @@
 <div class="app-profile-container">
   <div class="app-profile-row">
     <div class="app-profile-title">
-      <button *ngIf="(appNavNarMode$ | async) === 'collapsed'" mat-icon-button (click)="toggleClick()"
-        title="{{'APP.TOOLTIPS.EXPAND_NAVIGATION' | translate}}">
-        <mat-icon>menu</mat-icon>
-      </button>
-      <mat-icon class="app-profile-icon" (click)="navigateToPersonalFiles()" id="backButton">arrow_back</mat-icon>
+      <adf-button *ngIf="(appNavNarMode$ | async) === 'collapsed'" variant="icon" icon="menu" (click)="toggleClick()"
+        title="{{'APP.TOOLTIPS.EXPAND_NAVIGATION' | translate}}"></adf-button>
+      <adf-button variant="icon" icon="arrow_back" (click)="navigateToPersonalFiles()"></adf-button>
       <h3 class="app-profile">{{'APP.EDIT_PROFILE.MY_PROFILE' | translate}}</h3>
     </div>
   </div>
-  <div class="app-profile-general-row" [formGroup]="profileForm">
-    <div class="app-profile-general">
-      <div class="app-profile-general-section">
-        <mat-icon class="app-profile-general-icon" (click)="toggleGeneralDropdown()" id="toggle-general-dropdown">
-          {{ generalSectionDropdown ?  'expand_more' : 'chevron_right'}}</mat-icon>
-        <h4 class="app-general-title">{{'APP.EDIT_PROFILE.GENERAL' | translate}}</h4>
-      </div>
-      <div class="app-general-edit-btn" *ngIf="generalSectionButtonsToggle">
-        <button mat-raised-button (click)="toggleGeneralButtons()" id="general-edit-button"
-          class="app-general-edit">{{'APP.EDIT_PROFILE.EDIT' | translate}}</button>
-      </div>
-      <div class="app-general-edit-btn" *ngIf="!generalSectionButtonsToggle">
-        <button mat-raised-button class="app-general-cancel-btn" id="general-cancel-button"
-          (click)="toggleGeneralButtons()">{{'APP.EDIT_PROFILE.CANCEL' | translate}}</button>
-        <button mat-raised-button class="app-general-save-btn" id="general-save-button" [disabled]="profileForm.invalid"
-          (click)="onSaveGeneralData(profileForm)">{{'APP.EDIT_PROFILE.SAVE' | translate}}</button>
-      </div>
-    </div>
-    <mat-divider class="app-divider" *ngIf="generalSectionDropdown"></mat-divider>
-    <div *ngIf="generalSectionDropdown">
-      <div class="app-general-dropdown">
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.FIRST_NAME' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details">{{personDetails?.firstName}}</p>
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.LAST_NAME' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details">{{personDetails?.lastName}}</p>
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.JOB_TITLE' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.jobTitle}}</p>
-          <input type="text" value="" formControlName="jobTitle" *ngIf="!generalSectionButtonsToggle"
-            class="app-profile-general-dropdown-input-details app-selected">
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.LOCATION' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details"  *ngIf="generalSectionButtonsToggle">{{personDetails?.location}}</p>
-          <input type="text" value="" formControlName="location" *ngIf="!generalSectionButtonsToggle"
-            class="app-profile-general-dropdown-input-details app-selected">
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.TELEPHONE' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.telephone}}</p>
-          <input type="tel" name="Telephone" value="" formControlName="telephone" *ngIf="!generalSectionButtonsToggle"
-            class="app-profile-general-dropdown-input-details app-selected">
-          <mat-error class="app-error-message" *ngIf="profileForm.get('telephone').invalid">
-            {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
-          </mat-error>
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.MOBILE' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.mobile}}</p>
-        <input type="tel" value="" formControlName="mobile" *ngIf="!generalSectionButtonsToggle"
-          class="app-profile-general-dropdown-input-details app-selected">
-        <mat-error class="app-error-message" *ngIf="profileForm.get('mobile').invalid">
-          {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
-        </mat-error>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="app-profile-contact-row" [formGroup]="profileForm">
-    <div class="app-profile-general profile-general-bottom-radius">
-      <div class="app-profile-general-section">
-        <mat-icon class="app-profile-general-icon" (click)="toggleContactDropdown()" id="toggle-contact-dropdown">
-          {{ contactSectionDropdown ?  'expand_more' : 'chevron_right'}}</mat-icon>
-        <h4 class="app-general-title">{{'APP.EDIT_PROFILE.COMPANY_DETAILS' | translate}}</h4>
-      </div>
+  <div class="app-profile-content">
+    <section [formGroup]="profileForm">
+      <div class="app-profile-general">
+        <div class="app-profile-general-section">
+          <adf-button
+            id="toggle-general-dropdown"
+            (click)="toggleGeneralDropdown($event)"
+            variant="icon"
+            icon="{{ generalSectionDropdown ?  'expand_more' : 'chevron_right'}}">
+          </adf-button>
+          <h4
+            tabindex="0"
+            class="app-general-title"
+            (click)="toggleGeneralDropdown($event)"
+            (keydown.enter)="toggleGeneralDropdown($event)"
+            (keydown.space)="toggleGeneralDropdown($event)">
+            {{'APP.EDIT_PROFILE.GENERAL' | translate}}
+          </h4>
+        </div>
 
-      <div class="app-general-edit-btn" *ngIf="contactSectionButtonsToggle">
-        <button mat-raised-button class="app-general-edit" id="contact-edit-button"
-          (click)="toggleContactButtons()">{{'APP.EDIT_PROFILE.EDIT' | translate}}</button>
+        <div class="flex flex-row items-center gap-x-2">
+          <ng-container *ngIf="generalSectionButtonsToggle">
+            <adf-button variant="raised" (click)="toggleGeneralButtons()" id="general-edit-button">{{'APP.EDIT_PROFILE.EDIT' | translate}}</adf-button>
+          </ng-container>
+          <ng-container *ngIf="!generalSectionButtonsToggle">
+            <adf-button
+              id="general-cancel-button"
+              variant="raised"
+              (click)="toggleGeneralButtons()">{{'APP.EDIT_PROFILE.CANCEL' | translate}}</adf-button>
+            <adf-button
+              id="general-save-button"
+              variant="raised"
+              color="primary"
+              [disabled]="profileForm.invalid"
+              (click)="onSaveGeneralData(profileForm)">{{'APP.EDIT_PROFILE.SAVE' | translate}}</adf-button>
+          </ng-container>
+        </div>
       </div>
-      <div class="app-general-edit-btn" *ngIf="!contactSectionButtonsToggle">
-        <button mat-raised-button class="app-general-cancel-btn" id="contact-cancel-button"
-          (click)="toggleContactButtons()">{{'APP.EDIT_PROFILE.CANCEL' | translate}}</button>
-        <button mat-raised-button  class="app-general-save-btn" id="contact-save-button" [disabled]="profileForm.invalid"
-          (click)="onSaveCompanyData(profileForm)">{{'APP.EDIT_PROFILE.SAVE' | translate}}</button>
-      </div>
-    </div>
-    <mat-divider class="app-divider" *ngIf="contactSectionDropdown"></mat-divider>
-    <div *ngIf="contactSectionDropdown">
-      <div class="app-general-dropdown">
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.NAME' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.organization}}</p>
-          <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyName"
+      <mat-divider class="app-divider" *ngIf="generalSectionDropdown"></mat-divider>
+      <div *ngIf="generalSectionDropdown">
+        <div class="app-general-dropdown">
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.FIRST_NAME' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details">{{personDetails?.firstName}}</p>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.LAST_NAME' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details">{{personDetails?.lastName}}</p>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.JOB_TITLE' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.jobTitle}}</p>
+            <input type="text" value="" formControlName="jobTitle" *ngIf="!generalSectionButtonsToggle"
+              class="app-profile-general-dropdown-input-details app-selected">
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.LOCATION' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details"  *ngIf="generalSectionButtonsToggle">{{personDetails?.location}}</p>
+            <input type="text" value="" formControlName="location" *ngIf="!generalSectionButtonsToggle"
+              class="app-profile-general-dropdown-input-details app-selected">
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.TELEPHONE' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.telephone}}</p>
+            <input type="tel" name="Telephone" value="" formControlName="telephone" *ngIf="!generalSectionButtonsToggle"
+              class="app-profile-general-dropdown-input-details app-selected">
+            <mat-error class="app-error-message" *ngIf="profileForm.get('telephone').invalid">
+              {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
+            </mat-error>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.MOBILE' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="generalSectionButtonsToggle">{{personDetails?.mobile}}</p>
+          <input type="tel" value="" formControlName="mobile" *ngIf="!generalSectionButtonsToggle"
             class="app-profile-general-dropdown-input-details app-selected">
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.ADDRESS' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.address1}}</p>
-          <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyAddress"
-            class="app-profile-general-dropdown-input-details app-selected">
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.POSTCODE' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.postcode}}</p>
-          <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyPostCode"
-            class="app-profile-general-dropdown-input-details app-selected">
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.TELEPHONE' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.telephone}}</p>
-          <input type="tel" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyTelephone"
-            class="app-profile-general-dropdown-input-details app-selected">
-          <mat-error class="app-error-message" *ngIf="profileForm.get('companyTelephone').invalid">
+          <mat-error class="app-error-message" *ngIf="profileForm.get('mobile').invalid">
             {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
           </mat-error>
-        </div>
-        <mat-divider class="app-general-dropdown-divider"></mat-divider>
-        <div class="app-general-dropdown-details">
-          <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.EMAIL' | translate}}</h4>
-          <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.email}}</p>
-          <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyEmail"
-            class="app-profile-general-dropdown-input-details app-selected">
-          <mat-error class="app-error-message" *ngIf="profileForm.get('companyEmail').invalid">
-            {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
-          </mat-error>
+          </div>
         </div>
       </div>
-    </div>
+    </section>
+
+    <section [formGroup]="profileForm">
+      <div class="app-profile-general profile-general-bottom-radius">
+        <div class="app-profile-general-section">
+          <adf-button
+            id="toggle-contact-dropdown"
+            (click)="toggleContactDropdown($event)"
+            variant="icon"
+            icon="{{ generalSectionDropdown ?  'expand_more' : 'chevron_right'}}">
+          </adf-button>
+          <h4
+            tabindex="0"
+            class="app-general-title"
+            (click)="toggleContactDropdown($event)"
+            (keydown.enter)="toggleContactDropdown($event)"
+            (keydown.space)="toggleContactDropdown($event)">
+            {{'APP.EDIT_PROFILE.COMPANY_DETAILS' | translate}}
+          </h4>
+        </div>
+
+        <div class="flex flex-row items-center gap-x-2">
+          <ng-container *ngIf="contactSectionButtonsToggle">
+            <adf-button variant="raised" (click)="toggleContactButtons()" id="contact-edit-button">{{'APP.EDIT_PROFILE.EDIT' | translate}}</adf-button>
+          </ng-container>
+          <ng-container *ngIf="!contactSectionButtonsToggle">
+            <adf-button id="contact-cancel-button" variant="raised" (click)="toggleContactButtons()">{{'APP.EDIT_PROFILE.CANCEL' | translate}}</adf-button>
+            <adf-button id="contact-save-button" variant="raised" color="primary" [disabled]="profileForm.invalid" (click)="onSaveCompanyData(profileForm)">{{'APP.EDIT_PROFILE.SAVE' | translate}}</adf-button>
+          </ng-container>
+        </div>
+      </div>
+      <mat-divider class="app-divider" *ngIf="contactSectionDropdown"></mat-divider>
+      <div *ngIf="contactSectionDropdown">
+        <div class="app-general-dropdown">
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.NAME' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.organization}}</p>
+            <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyName"
+              class="app-profile-general-dropdown-input-details app-selected">
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.ADDRESS' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.address1}}</p>
+            <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyAddress"
+              class="app-profile-general-dropdown-input-details app-selected">
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.POSTCODE' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.postcode}}</p>
+            <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyPostCode"
+              class="app-profile-general-dropdown-input-details app-selected">
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.TELEPHONE' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.telephone}}</p>
+            <input type="tel" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyTelephone"
+              class="app-profile-general-dropdown-input-details app-selected">
+            <mat-error class="app-error-message" *ngIf="profileForm.get('companyTelephone').invalid">
+              {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
+            </mat-error>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="flex">
+            <h4 class="app-profile-general-dropdown-heading">{{'APP.EDIT_PROFILE.EMAIL' | translate}}</h4>
+            <p class="app-profile-general-dropdown-details" *ngIf="contactSectionButtonsToggle">{{personDetails?.company?.email}}</p>
+            <input type="text" value="" *ngIf="!contactSectionButtonsToggle" formControlName="companyEmail"
+              class="app-profile-general-dropdown-input-details app-selected">
+            <mat-error class="app-error-message" *ngIf="profileForm.get('companyEmail').invalid">
+              {{ 'APP.EDIT_PROFILE.INVALID_INPUT' | translate }}
+            </mat-error>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 </div>

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.scss
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.scss
@@ -1,10 +1,37 @@
 app-view-profile {
+  /* stylelint-disable selector-class-pattern */
+  .flex {
+    display: flex;
+  }
+
+  .flex-row {
+    flex-direction: row;
+  }
+
+  .items-center {
+    align-items: center;
+  }
+
+  .gap-x-2 {
+    column-gap: 0.5rem;
+  }
+  /* stylelint-enable selector-class-pattern */
+
+  mat-divider {
+    border-top-color: var(--theme-grey-divider-color);
+  }
+
   letter-spacing: 0.5px;
 
   .app-profile-container {
     overflow: scroll;
     height: 100%;
     width: 100%;
+
+    section {
+      border: 1px solid var(--theme-grey-background-color);
+      border-radius: 1rem;
+    }
   }
 
   .app-profile-row {
@@ -27,52 +54,32 @@ app-view-profile {
     margin-top: 1rem;
   }
 
-  .app-profile-general-row {
+  .app-profile-content {
     margin: 2rem 0 0 2rem;
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.5rem;
     width: 70%;
-    border: 1px solid var(--theme-grey-background-color);
-    border-radius: 1rem;
-  }
-
-  .app-profile-icon {
-    margin-right: 1rem;
-    cursor: pointer;
-  }
-
-  .app-profile-general-icon {
-    cursor: pointer;
-  }
-
-  .app-profile-text {
-    letter-spacing: 0.5px;
   }
 
   .app-profile-general {
     display: flex;
-    padding-left: 1rem;
-  }
-
-  .app-profile-general-bottom-radius {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    margin: 0.5rem;
   }
 
   .app-profile-general-section {
     display: flex;
-    width: 60%;
-    padding-top: 1rem;
-    cursor: pointer;
+    width: 100%;
+    align-items: center;
   }
 
   .app-general-title {
     margin-left: 0.6rem;
-    margin-top: 4px;
+    margin-top: 0;
+    margin-bottom: 0;
     letter-spacing: 0.5px;
-  }
-
-  .app-general-edit-btn {
-    width: 60%;
-    text-align: end;
+    cursor: pointer;
+    user-select: none;
   }
 
   .app-divider {
@@ -89,43 +96,8 @@ app-view-profile {
     box-shadow: 0 0 2px var(--theme-blue-button-color);
   }
 
-  .app-general-edit {
-    background: var(--theme-grey-text-background-color);
-    height: 30px;
-    margin: 1rem;
-  }
-
-  .app-general-edit:hover {
-    background: var(--theme-grey-hover-background-color);
-  }
-
-  .app-general-cancel-btn {
-    height: 30px;
-    margin: 1rem;
-    margin-left: 0.5rem;
-    background-color: var(--theme-grey-text-background-color);
-    padding-top: 0.25px;
-  }
-
-  .app-general-save-btn {
-    width: 75px;
-    height: 30px;
-    margin: 1rem;
-    margin-left: 0.5rem;
-    color: white;
-    background-color: var(--theme-blue-button-color);
-  }
-
-  .app-general-dropdown-divider {
-    border-top-color: var(--theme-grey-divider-color);
-  }
-
   .app-general-dropdown {
     padding: 0 1rem;
-  }
-
-  .app-general-dropdown-details {
-    display: flex;
   }
 
   .app-profile-general-dropdown-heading {
@@ -146,43 +118,6 @@ app-view-profile {
     border: none;
     margin-top: 1.3rem;
     background-color: var(--theme-dropdown-color);
-  }
-
-  .app-profile-login-row {
-    margin: 2rem 0 0 2rem;
-    width: 70%;
-    border: 1px solid var(--theme-grey-background-color);
-    border-radius: 1rem;
-  }
-
-  .app-profile-login {
-    display: flex;
-    padding-left: 1rem;
-  }
-
-  .app-profile-login-dropdown-details {
-    width: 24%;
-    height: 25px;
-    border: none;
-    margin-top: 1.3rem;
-    background-color: var(--theme-dropdown-color);
-  }
-
-  .app-profile-login-dropdown-heading-forgot {
-    margin-top: 1.3rem;
-    color: var(--theme-heading-color);
-    margin-left: 16rem;
-  }
-
-  .app-profile-company-row {
-    margin-top: 2rem;
-  }
-
-  .app-profile-contact-row {
-    margin: 2rem 0 5rem 2rem;
-    width: 70%;
-    border: 1px solid var(--theme-grey-background-color);
-    border-radius: 1rem;
   }
 
   .app-error-message {

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AlfrescoApiService } from '@alfresco/adf-core';
+import { AlfrescoApiService, ButtonComponent } from '@alfresco/adf-core';
 import { PeopleApi, Person } from '@alfresco/js-api';
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -31,15 +31,13 @@ import { Observable, Subject, throwError } from 'rxjs';
 import { AppService } from '@alfresco/aca-shared';
 import { takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, ReactiveFormsModule, MatButtonModule, MatIconModule, MatDividerModule, MatFormFieldModule],
+  imports: [CommonModule, TranslateModule, ReactiveFormsModule, MatDividerModule, MatFormFieldModule, ButtonComponent],
   selector: 'app-view-profile',
   templateUrl: './view-profile.component.html',
   styleUrls: ['./view-profile.component.scss'],
@@ -108,7 +106,8 @@ export class ViewProfileComponent implements OnInit, OnDestroy {
     });
   }
 
-  toggleGeneralDropdown() {
+  toggleGeneralDropdown(event: Event) {
+    event.preventDefault();
     this.generalSectionDropdown = !this.generalSectionDropdown;
 
     if (!this.generalSectionDropdown) {
@@ -157,7 +156,8 @@ export class ViewProfileComponent implements OnInit, OnDestroy {
     }
   }
 
-  toggleContactDropdown() {
+  toggleContactDropdown(event: Event) {
+    event.preventDefault();
     this.contactSectionDropdown = !this.contactSectionDropdown;
 
     if (!this.contactSectionDropdown) {

--- a/projects/aca-playwright-shared/src/page-objects/components/aca-header.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/aca-header.component.ts
@@ -28,23 +28,23 @@ import { BaseComponent } from './base.component';
 
 export class AcaHeader extends BaseComponent {
   private static rootElement = 'aca-toolbar';
-  private moreActionsButton = this.getChild('button[id="app.viewer.toolbar.more"]');
-  private toolbarMoreActions = this.getChild('button[id="app.toolbar.more"]');
+  private moreActionsButton = this.getChild('[id="app.viewer.toolbar.more"]');
+  private toolbarMoreActions = this.getChild('[id="app.toolbar.more"]');
   public createButton = this.getChild('[id="app.toolbar.create"]');
   public viewDetails = this.getChild('[title="View Details"]');
-  public viewButton = this.getChild('button[title="View"]');
-  public searchButton = this.getChild('button[title="Search"]');
-  public fullScreenButton = this.getChild('button[id="app.viewer.fullscreen"]');
-  public shareButton = this.getChild('button[id="share-action-button"]');
-  public downloadButtonViewer = this.getChild('button[id="app.viewer.download"]');
-  public downloadButton = this.getChild('button[id="app.toolbar.download"]');
-  public sharedDownloadButton = this.getChild('button[id="app.viewer.shared.download"]');
-  public uploadButton = this.getChild('button[id="app.toolbar.upload"]');
-  public uploadFileButton = this.page.locator('button[id="app.create.uploadFile"]');
+  public viewButton = this.getChild('[title="View"]');
+  public searchButton = this.getChild('[title="Search"]');
+  public fullScreenButton = this.getChild('[id="app.viewer.fullscreen"]');
+  public shareButton = this.getChild('[id="share-action-button"]');
+  public downloadButtonViewer = this.getChild('[id="app.viewer.download"]');
+  public downloadButton = this.getChild('[id="app.toolbar.download"]');
+  public sharedDownloadButton = this.getChild('[id="app.viewer.shared.download"]');
+  public uploadButton = this.getChild('[id="app.toolbar.upload"]');
+  public uploadFileButton = this.page.locator('[id="app.create.uploadFile"]');
   public uploadInput = this.page.locator('input[id="app-upload-files"]');
   public uploadNewVersionButton = this.page.locator('#app-upload-file-version');
-  public permanentlyDeleteButton = this.getChild('button[id="app.toolbar.purgeDeletedNodes"]');
-  public restoreButton = this.getChild('button[id="app.toolbar.restoreDeletedNodes"]');
+  public permanentlyDeleteButton = this.getChild('[id="app.toolbar.purgeDeletedNodes"]');
+  public restoreButton = this.getChild('[id="app.toolbar.restoreDeletedNodes"]');
 
   constructor(page: Page) {
     super(page, AcaHeader.rootElement);

--- a/projects/aca-playwright-shared/src/page-objects/components/viewer.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/viewer.component.ts
@@ -34,8 +34,8 @@ export class ViewerComponent extends BaseComponent {
   public closeButtonLocator = this.getChild('.adf-viewer-close-button');
   public fileTitleButtonLocator = this.getChild('.adf-viewer__file-title');
   public pdfViewerContentPages = this.getChild('.adf-pdf-viewer__content .page');
-  public shareButton = this.getChild('button[id="share-action-button"]');
-  public downloadButton = this.getChild('button[id="app.viewer.download"]');
+  public shareButton = this.getChild('[id="share-action-button"]');
+  public downloadButton = this.getChild('[id="app.viewer.download"]');
   public allButtons = this.getChild('button');
   public unknownFormat = this.getChild(`adf-viewer-unknown-format .adf-viewer__unknown-format-view`);
 

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.html
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.html
@@ -1,10 +1,10 @@
 <div class="aca-content-header">
-    <button *ngIf="(appNavNarMode$ | async) === 'collapsed'"
-      mat-icon-button
+    <adf-button *ngIf="(appNavNarMode$ | async) === 'collapsed'"
+      variant="icon"
+      icon="keyboard_double_arrow_right"
       (click)="toggleClick()"
-      title="{{'APP.TOOLTIPS.EXPAND_NAVIGATION' | translate}}">
-      <mat-icon>keyboard_double_arrow_right</mat-icon>
-    </button>
+      [tooltip]="'APP.TOOLTIPS.EXPAND_NAVIGATION' | translate">
+    </adf-button>
     <ng-content select=".aca-page-layout-header, aca-page-layout-header"></ng-content>
 </div>
 

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
@@ -28,12 +28,11 @@ import { takeUntil } from 'rxjs/operators';
 import { AppService } from '../../services/app.service';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { ButtonComponent } from '@alfresco/adf-core';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, TranslateModule, ButtonComponent],
   selector: 'aca-page-layout',
   templateUrl: './page-layout.component.html',
   styleUrls: ['./page-layout.component.scss'],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- upgrade various components to use `adf-button`
- break direct dependencies on `mat-button` and `mat-icon` where possible
- cleanup the Profile screen styles and layout
- a11y: user profile screen has clickable headers, supports keyboard and focus

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8109