### PR TITLE
[ACS-8379] Fixed issue where icons in menus were coming as black after ng16 upgrade

### DIFF
--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -287,9 +287,11 @@ adf-dynamic-component {
   }
 }
 
-#{$mat-menu-item} #{$mat-icon-no-color},
-#{$mat-mdc-submenu-icon} {
-  color: var(--theme-text-color);
+#{$mat-menu-item} #{$mat-icon} {
+  &#{$mat-icon-no-color},
+  &#{$mat-mdc-submenu-icon} {
+    color: var(--theme-text-color);
+  }
 }
 
 #{$mat-notched-outline-trailing},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Icons inside menus were coming up as black after ng16 upgrade


**What is the new behaviour?**
Icons are now back to showing as grey


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8379