### PR TITLE
[ACS-8378] Fixed inputs having fill styling throughout ACA

### DIFF
--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.html
@@ -16,7 +16,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field *ngIf="i > 0" subscriptSizing="dynamic">
+    <mat-form-field *ngIf="i > 0" subscriptSizing="dynamic" class="aca-rule-composite-condition__boolean-mode-control">
       <mat-select
         [formControl]="booleanModeControl">
         <mat-option value="and">{{ 'ACA_FOLDER_RULES.RULE_DETAILS.LOGIC_OPERATORS.AND' | translate }}</mat-option>

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.scss
@@ -37,6 +37,14 @@
       & > :nth-child(2) {
         flex: 1;
       }
+
+      .aca-rule-composite-condition__boolean-mode-control #{$mat-form-field-wrapper} {
+        background-color: unset;
+
+        #{$mat-select-disabled} {
+          color: var(--adf-theme-foreground-text-color);
+        }
+      }
     }
 
     &__no-conditions {

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.scss
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.scss
@@ -36,6 +36,7 @@
       & > label,
       & > .aca-label {
         font-weight: bold;
+        color: var(--adf-theme-foreground-text-color);
         width: 20%;
         min-width: 100px;
         max-width: 150px;

--- a/projects/aca-content/src/lib/ui/theme.scss
+++ b/projects/aca-content/src/lib/ui/theme.scss
@@ -18,7 +18,7 @@ mat-icon {
   color: var(--theme-secondary-text);
 }
 
-#{$mat-text-field-filled}:not(#{$mat-text-field-disabled}) {
+#{$mat-form-field} #{$mat-text-field-filled}:not(#{$mat-text-field-disabled}) {
   background-color: transparent;
   padding: 0;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
UI fixes - Inputs throughout the application appeared to have fill styling applied

**What is the current behaviour?** (You can also link to an open issue here)
Inputs throughout the application appeared to have fill styling applied


**What is the new behaviour?**
Inputs no longer have fill styling applied


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8378