### PR TITLE
[ACS-8415] Sidenav labels are now grey

### DIFF
--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
@@ -79,6 +79,10 @@
         width: 100%;
         user-select: none;
 
+        .aca-action-button__label {
+          color: var(--theme-action-button-text-color);
+        }
+
         &:hover .aca-action-button__label {
           color: var(--theme-sidenav-active-text-color);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Sidenav labels were black after ng16 upgrade

**What is the current behaviour?** (You can also link to an open issue here)
Sidenav labels were black after ng16 upgrade


**What is the new behaviour?**
Sidenav labels are now grey


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8415