### PR TITLE
[ACS-8326] enable running actions from bulk dropdown and resetting selection

### DIFF
--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -688,6 +688,14 @@
         ]
       }
     ],
+    "bulk-actions-dropdown": [
+      {
+          "id": "app.bulk.actions.legalHold",
+          "component": "app.bulk-actions-dropdown",
+          "title": "GOVERNANCE.MANAGE_HOLDS.DIALOG_TITLE",
+          "type": "custom"
+        }
+  ],
     "contextMenu": [
       {
         "id": "app.context.menu.share",

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -688,14 +688,6 @@
         ]
       }
     ],
-    "bulk-actions-dropdown": [
-      {
-          "id": "app.bulk.actions.legalHold",
-          "component": "app.bulk-actions-dropdown",
-          "title": "GOVERNANCE.MANAGE_HOLDS.DIALOG_TITLE",
-          "type": "custom"
-        }
-  ],
     "contextMenu": [
       {
         "id": "app.context.menu.share",

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -27,4 +27,13 @@
       {{ option.title | translate }}
     </mat-option>
   </mat-select>
+
+<ng-template #disabledMode>
+  <mat-select
+    [placeholder]="'BULK_NOT_AVAILABLE' | translate"
+    [title]="'GOVERNANCE.MANAGE_HOLDS.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
+    [disabled]="true"
+    data-automation-id="aca-bulk-dropdown-disabled"
+  ></mat-select>
+</ng-template>
 </mat-form-field>

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -30,8 +30,8 @@
 
 <ng-template #disabledMode>
   <mat-select
-    [placeholder]="'GOVERNANCE.MANAGE_HOLDS.BULK_NOT_AVAILABLE' | translate"
-    [title]="'GOVERNANCE.MANAGE_HOLDS.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
+    [placeholder]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE' | translate"
+    [title]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
     [disabled]="true"
     data-automation-id="aca-bulk-dropdown-disabled"
   ></mat-select>

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -27,12 +27,4 @@
       {{ option.title | translate }}
     </mat-option>
   </mat-select>
-
-<ng-template #disabledMode>
-  <mat-select
-    [placeholder]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE' | translate"
-    [title]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
-    data-automation-id="aca-bulk-dropdown-disabled"
-  ></mat-select>
-</ng-template>
 </mat-form-field>

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -32,7 +32,6 @@
   <mat-select
     [placeholder]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE' | translate"
     [title]="'SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
-    [disabled]="true"
     data-automation-id="aca-bulk-dropdown-disabled"
   ></mat-select>
 </ng-template>

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -6,7 +6,7 @@
   data-automation-id="aca-bulk-actions-form-field"
 >
   <mat-select
-    [formControl]="disableControl"
+    [formControl]="bulkSelectControl"
     [placeholder]="placeholder"
     panelClass="aca-bulk-actions-select"
     disableOptionCentering

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -30,7 +30,7 @@
 
 <ng-template #disabledMode>
   <mat-select
-    [placeholder]="'BULK_NOT_AVAILABLE' | translate"
+    [placeholder]="'GOVERNANCE.MANAGE_HOLDS.BULK_NOT_AVAILABLE' | translate"
     [title]="'GOVERNANCE.MANAGE_HOLDS.BULK_NOT_AVAILABLE_TOOLTIP' | translate"
     [disabled]="true"
     data-automation-id="aca-bulk-dropdown-disabled"

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.html
@@ -17,6 +17,7 @@
       [value]="option.id"
       [title]="option.tooltip | translate"
       [attr.data-automation-id]="option.id"
+      (click)="runAction(option)"
     >
       <adf-icon
         *ngIf="option.icon"

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -150,20 +150,4 @@ describe('BulkActionsDropdownComponent', () => {
       expect(translationService.get).toHaveBeenCalledWith('SEARCH.BULK_ACTIONS_DROPDOWN.TITLE', { count: 10 });
     });
   });
-
-  it('should use option title for tooltip if no description provided', () => {
-    component.items = [
-      {
-        ...mockItem,
-        description: null
-      }
-    ];
-    totalItemsMock$.next(1);
-    dropdown = getElement('aca-bulk-dropdown');
-    dropdown.click();
-    fixture.detectChanges();
-    const option = getElement('app.bulk.actions.legalHold');
-
-    expect(option.getAttribute('title')).toEqual('GOVERNANCE.MANAGE_HOLDS.TITLE');
-  });
 });

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -180,12 +180,12 @@ describe('BulkActionsDropdownComponent', () => {
         option.click();
         fixture.detectChanges();
 
-        expect(component.select.value).toEqual(mockItem.id);
+        expect(component.bulkSelectControl.value).toEqual(mockItem.id);
 
         extensionService.resetBulkActions();
         fixture.detectChanges();
 
-        expect(component.select.value).toBeNull();
+        expect(component.bulkSelectControl.value).toBeNull();
       });
     });
   });

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -175,14 +175,14 @@ describe('BulkActionsDropdownComponent', () => {
         });
       });
 
-      it('should reset selection on resetBulkActions', () => {
+      it('should reset selection on bulkActionExecuted', () => {
         const option = getElement(mockItem.id);
         option.click();
         fixture.detectChanges();
 
         expect(component.bulkSelectControl.value).toEqual(mockItem.id);
 
-        extensionService.resetBulkActions();
+        extensionService.bulkActionExecuted();
         fixture.detectChanges();
 
         expect(component.bulkSelectControl.value).toBeNull();

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -150,4 +150,20 @@ describe('BulkActionsDropdownComponent', () => {
       expect(translationService.get).toHaveBeenCalledWith('SEARCH.BULK_ACTIONS_DROPDOWN.TITLE', { count: 10 });
     });
   });
+
+  it('should use option title for tooltip if no description provided', () => {
+    component.items = [
+      {
+        ...mockItem,
+        description: null
+      }
+    ];
+    totalItemsMock$.next(1);
+    dropdown = getElement('aca-bulk-dropdown');
+    dropdown.click();
+    fixture.detectChanges();
+    const option = getElement('app.bulk.actions.legalHold');
+
+    expect(option.getAttribute('title')).toEqual('GOVERNANCE.MANAGE_HOLDS.TITLE');
+  });
 });

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -165,7 +165,7 @@ describe('BulkActionsDropdownComponent', () => {
       it('should run action on selection', () => {
         spyOn(component, 'runAction').and.callThrough();
         spyOn(extensionService, 'runActionById');
-        const option = getElement('app.bulk.actions.legalHold');
+        const option = getElement(mockItem.id);
         option.click();
         fixture.detectChanges();
 
@@ -176,7 +176,7 @@ describe('BulkActionsDropdownComponent', () => {
       });
 
       it('should reset selection on resetBulkActions', () => {
-        const option = getElement('app.bulk.actions.legalHold');
+        const option = getElement(mockItem.id);
         option.click();
         fixture.detectChanges();
 

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
@@ -25,8 +25,8 @@
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { AppStore, getSearchItemsTotalCount } from '@alfresco/aca-shared/store';
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
-import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { MatSelectModule } from '@angular/material/select';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { combineLatest, Observable, Subject } from 'rxjs';
@@ -46,11 +46,9 @@ import { AppExtensionService } from '@alfresco/aca-shared';
 export class BulkActionsDropdownComponent implements OnInit, OnDestroy {
   @Input() items: ContentActionRef[];
 
-  @ViewChild(MatSelect) select: MatSelect;
-
   placeholder: string;
   tooltip: string;
-  disableControl = new FormControl();
+  bulkSelectControl = new FormControl();
 
   private readonly totalItems$: Observable<number> = this.store.select(getSearchItemsTotalCount);
   private readonly onDestroy$ = new Subject();
@@ -62,14 +60,14 @@ export class BulkActionsDropdownComponent implements OnInit, OnDestroy {
       .pipe(
         switchMap((totalItems) => {
           if (totalItems > 0) {
-            this.disableControl.enable();
+            this.bulkSelectControl.enable();
 
             return combineLatest([
               this.translationService.get('SEARCH.BULK_ACTIONS_DROPDOWN.TITLE', { count: totalItems }),
               this.translationService.get('SEARCH.BULK_ACTIONS_DROPDOWN.TITLE', { count: totalItems })
             ]);
           } else {
-            this.disableControl.disable();
+            this.bulkSelectControl.disable();
 
             return combineLatest([
               this.translationService.get('SEARCH.BULK_ACTIONS_DROPDOWN.BULK_NOT_AVAILABLE'),
@@ -84,8 +82,8 @@ export class BulkActionsDropdownComponent implements OnInit, OnDestroy {
         this.placeholder = placeholder;
       });
 
-    this.extensions.resetBulkActionsSubject$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
-      this.select.value = null;
+    this.extensions.resetBulkActions$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      this.bulkSelectControl.setValue(null);
     });
   }
 

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
@@ -82,7 +82,7 @@ export class BulkActionsDropdownComponent implements OnInit, OnDestroy {
         this.placeholder = placeholder;
       });
 
-    this.extensions.resetBulkActions$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+    this.extensions.bulkActionExecuted$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.bulkSelectControl.setValue(null);
     });
   }

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -1366,7 +1366,7 @@ describe('AppExtensionService', () => {
         {
           ...defaultConfigMock,
           features: {
-            'bulk-actions-dropdown': actions
+            'bulk-actions': actions
           }
         },
         true
@@ -1676,13 +1676,13 @@ describe('AppExtensionService', () => {
     expect(loader.getContentActions).toHaveBeenCalledWith(service.config, 'features.sidebar.toolbar');
   });
 
-  it('should emit resetBulkActions', (done) => {
-    spyOn(service, 'resetBulkActions').and.callThrough();
-    service.resetBulkActions$.subscribe(() => {
-      expect(service.resetBulkActions).toHaveBeenCalled();
+  it('should emit bulkActionExecuted', (done) => {
+    spyOn(service, 'bulkActionExecuted').and.callThrough();
+    service.bulkActionExecuted$.subscribe(() => {
+      expect(service.bulkActionExecuted).toHaveBeenCalled();
       done();
     });
 
-    service.resetBulkActions();
+    service.bulkActionExecuted();
   });
 });

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -1675,4 +1675,14 @@ describe('AppExtensionService', () => {
     service.updateSidebarActions();
     expect(loader.getContentActions).toHaveBeenCalledWith(service.config, 'features.sidebar.toolbar');
   });
+
+  it('should emit resetBulkActions', (done) => {
+    spyOn(service, 'resetBulkActions').and.callThrough();
+    service.resetBulkActionsSubject$.subscribe(() => {
+      expect(service.resetBulkActions).toHaveBeenCalled();
+      done();
+    });
+
+    service.resetBulkActions();
+  });
 });

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -1678,7 +1678,7 @@ describe('AppExtensionService', () => {
 
   it('should emit resetBulkActions', (done) => {
     spyOn(service, 'resetBulkActions').and.callThrough();
-    service.resetBulkActionsSubject$.subscribe(() => {
+    service.resetBulkActions$.subscribe(() => {
       expect(service.resetBulkActions).toHaveBeenCalled();
       done();
     });

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -63,7 +63,7 @@ import { SearchCategory } from '@alfresco/adf-content-services';
 })
 export class AppExtensionService implements RuleContext {
   private _references = new BehaviorSubject<ExtensionRef[]>([]);
-  resetBulkActionsSubject$ = new Subject<void>();
+  resetBulkActions$ = new Subject<void>();
 
   navbar: Array<NavBarGroupRef> = [];
   sidebarTabs: Array<SidebarTabRef> = [];
@@ -574,6 +574,6 @@ export class AppExtensionService implements RuleContext {
   }
 
   resetBulkActions(): void {
-    this.resetBulkActionsSubject$.next();
+    this.resetBulkActions$.next();
   }
 }

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -68,7 +68,6 @@ export class AppExtensionService implements RuleContext {
   sidebarTabs: Array<SidebarTabRef> = [];
   contentMetadata: any;
   search: any;
-  bulkActionsDropdown: any;
   viewerRules: ViewerRules = {};
 
   private _headerActions = new BehaviorSubject<Array<ContentActionRef>>([]);
@@ -167,7 +166,6 @@ export class AppExtensionService implements RuleContext {
     this.navbar = this.loadNavBar(config);
     this.sidebarTabs = this.loader.getElements<SidebarTabRef>(config, 'features.sidebar.tabs');
     this.contentMetadata = this.loadContentMetadata(config);
-    this.bulkActionsDropdown = this.loadBulkActionsDropdown(config);
     this.search = this.loadSearchForms(config);
     this.search?.forEach((searchSet) => {
       searchSet.categories = searchSet.categories?.filter((category) => this.filterVisible(category));
@@ -295,22 +293,6 @@ export class AppExtensionService implements RuleContext {
 
   loadContentMetadata(config: ExtensionConfig): any {
     const elements = this.loader.getElements<any>(config, 'features.content-metadata-presets');
-    if (!elements.length) {
-      return null;
-    }
-
-    let presets = {};
-    presets = this.filterDisabled(mergeObjects(presets, ...elements));
-
-    const metadata = this.appConfig.config['content-metadata'] || {};
-    metadata.presets = presets;
-
-    this.appConfig.config['content-metadata'] = metadata;
-    return { presets };
-  }
-
-  loadBulkActionsDropdown(config: ExtensionConfig): any {
-    const elements = this.loader.getElements<any>(config, 'features.bulk-actions-dropdown');
     if (!elements.length) {
       return null;
     }

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -63,7 +63,7 @@ import { SearchCategory } from '@alfresco/adf-content-services';
 })
 export class AppExtensionService implements RuleContext {
   private _references = new BehaviorSubject<ExtensionRef[]>([]);
-  resetBulkActions$ = new Subject<void>();
+  bulkActionExecuted$ = new Subject<void>();
 
   navbar: Array<NavBarGroupRef> = [];
   sidebarTabs: Array<SidebarTabRef> = [];
@@ -573,7 +573,7 @@ export class AppExtensionService implements RuleContext {
     return true;
   }
 
-  resetBulkActions(): void {
-    this.resetBulkActions$.next();
+  bulkActionExecuted(): void {
+    this.bulkActionExecuted$.next();
   }
 }

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -50,7 +50,7 @@ import {
   sortByOrder
 } from '@alfresco/adf-extensions';
 import { AppConfigService, AuthenticationService, LogService } from '@alfresco/adf-core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { NodeEntry, RepositoryInfo } from '@alfresco/js-api';
 import { ViewerRules } from '../models/viewer.rules';
 import { Badge } from '../models/types';
@@ -63,6 +63,7 @@ import { SearchCategory } from '@alfresco/adf-content-services';
 })
 export class AppExtensionService implements RuleContext {
   private _references = new BehaviorSubject<ExtensionRef[]>([]);
+  resetBulkActionsSubject$ = new Subject<void>();
 
   navbar: Array<NavBarGroupRef> = [];
   sidebarTabs: Array<SidebarTabRef> = [];
@@ -570,5 +571,9 @@ export class AppExtensionService implements RuleContext {
     }
 
     return true;
+  }
+
+  resetBulkActions(): void {
+    this.resetBulkActionsSubject$.next();
   }
 }

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -68,6 +68,7 @@ export class AppExtensionService implements RuleContext {
   sidebarTabs: Array<SidebarTabRef> = [];
   contentMetadata: any;
   search: any;
+  bulkActionsDropdown: any;
   viewerRules: ViewerRules = {};
 
   private _headerActions = new BehaviorSubject<Array<ContentActionRef>>([]);
@@ -166,6 +167,7 @@ export class AppExtensionService implements RuleContext {
     this.navbar = this.loadNavBar(config);
     this.sidebarTabs = this.loader.getElements<SidebarTabRef>(config, 'features.sidebar.tabs');
     this.contentMetadata = this.loadContentMetadata(config);
+    this.bulkActionsDropdown = this.loadBulkActionsDropdown(config);
     this.search = this.loadSearchForms(config);
     this.search?.forEach((searchSet) => {
       searchSet.categories = searchSet.categories?.filter((category) => this.filterVisible(category));
@@ -293,6 +295,22 @@ export class AppExtensionService implements RuleContext {
 
   loadContentMetadata(config: ExtensionConfig): any {
     const elements = this.loader.getElements<any>(config, 'features.content-metadata-presets');
+    if (!elements.length) {
+      return null;
+    }
+
+    let presets = {};
+    presets = this.filterDisabled(mergeObjects(presets, ...elements));
+
+    const metadata = this.appConfig.config['content-metadata'] || {};
+    metadata.presets = presets;
+
+    this.appConfig.config['content-metadata'] = metadata;
+    return { presets };
+  }
+
+  loadBulkActionsDropdown(config: ExtensionConfig): any {
+    const elements = this.loader.getElements<any>(config, 'features.bulk-actions-dropdown');
     if (!elements.length) {
       return null;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8326


**What is the new behaviour?**
Actions are run on bulk dropdown selection.
There is a possibility to reset bulk dropdown selection.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
