### PR TITLE
[ACS-8561] [E2E] Merge-selectItem-and-selectMultiItem-into-one-method

### DIFF
--- a/e2e/playwright/copy-move-actions/src/tests/destination-picker-dialog.e2e.ts
+++ b/e2e/playwright/copy-move-actions/src/tests/destination-picker-dialog.e2e.ts
@@ -74,7 +74,7 @@ test.describe('Copy Move actions', () => {
 
   const copyContentInMyLibraries = async (myLibrariesPage: MyLibrariesPage) => {
     await myLibrariesPage.dataTable.performClickFolderOrFileToOpen(site);
-    await myLibrariesPage.dataTable.selectItem(sourceFile);
+    await myLibrariesPage.dataTable.selectItems(sourceFile);
     await myLibrariesPage.clickMoreActionsButton('Copy');
     await myLibrariesPage.contentNodeSelector.selectDestination(destinationFolder);
   };

--- a/e2e/playwright/delete-actions/src/tests/delete-undo-delete.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/delete-undo-delete.e2e.ts
@@ -118,7 +118,7 @@ test.describe('Delete and undo delete', () => {
 
     test('[C217125] delete a file and check notification', async ({ personalFiles, trashPage }) => {
       let items = await personalFiles.dataTable.getRowsCount();
-      await personalFiles.dataTable.selectItem(file1);
+      await personalFiles.dataTable.selectItems(file1);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       const message = await personalFiles.snackBar.getSnackBarMessage();
@@ -136,7 +136,7 @@ test.describe('Delete and undo delete', () => {
     test('[C280502] delete multiple files and check notification', async ({ personalFiles, trashPage }) => {
       await personalFiles.page.reload({ waitUntil: 'load' });
       let items = await personalFiles.dataTable.getRowsCount();
-      await personalFiles.dataTable.selectMultiItem(file2, file3);
+      await personalFiles.dataTable.selectItems(file2, file3);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.verifySnackBarActionText(`Deleted 2 items`);
@@ -152,7 +152,7 @@ test.describe('Delete and undo delete', () => {
 
     test('[C217126] delete a folder with content', async ({ personalFiles, trashPage }) => {
       let items = await personalFiles.dataTable.getRowsCount();
-      await personalFiles.dataTable.selectItem(folder1);
+      await personalFiles.dataTable.selectItems(folder1);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.closeIcon.click();
@@ -165,7 +165,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C217127] delete a folder containing locked files', async ({ personalFiles, trashPage }) => {
-      await personalFiles.dataTable.selectItem(folder2);
+      await personalFiles.dataTable.selectItems(folder2);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.verifySnackBarActionText(`${folder2} couldn't be deleted`);
@@ -177,7 +177,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C217129] notification on multiple items deletion - some items fail to delete', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(file4, folder3);
+      await personalFiles.dataTable.selectItems(file4, folder3);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.verifySnackBarActionText(`Deleted 1 item, 1 couldn't be deleted`);
@@ -186,7 +186,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C217130] notification on multiple items deletion - all items fail to delete', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(folder4, folder5);
+      await personalFiles.dataTable.selectItems(folder4, folder5);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.verifySnackBarActionText(`2 items couldn't be deleted`);
@@ -196,7 +196,7 @@ test.describe('Delete and undo delete', () => {
     test('[C217132] undo delete of file', async ({ personalFiles }) => {
       const items = await personalFiles.dataTable.getRowsCount();
 
-      await personalFiles.dataTable.selectItem(file5);
+      await personalFiles.dataTable.selectItems(file5);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
 
@@ -207,7 +207,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C280503] undo delete of folder with content', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folder6);
+      await personalFiles.dataTable.selectItems(folder6);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.clickSnackBarAction();
@@ -219,7 +219,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C280504] undo delete of multiple files', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(file6, file7);
+      await personalFiles.dataTable.selectItems(file6, file7);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItem('Delete');
       await personalFiles.snackBar.clickSnackBarAction();

--- a/e2e/playwright/delete-actions/src/tests/permanently-delete.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/permanently-delete.e2e.ts
@@ -80,7 +80,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C217091] delete a file', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(file1);
+      await trashPage.dataTable.selectItems(file1);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.deleteButton.click();
 
@@ -89,7 +89,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C280416] delete a folder', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(folder1);
+      await trashPage.dataTable.selectItems(folder1);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.deleteButton.click();
 
@@ -98,7 +98,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C290103] delete a library', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(site);
+      await trashPage.dataTable.selectItems(site);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.deleteButton.click();
 
@@ -107,7 +107,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C280417] delete multiple items', async ({ trashPage }) => {
-      await trashPage.dataTable.selectMultiItem(file2, folder2);
+      await trashPage.dataTable.selectItems(file2, folder2);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.deleteButton.click();
 
@@ -117,7 +117,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C269113] Confirmation dialog UI', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(file3);
+      await trashPage.dataTable.selectItems(file3);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.waitForDialog();
 
@@ -129,7 +129,7 @@ test.describe('Delete and undo delete', () => {
     });
 
     test('[C269115] Keep action cancels the deletion', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(file3);
+      await trashPage.dataTable.selectItems(file3);
       await trashPage.acaHeader.permanentlyDeleteButton.click();
       await trashPage.deleteDialog.waitForDialog();
 

--- a/e2e/playwright/delete-actions/src/tests/restore.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/restore.e2e.ts
@@ -83,7 +83,7 @@ test.describe('Restore from Trash', () => {
     });
 
     async function restoreNode(trashPage: TrashPage, nodeName: string) {
-      await trashPage.dataTable.selectItem(nodeName);
+      await trashPage.dataTable.selectItems(nodeName);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText(`${nodeName} restored`);
       const action = await trashPage.snackBar.getSnackBarActionText();
@@ -110,7 +110,7 @@ test.describe('Restore from Trash', () => {
     });
 
     test('[C217182] restore multiple items', async ({ trashPage, personalFiles }) => {
-      await trashPage.dataTable.selectMultiItem(file2, folder2);
+      await trashPage.dataTable.selectItems(file2, folder2);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText(`Restore successful`);
       const action = await trashPage.snackBar.getSnackBarActionText();
@@ -123,7 +123,7 @@ test.describe('Restore from Trash', () => {
     });
 
     test('[C217181] View from notification', async ({ trashPage, personalFiles }) => {
-      await trashPage.dataTable.selectItem(file3);
+      await trashPage.dataTable.selectItems(file3);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.clickSnackBarAction();
       await trashPage.dataTable.spinnerWaitForReload();
@@ -163,13 +163,13 @@ test.describe('Restore from Trash', () => {
     });
 
     test('[C217178] Restore a file when another file with same name exists on the restore location', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(file1);
+      await trashPage.dataTable.selectItems(file1);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText(`Can't restore, ${file1} already exists`);
     });
 
     test('[C217179] Restore a file when original location no longer exists', async ({ trashPage }) => {
-      await trashPage.dataTable.selectItem(file2);
+      await trashPage.dataTable.selectItems(file2);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText(`Can't restore ${file2}, the original location no longer exists`);
     });
@@ -223,13 +223,13 @@ test.describe('Restore from Trash', () => {
     });
 
     test('[C217183] one failure', async ({ trashPage }) => {
-      await trashPage.dataTable.selectMultiItem(file1, file2);
+      await trashPage.dataTable.selectItems(file1, file2);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText(`Can't restore ${file1}, the original location no longer exists`);
     });
 
     test('[C217184] multiple failures', async ({ trashPage }) => {
-      await trashPage.dataTable.selectMultiItem(file3, file4, file5);
+      await trashPage.dataTable.selectItems(file3, file4, file5);
       await trashPage.acaHeader.restoreButton.click();
       await trashPage.snackBar.verifySnackBarActionText('2 items not restored because of issues with the restore location');
     });

--- a/e2e/playwright/edit-actions/src/tests/edit-folder.e2e.ts
+++ b/e2e/playwright/edit-actions/src/tests/edit-folder.e2e.ts
@@ -71,7 +71,7 @@ test.describe('Edit folder', () => {
 
   test.describe('on Personal Files', () => {
     test('[XAT-5089] "Edit folder" dialog UI', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
 
@@ -84,7 +84,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5093] Properties are modified when clicking Update button', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderNameToEdit);
+      await personalFiles.dataTable.selectItems(folderNameToEdit);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.descriptionInput.fill(folderDescriptionEdited);
@@ -98,7 +98,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5090] Empty folder name', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.nameInput.fill('');
@@ -110,7 +110,7 @@ test.describe('Edit folder', () => {
     test('[XAT-5091] Folder name with special characters', async ({ personalFiles }) => {
       const namesWithSpecialChars = ['a*a', 'a"a', 'a<a', 'a>a', `a\\a`, 'a/a', 'a?a', 'a:a', 'a|a'];
 
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
 
@@ -122,7 +122,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5092] Folder name ending with a dot', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.nameInput.fill(`${folderName}.`);
@@ -132,7 +132,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5094] Cancel editing properties', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.cancelButton.click();
@@ -141,7 +141,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5095] Duplicated folder name', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.nameInput.fill(duplicateFolderName);
@@ -152,7 +152,7 @@ test.describe('Edit folder', () => {
     });
 
     test('[XAT-5096] Trim ending spaces', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(folderName);
+      await personalFiles.dataTable.selectItems(folderName);
       await personalFiles.acaHeader.clickMoreActions();
       await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Edit');
       await personalFiles.editDialog.nameInput.fill(`${folderName} `);

--- a/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
+++ b/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
@@ -71,7 +71,7 @@ test.describe('Edit offline - on Personal Files', () => {
   });
 
   test('[XAT-5304] File is locked and downloaded when clicking Edit offline', async ({ personalFiles }) => {
-    await personalFiles.dataTable.selectItem(file1);
+    await personalFiles.dataTable.selectItems(file1);
     await personalFiles.acaHeader.clickMoreActions();
     await personalFiles.matMenu.clickMenuItem('Edit Offline');
     const [download] = await Promise.all([personalFiles.page.waitForEvent('download')]);
@@ -84,10 +84,10 @@ test.describe('Edit offline - on Personal Files', () => {
   });
 
   test('[XAT-5306] Cancel Editing unlocks the file', async ({ personalFiles }) => {
-    await personalFiles.dataTable.selectItem(fileLocked);
+    await personalFiles.dataTable.selectItems(fileLocked);
     await personalFiles.acaHeader.clickMoreActions();
     await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Cancel Editing');
-    await personalFiles.dataTable.selectItem(fileLocked);
+    await personalFiles.dataTable.selectItems(fileLocked);
 
     expect(await nodesApi.isFileLockedWrite(fileLockedId), `${fileLocked} is still locked`).not.toEqual('WRITE_LOCK');
   });

--- a/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
+++ b/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
@@ -87,7 +87,6 @@ test.describe('Edit offline - on Personal Files', () => {
     await personalFiles.dataTable.selectItems(fileLocked);
     await personalFiles.acaHeader.clickMoreActions();
     await personalFiles.matMenu.clickMenuItemFromHeaderMenu('Cancel Editing');
-    await personalFiles.dataTable.selectItems(fileLocked);
 
     expect(await nodesApi.isFileLockedWrite(fileLockedId), `${fileLocked} is still locked`).not.toEqual('WRITE_LOCK');
   });

--- a/e2e/playwright/favorite-actions/src/tests/mark-favorite.e2e.ts
+++ b/e2e/playwright/favorite-actions/src/tests/mark-favorite.e2e.ts
@@ -124,19 +124,19 @@ test.describe('Mark items as favorites', () => {
     });
 
     test('[XAT-5042] Favorite action has empty star icon for an item not marked as favorite', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(fileNotFavUI);
+      await personalFiles.dataTable.selectItems(fileNotFavUI);
       await personalFiles.acaHeader.clickMoreActions();
       expect(await personalFiles.matMenu.isMenuItemVisible('Favorite')).toBe(true);
     });
 
     test('[XAT-5043] Favorite action has empty star icon for multiple selection of items when some are not favorite', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(fileNotFavUI, fileFavUI);
+      await personalFiles.dataTable.selectItems(fileNotFavUI, fileFavUI);
       await personalFiles.acaHeader.clickMoreActions();
       expect(await personalFiles.matMenu.isMenuItemVisible('Favorite')).toBe(true);
     });
 
     test('[XAT-5044] Favorite action has full star icon for items marked as favorite', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectItem(fileFavUI);
+      await personalFiles.dataTable.selectItems(fileFavUI);
       await personalFiles.acaHeader.clickMoreActions();
       expect(await personalFiles.matMenu.isMenuItemVisible('Remove Favorite')).toBe(true);
     });

--- a/e2e/playwright/folder-rules/src/tests/create-rules.e2e.ts
+++ b/e2e/playwright/folder-rules/src/tests/create-rules.e2e.ts
@@ -171,7 +171,7 @@ test.describe('Folder Rules Actions', () => {
     await nodesPage.manageRules.checkIfRuleIsOnTheList(randomRuleName);
 
     await personalFiles.navigate({ remoteUrl: `#/personal-files/${randomFolderName1Id}` });
-    await personalFiles.dataTable.selectItem(copyFileName);
+    await personalFiles.dataTable.selectItems(copyFileName);
     await personalFiles.acaHeader.clickMoreActions();
     await personalFiles.acaHeader.matMenu.clickMenuItem('Delete');
     await personalFiles.snackBar.message.waitFor({ state: 'visible' });

--- a/e2e/playwright/info-drawer/src/tests/comments.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/comments.e2e.ts
@@ -115,7 +115,7 @@ test.describe('Info Drawer - Comments', () => {
     await fileActionsApi.waitForNodes(recentFile, { expect: 1 });
     await recentFilesPage.navigate();
     await expect(recentFilesPage.dataTable.getRowByName(recentFile)).toBeVisible();
-    await recentFilesPage.dataTable.selectItem(recentFile);
+    await recentFilesPage.dataTable.selectItems(recentFile);
     await recentFilesPage.acaHeader.viewDetails.click();
     await recentFilesPage.infoDrawer.commentsTab.click();
     await expect(recentFilesPage.infoDrawer.commentInputField).toBeVisible();

--- a/e2e/playwright/info-drawer/src/tests/general.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/general.e2e.ts
@@ -66,13 +66,13 @@ test.describe('Info Drawer - General', () => {
     await Utils.reloadPageIfRowNotVisible(personalFiles, parentFolder);
     await expect(personalFiles.dataTable.getRowByName(parentFolder)).toBeVisible();
     await personalFiles.dataTable.performClickFolderOrFileToOpen(parentFolder);
-    await personalFiles.dataTable.selectItem(file1);
+    await personalFiles.dataTable.selectItems(file1);
     await personalFiles.acaHeader.viewDetails.click();
     await expect(personalFiles.infoDrawer.infoDrawerPanel).toBeVisible();
 
     await personalFiles.reload({ waitUntil: 'load' });
     await expect(personalFiles.infoDrawer.infoDrawerPanel).toBeHidden();
-    await personalFiles.dataTable.selectItem(file1);
+    await personalFiles.dataTable.selectItems(file1);
     await personalFiles.acaHeader.viewDetails.click();
     await expect(personalFiles.infoDrawer.infoDrawerPanel).toBeVisible();
 

--- a/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
@@ -223,7 +223,7 @@ test.describe('Share a file', () => {
         const url1 = await personalFiles.shareDialog.getLinkUrl();
         await personalFiles.shareDialog.clickClose();
 
-        await personalFiles.dataTable.selectItem(file8);
+        await personalFiles.dataTable.selectItems(file8);
         await personalFiles.acaHeader.shareButton.click();
         const url2 = await personalFiles.shareDialog.getLinkUrl();
 

--- a/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
@@ -132,7 +132,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286327] Share dialog default values', async ({ personalFiles }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file3, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file3, 'Share');
         const labels = await personalFiles.shareDialog.getLabels();
         expect(await personalFiles.shareDialog.getDialogTitle()).toEqual(`Share ${file3}`);
         expect(labels[0].trim()).toBe(`Share ${file3}`);
@@ -146,7 +146,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286329] Share a file', async ({ personalFiles, nodesApiAction }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file3, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file3, 'Share');
 
         const url = await personalFiles.shareDialog.getLinkUrl();
         await personalFiles.shareDialog.clickClose();
@@ -156,7 +156,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286330] Copy shared file URL', async ({ personalFiles, page }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file4, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file4, 'Share');
 
         const url = await personalFiles.shareDialog.getLinkUrl();
         expect(url).toContain(shareLinkPreUrl);
@@ -177,7 +177,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286332] Share a file with expiration date', async ({ personalFiles, nodesApiAction, page }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file5, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file5, 'Share');
 
         await personalFiles.shareDialog.expireToggle.click();
         expect(await personalFiles.shareDialog.isExpireToggleEnabled()).toBe(true);
@@ -195,7 +195,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286337] Expire date is displayed correctly', async ({ personalFiles, nodesApiAction }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file6, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file6, 'Share');
         const expireProperty = await nodesApiAction.getNodeProperty(file6Id, 'qshare:expiryDate');
 
         expect(expireProperty).toEqual(expiryDate);
@@ -204,7 +204,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286333] Disable the share link expiration', async ({ personalFiles, nodesApiAction, page }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file7, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file7, 'Share');
 
         expect(await personalFiles.shareDialog.isExpireToggleEnabled()).toBe(true);
         expect(await personalFiles.shareDialog.getExpireDate()).not.toBe('');
@@ -218,7 +218,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286335] Shared file URL is not changed when Share dialog is closed and opened again', async ({ personalFiles }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file8, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file8, 'Share');
 
         const url1 = await personalFiles.shareDialog.getLinkUrl();
         await personalFiles.shareDialog.clickClose();
@@ -231,7 +231,7 @@ test.describe('Share a file', () => {
       });
 
       test('[C286345] Share a file from the context menu', async ({ personalFiles, nodesApiAction }) => {
-        expect(await personalFiles.dataTable.performActionFromExpandableMenu(file9, 'Share'));
+        await personalFiles.dataTable.performActionFromExpandableMenu(file9, 'Share');
 
         const url = await personalFiles.shareDialog.getLinkUrl();
         await personalFiles.shareDialog.clickClose();

--- a/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
@@ -116,7 +116,7 @@ test.describe('Unshare a file from Search Results', () => {
     await searchPage.searchOverlay.checkFilesAndFolders();
     await searchPage.searchOverlay.searchFor(file1);
 
-    await personalFiles.dataTable.selectItem(file1);
+    await personalFiles.dataTable.selectItems(file1);
     await personalFiles.acaHeader.shareButton.click();
     await personalFiles.viewerDialog.shareDialogTitle.waitFor({ state: 'attached', timeout: timeouts.normal });
 
@@ -137,7 +137,7 @@ test.describe('Unshare a file from Search Results', () => {
     await searchPage.searchOverlay.checkFilesAndFolders();
     await searchPage.searchOverlay.searchFor(file2);
 
-    await personalFiles.dataTable.selectItem(file2);
+    await personalFiles.dataTable.selectItems(file2);
     await personalFiles.acaHeader.shareButton.click();
     const url = await personalFiles.shareDialog.getLinkUrl();
     await personalFiles.shareDialog.shareToggle.click();
@@ -156,7 +156,7 @@ test.describe('Unshare a file from Search Results', () => {
     await searchPage.searchOverlay.checkFilesAndFolders();
     await searchPage.searchOverlay.searchFor(file3);
 
-    await personalFiles.dataTable.selectItem(file3);
+    await personalFiles.dataTable.selectItems(file3);
     await personalFiles.acaHeader.shareButton.click();
 
     const urlBefore = await personalFiles.shareDialog.getLinkUrl();
@@ -193,7 +193,7 @@ test.describe('Unshare a file from Search Results', () => {
     await searchPage.searchOverlay.checkFilesAndFolders();
     await searchPage.searchOverlay.searchFor(fileSite1);
 
-    await personalFiles.dataTable.selectItem(fileSite1);
+    await personalFiles.dataTable.selectItems(fileSite1);
     await personalFiles.acaHeader.shareButton.click();
 
     expect(await personalFiles.shareDialog.isShareToggleChecked()).toBe(true);
@@ -208,7 +208,7 @@ test.describe('Unshare a file from Search Results', () => {
     await searchPage.searchOverlay.checkFilesAndFolders();
     await searchPage.searchOverlay.searchFor(fileSite2);
 
-    await personalFiles.dataTable.selectItem(fileSite2);
+    await personalFiles.dataTable.selectItems(fileSite2);
     await personalFiles.acaHeader.shareButton.click();
     expect(await personalFiles.shareDialog.isShareToggleChecked()).toBe(true);
 

--- a/e2e/playwright/special-permissions-actions-available/src/tests/folders-actions.e2e.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/folders-actions.e2e.ts
@@ -37,7 +37,7 @@ test.describe('Folders - available actions : ', () => {
     expectedToolbarPrimary: string[],
     expectedToolbarMore: string[]
   ): Promise<void> {
-    await myPersonalFiles.dataTable.selectItem(item);
+    await myPersonalFiles.dataTable.selectItems(item);
     await myPersonalFiles.acaHeader.verifyToolbarPrimaryActions(expectedToolbarPrimary);
     await myPersonalFiles.acaHeader.clickMoreActions();
     await myPersonalFiles.matMenu.verifyActualMoreActions(expectedToolbarMore);
@@ -99,15 +99,15 @@ test.describe('Folders - available actions : ', () => {
     });
 
     test('multiple folders - [C280459]', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(testData.folderFavFile.name, testData.folderFile.name);
+      await personalFiles.dataTable.selectItems(testData.folderFavFile.name, testData.folderFile.name);
       await personalFiles.dataTable.getRowByName(testData.folderFavFile.name).click({ button: 'right' });
       await personalFiles.page.reload({ waitUntil: 'load' });
-      await personalFiles.dataTable.selectMultiItem(testData.folderFavFile.name, testData.folderFile.name);
+      await personalFiles.dataTable.selectItems(testData.folderFavFile.name, testData.folderFile.name);
       await checkMultipleSelActionsAvailable(personalFiles, testData.multipleSelFile.toolbarPrimary, testData.multipleSelFile.toolbarMore);
     });
 
     test('both files and folders - [C280460]', async ({ personalFiles }) => {
-      await personalFiles.dataTable.selectMultiItem(testData.file.name, testData.folderFile.name);
+      await personalFiles.dataTable.selectItems(testData.file.name, testData.folderFile.name);
       await personalFiles.dataTable.getRowByName(testData.folderFile.name).click({ button: 'right' });
       await personalFiles.matMenu.verifyActualMoreActions(testData.multipleSelFile.contextMenu);
       await checkMultipleSelActionsAvailable(personalFiles, testData.multipleSelFile.toolbarPrimary, testData.multipleSelFile.toolbarMore);

--- a/e2e/playwright/special-permissions-actions-available/src/tests/other-permissions.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/other-permissions.ts
@@ -32,7 +32,7 @@ async function checkActionsAvailable(
   expectedToolbarPrimary: string[],
   expectedToolbarMore: string[]
 ): Promise<void> {
-  await myLibrariesPage.dataTable.selectItem(item);
+  await myLibrariesPage.dataTable.selectItems(item);
   await myLibrariesPage.acaHeader.verifyToolbarPrimaryActions(expectedToolbarPrimary);
   await myLibrariesPage.acaHeader.clickMoreActions();
   await myLibrariesPage.matMenu.verifyActualMoreActions(expectedToolbarMore);

--- a/e2e/playwright/upload-download-actions/src/tests/download.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/download.e2e.ts
@@ -62,14 +62,14 @@ test.describe('Download from Personal Files', () => {
 
   test('Download a file', async ({ personalFiles }) => {
     await personalFiles.dataTable.performClickFolderOrFileToOpen(parent);
-    await personalFiles.dataTable.selectItem(childFile);
+    await personalFiles.dataTable.selectItems(childFile);
     const [download] = await Promise.all([personalFiles.page.waitForEvent('download'), personalFiles.acaHeader.downloadButton.click()]);
     expect(download.suggestedFilename()).toBe(childFile);
   });
 
   test('Download a folder', async ({ personalFiles }) => {
     await personalFiles.dataTable.performClickFolderOrFileToOpen(parent);
-    await personalFiles.dataTable.selectItem(childFolder);
+    await personalFiles.dataTable.selectItems(childFolder);
     const [download] = await Promise.all([personalFiles.page.waitForEvent('download'), personalFiles.acaHeader.downloadButton.click()]);
     const filePath = await download.path();
     expect(await Utils.verifyZipFileContent(filePath, [childFolder])).toBe(true);
@@ -77,7 +77,7 @@ test.describe('Download from Personal Files', () => {
 
   test('Download multiple items', async ({ personalFiles }) => {
     await personalFiles.dataTable.performClickFolderOrFileToOpen(parent);
-    await personalFiles.dataTable.selectMultiItem(childFile, childFolder);
+    await personalFiles.dataTable.selectItems(childFile, childFolder);
     const [download] = await Promise.all([personalFiles.page.waitForEvent('download'), personalFiles.acaHeader.downloadButton.click()]);
     const filePath = await download.path();
     expect(await Utils.verifyZipFileContent(filePath, [childFile, childFolder])).toBe(true);

--- a/e2e/playwright/upload-download-actions/src/tests/upload-new-version.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/upload-new-version.e2e.ts
@@ -69,7 +69,7 @@ test.describe('Upload new version', () => {
   let fileActionAPI: FileActionsApi;
 
   async function uploadNewVersion(page: PersonalFilesPage | SearchPage, filename: string, location: string) {
-    await page.dataTable.selectItem(filename);
+    await page.dataTable.selectItems(filename);
     await page.acaHeader.clickMoreActions();
     await page.acaHeader.matMenu.clickMenuItem('Upload New Version');
     await page.acaHeader.uploadNewVersionButton.setInputFiles(location);

--- a/e2e/playwright/upload-download-actions/src/tests/version-actions.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/version-actions.e2e.ts
@@ -56,7 +56,7 @@ test.describe('Version actions', () => {
   let fileId: string;
 
   async function viewFirstFileVersion(page: PersonalFilesPage | RecentFilesPage | FavoritesPage | SharedPage | SearchPage) {
-    await page.dataTable.selectItem(filenameAfterUpdate);
+    await page.dataTable.selectItems(filenameAfterUpdate);
     await page.acaHeader.clickMoreActions();
     await page.matMenu.clickMenuItem('Manage Versions');
     await page.manageVersionsDialog.viewFileVersion('1.0');

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
@@ -238,17 +238,7 @@ export class DataTableComponent extends BaseComponent {
     }
   }
 
-  async selectItem(name: string): Promise<void> {
-    const isSelected = await this.isRowSelected(name);
-    if (!isSelected) {
-      let row = this.getRowByName(name);
-      await row.hover();
-      await row.locator('.mat-mdc-checkbox').click();
-      await row.locator('.mat-mdc-checkbox-checked').waitFor({ state: 'attached' });
-    }
-  }
-
-  async selectMultiItem(...names: string[]): Promise<void> {
+  async selectItems(...names: string[]): Promise<void> {
     for (const name of names) {
       let row = this.getRowByName(name);
       await row.hover();

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
@@ -56,6 +56,8 @@ export class DataTableComponent extends BaseComponent {
   sitesName = this.page.locator('.adf-datatable-body [data-automation-id*="datatable-row"] [aria-label="Name"]');
   sitesRole = this.page.locator('.adf-datatable-body [data-automation-id*="datatable-row"] [aria-label="My Role"]');
   lockOwner = this.page.locator('.aca-locked-by--name');
+  uncheckedChecbox = this.page.locator('.mat-mdc-checkbox');
+  checkedChecbox = this.page.locator('.mat-mdc-checkbox-checked');
 
   /** Locator for row (or rows) */
   getRowLocator = this.page.getByRole('rowgroup').nth(1).locator('adf-datatable-row');
@@ -240,20 +242,19 @@ export class DataTableComponent extends BaseComponent {
 
   async selectItems(...names: string[]): Promise<void> {
     for (const name of names) {
-      let row = this.getRowByName(name);
-      if(row.locator('.mat-mdc-checkbox-checked').isVisible()){
-        break;
+      const isSelected = await this.isRowSelected(name);
+      if (!isSelected) {
+        let row = this.getRowByName(name);
+        await row.hover();
+        await row.locator(this.uncheckedChecbox).click();
+        await row.locator(this.checkedChecbox).waitFor({ state: 'attached' });
       }
-      await row.hover();
-      await row.locator('.mat-mdc-checkbox').click();
-      await row.locator('.mat-mdc-checkbox-checked').waitFor({ state: 'attached' });
-      await this.page.waitForTimeout(1000);
     }
   }
 
   async isRowSelected(itemName: string): Promise<boolean> {
     const row = this.getRowByName(itemName);
-    return await row.locator('.adf-datatable-checkbox .mat-mdc-checkbox-checked').isVisible();
+    return await row.locator(this.checkedChecbox).isVisible();
   }
 
   async getColumnHeaders(): Promise<Array<string>> {

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
@@ -241,6 +241,9 @@ export class DataTableComponent extends BaseComponent {
   async selectItems(...names: string[]): Promise<void> {
     for (const name of names) {
       let row = this.getRowByName(name);
+      if(row.locator('.mat-mdc-checkbox-checked').isVisible()){
+        break;
+      }
       await row.hover();
       await row.locator('.mat-mdc-checkbox').click();
       await row.locator('.mat-mdc-checkbox-checked').waitFor({ state: 'attached' });

--- a/projects/aca-playwright-shared/src/page-objects/pages/personal-files.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/personal-files.page.ts
@@ -98,7 +98,7 @@ export class PersonalFilesPage extends BasePage {
   async copyOrMoveContentInDatatable(sourceFileList: string[], destinationName: string, operation = 'Copy'): Promise<void> {
     await this.page.keyboard.down('Control');
     for (const sourceName of sourceFileList) {
-      await this.dataTable.selectItem(sourceName);
+      await this.dataTable.selectItems(sourceName);
     }
     await this.page.keyboard.up('Control');
     await this.clickMoreActionsButton(operation);
@@ -108,7 +108,7 @@ export class PersonalFilesPage extends BasePage {
 
   async selectItemsAndToggleFavorite(item: string[], action: 'Favorite' | 'Remove Favorite') {
     for (const itemToSelect of item) {
-      await this.dataTable.selectItem(itemToSelect);
+      await this.dataTable.selectItems(itemToSelect);
     }
     await this.acaHeader.clickMoreActions();
     await this.matMenu.clickMenuItem(action);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8561


**What is the new behaviour?**
[ACS-8561] [E2E] Merge-selectItem-and-selectMultiItem-into-one-method


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-8561]: https://hyland.atlassian.net/browse/ACS-8561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ