### PR TITLE
[Acs 8484] Add feature flag to knowledge retrieval 

### DIFF
--- a/app/src/app.config.json
+++ b/app/src/app.config.json
@@ -14,7 +14,8 @@
     "contentService": true,
     "folderRules": true,
     "tagsEnabled": true,
-    "categoriesEnabled": true
+    "categoriesEnabled": true,
+    "knowledgeRetrievalEnabled": true
   },
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/projects/aca-content/src/lib/aca-content.routes.ts
+++ b/projects/aca-content/src/lib/aca-content.routes.ts
@@ -27,7 +27,7 @@ import { LibrariesComponent } from './components/libraries/libraries.component';
 import { FavoriteLibrariesComponent } from './components/favorite-libraries/favorite-libraries.component';
 import { SearchResultsComponent } from './components/search/search-results/search-results.component';
 import { SearchLibrariesResultsComponent } from './components/search/search-libraries-results/search-libraries-results.component';
-import { AppSharedRuleGuard, GenericErrorComponent, ExtensionRoute, ExtensionsDataLoaderGuard } from '@alfresco/aca-shared';
+import { AppSharedRuleGuard, GenericErrorComponent, ExtensionRoute, ExtensionsDataLoaderGuard, PluginEnabledGuard } from '@alfresco/aca-shared';
 import { AuthGuard } from '@alfresco/adf-core';
 import { FavoritesComponent } from './components/favorites/favorites.component';
 import { RecentFilesComponent } from './components/recent-files/recent-files.component';
@@ -510,7 +510,11 @@ export const CONTENT_LAYOUT_ROUTES: Route = {
     },
     {
       path: 'knowledge-retrieval',
-      component: SearchAiResultsComponent
+      component: SearchAiResultsComponent,
+      canActivate: [PluginEnabledGuard],
+      data: {
+        plugin: 'plugins.knowledgeRetrievalEnabled'
+      }
     },
     {
       path: '**',

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.spec.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.spec.ts
@@ -53,18 +53,14 @@ describe('SearchAiInputContainerComponent', () => {
           provide: AgentService,
           useValue: {
             getAgents: () =>
-              of({
-                list: {
-                  entries: [
-                    {
-                      entry: {
-                        id: '1',
-                        name: 'HR Agent'
-                      }
-                    }
-                  ]
+              of([
+                {
+                  id: '1',
+                  name: 'HR Agent',
+                  description: 'HR Agent',
+                  avatar: 'avatar1'
                 }
-              })
+              ])
           }
         }
       ]

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -23,9 +23,9 @@
  */
 
 import * as app from './app.rules';
-import { getFileExtension } from './app.rules';
 import { TestRuleContext } from './test-rule-context';
 import { NodeEntry, RepositoryInfo, StatusInfo } from '@alfresco/js-api';
+import { getFileExtension } from './app.rules';
 
 describe('app.evaluators', () => {
   let context: TestRuleContext;
@@ -534,6 +534,47 @@ describe('app.evaluators', () => {
         app.areCategoriesEnabled({
           appConfig: {
             get: () => false
+          }
+        } as any)
+      ).toBeFalse();
+    });
+  });
+
+  describe('isKnowledgeRetrievalEnabled', () => {
+    it('should call context.appConfig.get with correct parameters', () => {
+      context.appConfig = { get: jasmine.createSpy() } as any;
+
+      app.canDisplayKnowledgeRetrievalButton(context);
+      expect(context.appConfig.get).toHaveBeenCalledWith('plugins.knowledgeRetrievalEnabled', true);
+    });
+
+    it('should return false if get from appConfig returns false', () => {
+      expect(
+        app.canDisplayKnowledgeRetrievalButton({
+          appConfig: {
+            get: () => false
+          }
+        } as any)
+      ).toBeFalse();
+    });
+
+    it('should return true if get from appConfig returns true and navigation is correct', () => {
+      expect(
+        app.canDisplayKnowledgeRetrievalButton({
+          navigation: { url: '/personal-files' },
+          appConfig: {
+            get: () => true
+          }
+        } as any)
+      ).toBeTrue();
+    });
+
+    it('should return false if get from appConfig returns true, but navigation is not correct', () => {
+      expect(
+        app.canDisplayKnowledgeRetrievalButton({
+          navigation: { url: '/my-special-files' },
+          appConfig: {
+            get: () => true
           }
         } as any)
       ).toBeFalse();

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -633,8 +633,9 @@ export const areTagsEnabled = (context: AcaRuleContext): boolean => context.appC
 export const areCategoriesEnabled = (context: AcaRuleContext): boolean => context.appConfig.get('plugins.categoriesEnabled', true);
 
 export const canDisplayKnowledgeRetrievalButton = (context: AcaRuleContext): boolean =>
-  navigation.isPersonalFiles(context) ||
-  navigation.isSharedFiles(context) ||
-  navigation.isRecentFiles(context) ||
-  navigation.isFavorites(context) ||
-  ((navigation.isSearchResults(context) || navigation.isLibraryContent(context)) && navigation.isNotLibraries(context));
+  context.appConfig.get('plugins.knowledgeRetrievalEnabled', true) &&
+  (navigation.isPersonalFiles(context) ||
+    navigation.isSharedFiles(context) ||
+    navigation.isRecentFiles(context) ||
+    navigation.isFavorites(context) ||
+    ((navigation.isSearchResults(context) || navigation.isLibraryContent(context)) && navigation.isNotLibraries(context)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8484


**What is the new behaviour?**
'knowledgeRetrievalEnabled' pluging flag has been added that allows user to enable/disable Knowledge Retrieval feature (hides 'Ask Agent' button and 'Knowledge Retrieval' search page)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
