### PR TITLE
Remove MaterialModule import from ADF

### DIFF
--- a/docs/tutorials/how-to-create-your-first-extension.md
+++ b/docs/tutorials/how-to-create-your-first-extension.md
@@ -44,7 +44,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ExtensionService, provideExtensionConfig } from '@alfresco/adf-extensions';
-import { CoreModule, MaterialModule, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
+import { CoreModule, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
 
 import { MyExtensionComponent } from './my-extension.component';
 import { MyExtensionService } from './my-extension.service';
@@ -54,7 +54,7 @@ export function components() {
 }
 
 @NgModule({
-    imports: [CoreModule, BrowserModule, FormsModule, MaterialModule],
+    imports: [CoreModule, BrowserModule, FormsModule],
     providers: [
         {
             provide: TRANSLATION_PROVIDER,

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
@@ -32,11 +32,12 @@ import { Store } from '@ngrx/store';
 import { Component } from '@angular/core';
 import { DiscoveryApiService, DocumentListComponent } from '@alfresco/adf-content-services';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { AuthModule, MaterialModule } from '@alfresco/adf-core';
+import { AuthModule } from '@alfresco/adf-core';
 import { HttpClientModule } from '@angular/common/http';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Subscription } from 'rxjs';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @Component({
   selector: 'aca-test',
@@ -61,7 +62,7 @@ describe('PageComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LibTestingModule, MaterialModule, AuthModule.forRoot()],
+      imports: [LibTestingModule, AuthModule.forRoot(), MatDialogModule],
       declarations: [TestComponent],
       providers: [
         { provide: DocumentBasePageService, useClass: DocumentBasePageServiceMock },
@@ -211,7 +212,7 @@ describe('Info Drawer state', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, HttpClientModule, RouterTestingModule, MaterialModule, AuthModule.forRoot()],
+      imports: [NoopAnimationsModule, HttpClientModule, RouterTestingModule, AuthModule.forRoot(), MatDialogModule],
       declarations: [TestComponent],
       providers: [
         { provide: DocumentBasePageService, useClass: DocumentBasePageServiceMock },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

remove any imports of the ADF `MaterialModule` (unit tests)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
