### PR TITLE
[ACS-8382] Blurring the AI answer section before getting response from backend

### DIFF
--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.html
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.html
@@ -18,7 +18,7 @@
       <div
         class="aca-search-ai-response-container"
         [class.aca-search-ai-response-container-error]="hasAnsweringError">
-        <ng-container *ngIf="!loading">
+        <ng-container *ngIf="!loading else skeleton">
           <div
             class="aca-search-ai-response-container-body"
             *ngIf="!hasAnsweringError">
@@ -105,3 +105,9 @@
     *ngIf="hasError">
   </adf-empty-content>
 </aca-page-layout>
+
+<ng-template #skeleton>
+  <div class="adf-skeleton"></div>
+  <div class="adf-skeleton"></div>
+  <div class="adf-skeleton adf-skeleton-half"></div>
+</ng-template>

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.scss
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.scss
@@ -29,16 +29,58 @@
       }
 
       .aca-search-ai-response-container {
+        padding: 18px 20px;
         display: flex;
         flex-direction: column;
         border: 1px solid var(--adf-card-view-border-color);
         border-radius: 12px;
         margin: 16px 0 75px;
-        padding: 14px 40px 36px 35px;
+
+        &-references-container-header {
+          padding-left: 8px;
+        }
+
+        .adf-skeleton {
+          position: relative;
+          background-image: linear-gradient(
+            to left,
+            var(--theme-light-grey-1-color) 0%,
+            var(--theme-light-grey-2-color) 20%,
+            var(--theme-light-grey-3-color) 40%,
+            var(--theme-light-grey-1-color) 100%
+          );
+          background-size: 200%;
+          display: inline-block;
+          height: 1em;
+          overflow: hidden;
+          width: 100%;
+          margin-bottom: 0.5rem;
+          border-radius: 0.25rem;
+
+          &-half {
+            width: 50%;
+            margin-bottom: 8px;
+          }
+
+          &::after {
+            position: absolute;
+            inset: 0;
+            transform: translateX(-100%);
+            background-image: linear-gradient(90deg, rgba(white, 0) 0, rgba(white, 0.2) 20%, rgba(white, 0.5) 60%, rgba(white, 0));
+            animation: shimmer 2s infinite;
+            content: '';
+          }
+
+          @keyframes shimmer {
+            100% {
+              transform: translateX(100%);
+            }
+          }
+        }
 
         &-error {
           border-color: var(--adf-error-color);
-          padding: 21px 19px 27px 18px;
+          padding: 32px 18px;
 
           &-message {
             display: flex;
@@ -58,12 +100,8 @@
         }
 
         &-body {
-          width: 100%;
-
           &-response {
-            margin: 17px 0;
-            padding-left: 6px;
-            padding-right: 5px;
+            margin-bottom: 17px;
             overflow-wrap: break-word;
 
             &-action {

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.ts
@@ -130,7 +130,6 @@ export class SearchAiResultsComponent extends PageComponent implements OnInit, O
       this._agentId = params.agentId;
       this._searchQuery = params.query ? decodeURIComponent(params.query) : '';
       this._selectedNodesState = JSON.parse(this.userPreferencesService.get('knowledgeRetrievalNodes'));
-
       if (!this.searchQuery || !this._selectedNodesState?.nodes?.length || !this.agentId) {
         this._hasError = true;
         return;

--- a/projects/aca-content/src/lib/ui/variables/variables.scss
+++ b/projects/aca-content/src/lib/ui/variables/variables.scss
@@ -46,6 +46,9 @@ $search-highlight-background-color: #ffd180;
 $info-snackbar-background: #1f74db;
 $text-light-color: rgba(33, 35, 40, 0.7);
 $card-background-grey-color: rgb(248, 248, 248);
+$light-grey-1: #d5d5d5;
+$light-grey-2: #d9d9d9;
+$light-grey-3: #dedede;
 
 // CSS Variables
 $defaults: (
@@ -96,7 +99,10 @@ $defaults: (
   --theme-secondary-text: $secondary-text,
   --theme-search-highlight-background-color: $search-highlight-background-color,
   --theme-text-light-color: $text-light-color,
-  --theme-card-background-grey-color: $card-background-grey-color
+  --theme-card-background-grey-color: $card-background-grey-color,
+  --theme-light-grey-1-color: $light-grey-1,
+  --theme-light-grey-2-color: $light-grey-2,
+  --theme-light-grey-3-color: $light-grey-3
 );
 
 // propagates SCSS variables into the CSS variables scope


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8382


**What is the new behaviour?**
Loading skeleton has been added to the answer generation component.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
