### PR TITLE
ACS-8572: Switch to using ADF document list reload

### DIFF
--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
@@ -22,14 +22,14 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, ViewEncapsulation, OnInit, Input } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit, Input, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { SelectionState } from '@alfresco/adf-extensions';
-import { AppStore, ReloadDocumentListAction, getAppSelection } from '@alfresco/aca-shared/store';
+import { AppStore, getAppSelection } from '@alfresco/aca-shared/store';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { NodeFavoriteDirective } from '@alfresco/adf-content-services';
+import { DocumentListService, NodeFavoriteDirective } from '@alfresco/adf-content-services';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
@@ -49,6 +49,8 @@ import { MatMenuModule } from '@angular/material/menu';
   host: { class: 'app-toggle-favorite' }
 })
 export class ToggleFavoriteComponent implements OnInit {
+  private documentListService = inject(DocumentListService);
+
   @Input() data: any;
   selection$: Observable<SelectionState>;
   private reloadOnRoutes: string[] = [];
@@ -65,7 +67,7 @@ export class ToggleFavoriteComponent implements OnInit {
 
   onToggleEvent() {
     if (this.reloadOnRoutes.includes(this.router.url)) {
-      this.store.dispatch(new ReloadDocumentListAction());
+      this.documentListService.reload();
     }
   }
 }

--- a/projects/aca-content/src/lib/directives/document-list.directive.spec.ts
+++ b/projects/aca-content/src/lib/directives/document-list.directive.spec.ts
@@ -54,9 +54,9 @@ describe('DocumentListDirective', () => {
     url: ''
   };
 
-  const appHookServiceMock: any = {
-    reload: new Subject<any>(),
-    reset: new Subject<any>()
+  const documentListServiceMock = {
+    reload$: new Subject<any>(),
+    resetSelection$: new Subject<any>()
   };
 
   const mockRoute: any = {
@@ -80,7 +80,7 @@ describe('DocumentListDirective', () => {
       userPreferencesServiceMock,
       mockRoute,
       mockRouter,
-      appHookServiceMock
+      documentListServiceMock as any
     );
   });
 
@@ -139,26 +139,17 @@ describe('DocumentListDirective', () => {
     expect(storeMock.dispatch).toHaveBeenCalled();
   });
 
-  it('should reset and reload document list on `reload` event', () => {
-    documentListDirective.ngOnInit();
-    appHookServiceMock.reload.next();
-
-    expect(documentListMock.resetSelection).toHaveBeenCalled();
-    expect(documentListMock.reload).toHaveBeenCalled();
-  });
-
   it('should reset store selection on `reload` event', () => {
     documentListDirective.ngOnInit();
-    appHookServiceMock.reload.next();
+    documentListServiceMock.reload$.next();
 
     expect(storeMock.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([]));
   });
 
   it('should reset selection state on `reset` event', () => {
     documentListDirective.ngOnInit();
-    appHookServiceMock.reset.next();
+    documentListServiceMock.resetSelection$.next();
 
-    expect(documentListMock.resetSelection).toHaveBeenCalled();
     expect(storeMock.dispatch).toHaveBeenCalledWith(new SetSelectedNodesAction([]));
     expect(documentListDirective.selectedNode).toBeNull();
   });

--- a/projects/aca-content/src/lib/directives/document-list.directive.ts
+++ b/projects/aca-content/src/lib/directives/document-list.directive.ts
@@ -23,12 +23,11 @@
  */
 
 import { Directive, OnDestroy, OnInit, HostListener } from '@angular/core';
-import { DocumentListComponent } from '@alfresco/adf-content-services';
+import { DocumentListComponent, DocumentListService } from '@alfresco/adf-content-services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UserPreferencesService } from '@alfresco/adf-core';
 import { Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { AppHookService } from '@alfresco/aca-shared';
 import { SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { takeUntil, filter } from 'rxjs/operators';
 import { NodeEntry } from '@alfresco/js-api';
@@ -53,7 +52,7 @@ export class DocumentListDirective implements OnInit, OnDestroy {
     private preferences: UserPreferencesService,
     private route: ActivatedRoute,
     private router: Router,
-    private appHookService: AppHookService
+    private documentListService: DocumentListService
   ) {}
 
   ngOnInit() {
@@ -92,11 +91,11 @@ export class DocumentListDirective implements OnInit, OnDestroy {
       )
       .subscribe(() => this.onReady());
 
-    this.appHookService.reload.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+    this.documentListService.reload$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.reload();
     });
 
-    this.appHookService.reset.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+    this.documentListService.resetSelection$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.reset();
     });
   }
@@ -167,14 +166,11 @@ export class DocumentListDirective implements OnInit, OnDestroy {
   }
 
   private reload() {
-    this.documentList.resetSelection();
     this.store.dispatch(new SetSelectedNodesAction([]));
-    this.documentList.reload();
   }
 
   private reset() {
     this.selectedNode = null;
-    this.documentList.resetSelection();
     this.store.dispatch(new SetSelectedNodesAction([]));
   }
 

--- a/projects/aca-content/src/lib/services/content-management.service.spec.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.spec.ts
@@ -1582,7 +1582,7 @@ describe('ContentManagementService', () => {
       expect(spyOnDispatch).toHaveBeenCalledOnceWith(new RefreshPreviewAction(fakeNodeIsFile));
     });
 
-    it('should dispatch ReloadDocumentListAction if dialog emit view action', () => {
+    it('should dispatch ViewNodeVersionAction if dialog emit view action', () => {
       const fakeVersionId = '1';
       const fakeLocation: ViewNodeExtras = {
         location: '/'

--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -32,7 +32,6 @@ import {
   NavigateToParentFolder,
   NodeInfo,
   RefreshPreviewAction,
-  ReloadDocumentListAction,
   SetSelectedNodesAction,
   ShowLoaderAction,
   SnackbarAction,
@@ -45,6 +44,7 @@ import {
   ViewNodeVersionAction
 } from '@alfresco/aca-shared/store';
 import {
+  DocumentListService,
   FolderDialogComponent,
   LibraryDialogComponent,
   NewVersionUploaderData,
@@ -90,7 +90,8 @@ export class ContentManagementService {
     private appHookService: AppHookService,
     private newVersionUploaderService: NewVersionUploaderService,
     private router: Router,
-    private appSettingsService: AppSettingsService
+    private appSettingsService: AppSettingsService,
+    private documentListService: DocumentListService
   ) {}
 
   addFavorite(nodes: Array<NodeEntry>) {
@@ -226,7 +227,7 @@ export class ContentManagementService {
 
     dialogInstance.afterClosed().subscribe((node) => {
       if (node) {
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       }
       this.focusAfterClose(this.createMenuButtonSelector);
     });
@@ -390,7 +391,7 @@ export class ContentManagementService {
       const failedStatus = this.processStatus([]);
       failedStatus.fail.push(...selection);
       this.showRestoreNotification(failedStatus);
-      this.store.dispatch(new ReloadDocumentListAction());
+      this.documentListService.reload();
       return;
     }
 
@@ -409,7 +410,7 @@ export class ContentManagementService {
 
         if (!remainingNodes.length) {
           this.showRestoreNotification(status);
-          this.store.dispatch(new ReloadDocumentListAction());
+          this.documentListService.reload();
         } else {
           this.restoreDeletedNodes(remainingNodes);
         }
@@ -436,7 +437,7 @@ export class ContentManagementService {
         const [operationResult, moveResponse] = result;
         this.showMoveMessage(nodes, operationResult, moveResponse);
 
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       },
       (error) => {
         this.showMoveMessage(nodes, error);
@@ -542,7 +543,7 @@ export class ContentManagementService {
     forkJoin(...batch).subscribe(
       () => {
         this.appHookService.nodesDeleted.next(null);
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       },
       (error) => {
         let i18nMessageString = 'APP.MESSAGES.ERRORS.GENERIC';
@@ -632,7 +633,7 @@ export class ContentManagementService {
       )
       .subscribe(
         () => {
-          this.store.dispatch(new ReloadDocumentListAction());
+          this.documentListService.reload();
         },
         (error) => {
           let message = 'APP.MESSAGES.ERRORS.GENERIC';
@@ -670,7 +671,7 @@ export class ContentManagementService {
 
       if (status.someSucceeded) {
         this.appHookService.nodesDeleted.next();
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       }
       this.store.dispatch(new ShowLoaderAction(false));
     });
@@ -692,7 +693,7 @@ export class ContentManagementService {
       }
 
       if (processedData.someSucceeded) {
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       }
     });
   }
@@ -761,7 +762,7 @@ export class ContentManagementService {
       const status = this.processStatus(purgedNodes);
 
       if (status.success.length) {
-        this.store.dispatch(new ReloadDocumentListAction());
+        this.documentListService.reload();
       }
 
       this.sendPurgeMessage(status);

--- a/projects/aca-content/src/lib/store/effects/app.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/app.effects.ts
@@ -26,18 +26,18 @@ import { Actions, ofType, createEffect } from '@ngrx/effects';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { AppActionTypes, ReloadDocumentListAction, ResetSelectionAction } from '@alfresco/aca-shared/store';
-import { AppHookService } from '@alfresco/aca-shared';
+import { DocumentListService } from '@alfresco/adf-content-services';
 
 @Injectable()
 export class AppEffects {
-  constructor(private actions$: Actions, private appHookService: AppHookService) {}
+  constructor(private actions$: Actions, private documentListService: DocumentListService) {}
 
   reload = createEffect(
     () =>
       this.actions$.pipe(
         ofType<ReloadDocumentListAction>(AppActionTypes.ReloadDocumentList),
-        map((action) => {
-          this.appHookService.reload.next(action);
+        map(() => {
+          this.documentListService.reload();
         })
       ),
     { dispatch: false }
@@ -47,8 +47,8 @@ export class AppEffects {
     () =>
       this.actions$.pipe(
         ofType<ResetSelectionAction>(AppActionTypes.ResetSelection),
-        map((action) => {
-          this.appHookService.reset.next(action);
+        map(() => {
+          this.documentListService.resetSelection();
         })
       ),
     { dispatch: false }

--- a/projects/aca-content/src/lib/store/effects/template.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/template.effects.spec.ts
@@ -33,14 +33,14 @@ import { of, Subject } from 'rxjs';
 import { Node, NodeEntry } from '@alfresco/js-api';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { CreateFromTemplateDialogComponent } from '../../dialogs/node-template/create-from-template.dialog';
-import { AppHookService } from '@alfresco/aca-shared';
 import { NotificationService } from '@alfresco/adf-core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { DocumentListService } from '@alfresco/adf-content-services';
 
 describe('TemplateEffects', () => {
   let store: Store<any>;
   let nodeTemplateService: NodeTemplateService;
-  let appHookService: AppHookService;
+  let documentListService: DocumentListService;
   let templateEffects: TemplateEffects;
   let copyNodeSpy;
   let updateNodeSpy;
@@ -91,7 +91,7 @@ describe('TemplateEffects', () => {
     store = TestBed.inject(Store);
     nodeTemplateService = TestBed.inject(NodeTemplateService);
     templateEffects = TestBed.inject(TemplateEffects);
-    appHookService = TestBed.inject(AppHookService);
+    documentListService = TestBed.inject(DocumentListService);
     matDialog = TestBed.inject(MatDialog);
     subject = new Subject<Node[]>();
 
@@ -99,7 +99,7 @@ describe('TemplateEffects', () => {
     showErrorSpy = spyOn(notificationService, 'showError');
 
     spyOn(store, 'dispatch').and.callThrough();
-    spyOn(appHookService.reload, 'next');
+    spyOn(documentListService, 'reload').and.stub();
     spyOn(store, 'select').and.returnValue(of({ id: 'parent-id' }));
     spyOn(nodeTemplateService, 'selectTemplateDialog').and.returnValue(subject);
 
@@ -212,6 +212,6 @@ describe('TemplateEffects', () => {
     const TEST_NODE = { id: 'test-node-id' } as Node;
     store.dispatch(new CreateFromTemplateSuccess(TEST_NODE));
     tick();
-    expect(appHookService.reload.next).toHaveBeenCalledWith(TEST_NODE);
+    expect(documentListService.reload).toHaveBeenCalled();
   }));
 });

--- a/projects/aca-content/src/lib/store/effects/template.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/template.effects.ts
@@ -37,14 +37,15 @@ import {
 } from '@alfresco/aca-shared/store';
 import { NodeTemplateService, TemplateDialogConfig } from '../../services/node-template.service';
 import { AlfrescoApiService, NotificationService } from '@alfresco/adf-core';
-import { AppHookService } from '@alfresco/aca-shared';
 import { from, Observable, of } from 'rxjs';
 import { NodeEntry, NodeBodyUpdate, Node, NodesApi } from '@alfresco/js-api';
 import { MatDialog } from '@angular/material/dialog';
+import { DocumentListService } from '@alfresco/adf-content-services';
 
 @Injectable()
 export class TemplateEffects {
   private notificationService = inject(NotificationService);
+  private documentListService = inject(DocumentListService);
 
   private _nodesApi: NodesApi;
   get nodesApi(): NodesApi {
@@ -54,7 +55,6 @@ export class TemplateEffects {
 
   constructor(
     private matDialog: MatDialog,
-    private appHookService: AppHookService,
     private store: Store<AppStore>,
     private apiService: AlfrescoApiService,
     private actions$: Actions,
@@ -114,9 +114,9 @@ export class TemplateEffects {
     () =>
       this.actions$.pipe(
         ofType<CreateFromTemplateSuccess>(TemplateActionTypes.CreateFromTemplateSuccess),
-        map((payload) => {
+        map(() => {
           this.matDialog.closeAll();
-          this.appHookService.reload.next(payload.node);
+          this.documentListService.reload();
         })
       ),
     { dispatch: false }

--- a/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.spec.ts
+++ b/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.spec.ts
@@ -25,8 +25,8 @@
 import { Router, ActivatedRoute } from '@angular/router';
 import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
 import { AuthenticationService } from '@alfresco/adf-core';
-import { UploadService, NodesApiService, DiscoveryApiService } from '@alfresco/adf-content-services';
-import { ClosePreviewAction, RefreshPreviewAction, ReloadDocumentListAction, ViewNodeAction } from '@alfresco/aca-shared/store';
+import { UploadService, NodesApiService, DiscoveryApiService, DocumentListService } from '@alfresco/adf-content-services';
+import { ClosePreviewAction, RefreshPreviewAction, ViewNodeAction } from '@alfresco/aca-shared/store';
 import { AcaViewerComponent } from './viewer.component';
 import { of } from 'rxjs';
 import {
@@ -42,7 +42,7 @@ import { Node } from '@alfresco/js-api';
 import { AcaViewerModule } from '../../viewer.module';
 
 const apiError = `{
-"error": { 
+"error": {
   "errorKey":"EntityNotFound",
   "statusCode":404,
   "briefSummary":"The entity with id: someId was not found",
@@ -63,6 +63,7 @@ describe('AcaViewerComponent', () => {
   let uploadService: UploadService;
   let nodesApiService: NodesApiService;
   let appHookService: AppHookService;
+  let documentListService: DocumentListService;
   let store: Store<any>;
 
   beforeEach(() => {
@@ -84,6 +85,7 @@ describe('AcaViewerComponent', () => {
     uploadService = TestBed.inject(UploadService);
     nodesApiService = TestBed.inject(NodesApiService);
     appHookService = TestBed.inject(AppHookService);
+    documentListService = TestBed.inject(DocumentListService);
     store = TestBed.inject(Store);
   });
 
@@ -122,11 +124,11 @@ describe('AcaViewerComponent', () => {
     });
 
     it('should reload document list and navigate to node location upon close', async () => {
-      spyOn(store, 'dispatch');
+      spyOn(documentListService, 'reload');
 
       component.onViewerVisibilityChanged();
 
-      expect(store.dispatch).toHaveBeenCalledWith(new ReloadDocumentListAction());
+      expect(documentListService.reload).toHaveBeenCalled();
       expect(component['navigateToFileLocation']).toHaveBeenCalled();
       expect(router.navigateByUrl).toHaveBeenCalledWith(fakeLocation);
     });

--- a/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.ts
+++ b/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.ts
@@ -36,7 +36,6 @@ import {
   getAppSelection,
   isInfoDrawerOpened,
   RefreshPreviewAction,
-  ReloadDocumentListAction,
   SetCurrentNodeVersionAction,
   SetSelectedNodesAction,
   ViewerActionTypes,
@@ -44,14 +43,14 @@ import {
 } from '@alfresco/aca-shared/store';
 import { ContentActionRef, SelectionState } from '@alfresco/adf-extensions';
 import { Node, VersionEntry, VersionsApi } from '@alfresco/js-api';
-import { Component, HostListener, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, HostListener, inject, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, PRIMARY_OUTLET, Router } from '@angular/router';
 import { AlfrescoApiService, AppConfigPipe, ViewerModule } from '@alfresco/adf-core';
 import { Store } from '@ngrx/store';
 import { from, Observable, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Actions, ofType } from '@ngrx/effects';
-import { AlfrescoViewerModule, NodesApiService, UploadService } from '@alfresco/adf-content-services';
+import { AlfrescoViewerModule, DocumentListService, NodesApiService, UploadService } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { ViewerService } from '../../services/viewer.service';
 
@@ -65,6 +64,8 @@ import { ViewerService } from '../../services/viewer.service';
   host: { class: 'app-viewer' }
 })
 export class AcaViewerComponent implements OnInit, OnDestroy {
+  private documentListService = inject(DocumentListService);
+
   private _versionsApi: VersionsApi;
   get versionsApi(): VersionsApi {
     this._versionsApi = this._versionsApi ?? new VersionsApi(this.apiService.getInstance());
@@ -189,7 +190,7 @@ export class AcaViewerComponent implements OnInit, OnDestroy {
   }
 
   onViewerVisibilityChanged() {
-    this.store.dispatch(new ReloadDocumentListAction());
+    this.documentListService.reload();
     this.navigateToFileLocation();
   }
 

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DocumentListComponent, ShareDataRow, UploadService } from '@alfresco/adf-content-services';
+import { DocumentListComponent, DocumentListService, ShareDataRow, UploadService } from '@alfresco/adf-content-services';
 import { ShowHeaderMode } from '@alfresco/adf-core';
 import { ContentActionRef, DocumentListPresetRef, SelectionState } from '@alfresco/adf-extensions';
 import { OnDestroy, OnInit, OnChanges, ViewChild, SimpleChanges, Directive, inject, HostListener } from '@angular/core';
@@ -33,7 +33,6 @@ import { takeUntil } from 'rxjs/operators';
 import { DocumentBasePageService } from './document-base-page.service';
 import {
   AppStore,
-  ReloadDocumentListAction,
   getCurrentFolder,
   getAppSelection,
   isInfoDrawerOpened,
@@ -71,6 +70,7 @@ export abstract class PageComponent implements OnInit, OnDestroy, OnChanges {
   isSmallScreen = false;
   selectedRowItemsCount = 0;
 
+  protected documentListService = inject(DocumentListService);
   protected settings = inject(AppSettingsService);
   protected extensions = inject(AppExtensionService);
   protected content = inject(DocumentBasePageService);
@@ -187,7 +187,7 @@ export abstract class PageComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
 
-    this.store.dispatch(new ReloadDocumentListAction());
+    this.documentListService.reload();
     if (selectedNode) {
       this.store.dispatch(new SetSelectedNodesAction([selectedNode]));
     }
@@ -217,7 +217,7 @@ export abstract class PageComponent implements OnInit, OnDestroy, OnChanges {
   onAllFilterCleared() {
     if (!this.isOutletPreviewUrl()) {
       this.documentList.node = null;
-      this.store.dispatch(new ReloadDocumentListAction());
+      this.documentListService.reload();
     }
   }
 }

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
@@ -24,13 +24,13 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PageComponent } from './document-base-page.component';
-import { AppState, ReloadDocumentListAction, SetSelectedNodesAction, ViewNodeAction } from '@alfresco/aca-shared/store';
+import { AppState, SetSelectedNodesAction, ViewNodeAction } from '@alfresco/aca-shared/store';
 import { AppExtensionService, LibTestingModule, discoveryApiServiceMockValue, DocumentBasePageServiceMock } from '@alfresco/aca-shared';
 import { NodeEntry, NodePaging } from '@alfresco/js-api';
 import { DocumentBasePageService } from './document-base-page.service';
 import { Store } from '@ngrx/store';
 import { Component } from '@angular/core';
-import { DiscoveryApiService, DocumentListComponent } from '@alfresco/adf-content-services';
+import { DiscoveryApiService, DocumentListComponent, DocumentListService } from '@alfresco/adf-content-services';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { AuthModule } from '@alfresco/adf-core';
 import { HttpClientModule } from '@angular/common/http';
@@ -59,6 +59,7 @@ describe('PageComponent', () => {
   let component: TestComponent;
   let store: Store<AppState>;
   let fixture: ComponentFixture<TestComponent>;
+  let documentListService: DocumentListService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -72,6 +73,7 @@ describe('PageComponent', () => {
     });
 
     store = TestBed.inject(Store);
+    documentListService = TestBed.inject(DocumentListService);
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
   });
@@ -110,10 +112,10 @@ describe('PageComponent', () => {
     });
 
     it('should reload if url does not contain viewer outlet', () => {
-      spyOn(store, 'dispatch');
+      spyOn(documentListService, 'reload');
 
       component.reload();
-      expect(store.dispatch).toHaveBeenCalledWith(new ReloadDocumentListAction());
+      expect(documentListService.reload).toHaveBeenCalledWith();
     });
 
     it('should set selection after reload if node is passed', () => {
@@ -129,6 +131,8 @@ describe('PageComponent', () => {
     });
 
     it('should clear results onAllFilterCleared event', () => {
+      spyOn(documentListService, 'reload');
+
       component.documentList = {
         node: {
           list: {
@@ -141,7 +145,7 @@ describe('PageComponent', () => {
 
       component.onAllFilterCleared();
       expect(component.documentList.node).toBe(null);
-      expect(store.dispatch['calls'].mostRecent().args[0]).toEqual(new ReloadDocumentListAction());
+      expect(documentListService.reload).toHaveBeenCalled();
     });
 
     it('should call onAllFilterCleared event if page is viewer outlet', () => {

--- a/projects/aca-shared/src/lib/services/app-hook.service.ts
+++ b/projects/aca-shared/src/lib/services/app-hook.service.ts
@@ -31,16 +31,6 @@ import { SiteEntry } from '@alfresco/js-api';
 })
 export class AppHookService {
   /**
-   * Gets emitted when reloads event fired
-   */
-  reload = new Subject<any>();
-
-  /**
-   * Gets emitted when user reset the node
-   */
-  reset = new Subject<any>();
-
-  /**
    * Gets emitted when user delete the node
    */
   nodesDeleted = new Subject<any>();
@@ -86,7 +76,7 @@ export class AppHookService {
   linksUnshared = new Subject<any>();
 
   /**
-   * Gets emitted when user mark the the favorite library
+   * Gets emitted when user mark the favorite library
    */
   favoriteLibraryToggle = new Subject<any>();
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

switch to newly introduced DocumentListService api for reload and selection reset

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8572