### PR TITLE
[ACS-8377] Fixed alignment of icons in search input control

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.scss
@@ -27,6 +27,8 @@ $top-margin: 12px;
 
     .app-suffix-search-icon-wrapper.app-close-button {
       height: 6px;
+      padding: 0;
+      width: 1.5em;
 
       .app-close-icon {
         font-size: 18px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Icons in search input were misaligned after ng16 upgrade


**What is the new behaviour?**
Fixed alignment of search input icons


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8377