### PR TITLE
[ACS-8185] [E2E] updated type to fill

### DIFF
--- a/e2e/playwright/create-actions/src/tests/create-file-from-template.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-file-from-template.e2e.ts
@@ -267,7 +267,7 @@ test.describe('Create file from template', () => {
       });
 
       test('[C325033] File name ending with a dot', async () => {
-        await createFileFromTemplateDialog.getDialogLabel(nameLabel).type(dotString);
+        await createFileFromTemplateDialog.getDialogLabel(nameLabel).fill(dotString);
         await createFileFromTemplateDialog.page.keyboard.press(tabKeyString);
         await expect(createFileFromTemplateDialog.getDialogLabel(nameLabel)).toHaveValue(template1InRoot + dotString);
         expect

--- a/e2e/playwright/create-actions/src/tests/create-folder-from-template.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-folder-from-template.e2e.ts
@@ -294,7 +294,7 @@ test.describe('Create folder from template', () => {
       });
 
       test('[C325145] Folder name ending with a dot', async () => {
-        await createFolderFromTemplateDialog.getDialogLabel(nameLabel).type(dotString);
+        await createFolderFromTemplateDialog.getDialogLabel(nameLabel).fill(dotString);
         await createFolderFromTemplateDialog.page.keyboard.press(tabKeyString);
         await expect(createFolderFromTemplateDialog.getDialogLabel(nameLabel)).toHaveValue(templateFolder1 + dotString);
         expect


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8185


**What is the new behaviour?**
[ACS-8185] [E2E] updated type to fill


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-8185]: https://hyland.atlassian.net/browse/ACS-8185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ