### PR TITLE
[ACS-8659] Refine ADF upstream to pick only 'alpha' versions

### DIFF
--- a/.github/workflows/upstream-adf.yml
+++ b/.github/workflows/upstream-adf.yml
@@ -30,11 +30,11 @@ jobs:
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
             const getLatestVersionOf = require('./scripts/gh/update/latest-version-of.js');
-            const { hasNewVersion: hasNewADFVersion , remoteVersion: latestADFVersion } = await getLatestVersionOf({github, dependencyName: 'adf-core'});
+            const { hasNewVersion: hasNewADFVersion , remoteVersion: latestADFVersion } = await getLatestVersionOf({exec, github, dependencyName: 'adf-core'});
             console.log('hasNewADFVersion', hasNewADFVersion);
             console.log('latestADFVersion', latestADFVersion?.name);
 
-            const { hasNewVersion: hasNewJSVersion, remoteVersion: latestJSVersion } = await getLatestVersionOf({github, dependencyName: 'js-api'});
+            const { hasNewVersion: hasNewJSVersion, remoteVersion: latestJSVersion } = await getLatestVersionOf({exec, github, dependencyName: 'js-api'});
             console.log('hasNewJSVersion', hasNewJSVersion);
             console.log('latestJSVersion', latestJSVersion?.name);
             if (hasNewADFVersion === 'true' || hasNewJSVersion  === 'true' ) {

--- a/scripts/gh/update/latest-version-of.js
+++ b/scripts/gh/update/latest-version-of.js
@@ -23,7 +23,7 @@ module.exports = async ({exec, github, dependencyName}) => {
           packageDistTag += data.toString()
       }
   };
-  await exec.exec(`npm dist-tag ls @alfresco/adf-core`, [], options);
+  await exec.exec(`npm dist-tag ls @alfresco/${dependencyName}`, [], options);
   const tagsType = packageDistTag.split('\n');
   console.log(tagsType);
   const latestPkgTag = tagsType.find((tag) => tag.includes(latestPkgToUpdate.name))?.split(':')[0];

--- a/scripts/gh/update/latest-version-of.js
+++ b/scripts/gh/update/latest-version-of.js
@@ -2,7 +2,7 @@ function inDays(d1, d2) {
   return Math.floor((d2.getTime() - d1.getTime()) / (24 * 3600 * 1000));
 }
 
-module.exports = async ({exec, github, dependencyName}) => {
+module.exports = async ({ exec, github, dependencyName }) => {
   const organization = 'alfresco';
   const dependencyFullName = `@${organization}/${dependencyName}`;
   const pkg = require('../../../package.json');
@@ -10,18 +10,18 @@ module.exports = async ({exec, github, dependencyName}) => {
   const localVersion = pkg.dependencies[dependencyFullName];
 
   const { data: availablePackages } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
-      package_type: 'npm',
-      package_name: dependencyName,
-      org: organization
+    package_type: 'npm',
+    package_name: dependencyName,
+    org: organization
   });
 
-  let latestPkgToUpdate  = availablePackages[0];
+  let latestPkgToUpdate = availablePackages[0];
   const options = {};
   let packageDistTag = '';
   options.listeners = {
-      stdout: (data) => {
-          packageDistTag += data.toString()
-      }
+    stdout: (data) => {
+      packageDistTag += data.toString();
+    }
   };
   await exec.exec(`npm dist-tag ls @alfresco/${dependencyName}`, [], options);
   const tagsType = packageDistTag.split('\n');
@@ -35,14 +35,13 @@ module.exports = async ({exec, github, dependencyName}) => {
   if (localVersion === latestPkgToUpdate?.name) {
     return { hasNewVersion: 'false' };
   } else {
-      const findLocalVersionOnRemote = availablePackages.find((item) => item.name === localVersion);
-      let rangeInDays = 'N/A'
-      if (findLocalVersionOnRemote !== undefined) {
-        const creationLocal = new Date(findLocalVersionOnRemote.created_at);
-        const creationLatest = new Date(latestPkgToUpdate.created_at);
-        rangeInDays = inDays(creationLocal, creationLatest);
-      }
-      return { hasNewVersion: 'true', remoteVersion: { name: latestPkgToUpdate?.name, rangeInDays } , localVersion};
+    const findLocalVersionOnRemote = availablePackages.find((item) => item.name === localVersion);
+    let rangeInDays = 'N/A';
+    if (findLocalVersionOnRemote !== undefined) {
+      const creationLocal = new Date(findLocalVersionOnRemote.created_at);
+      const creationLatest = new Date(latestPkgToUpdate.created_at);
+      rangeInDays = inDays(creationLocal, creationLatest);
+    }
+    return { hasNewVersion: 'true', remoteVersion: { name: latestPkgToUpdate?.name, rangeInDays }, localVersion };
   }
-
-}
+};

--- a/scripts/gh/update/latest-version-of.js
+++ b/scripts/gh/update/latest-version-of.js
@@ -15,9 +15,19 @@ module.exports = async ({github, dependencyName}) => {
       org: organization
   });
 
-  console.log(availablePackages);
+  let i = 0;
+  let latestPkgToUpdate = null;
 
-  const latestPkgToUpdate = availablePackages[0];
+  while (latestPkgToUpdate === null && i < availablePackages.length) {
+    const { data: pkg } = await github.rest.packages.getPackageVersionForOrganization({
+      package_type: 'npm',
+      package_name: dependencyName,
+      org: organization,
+      package_version_id: availablePackages[i].id
+    });
+
+    console.log(pkg);
+  }
 
   if (localVersion === latestPkgToUpdate?.name) {
       return { hasNewVersion: 'false' };

--- a/scripts/gh/update/latest-version-of.js
+++ b/scripts/gh/update/latest-version-of.js
@@ -15,6 +15,8 @@ module.exports = async ({github, dependencyName}) => {
       org: organization
   });
 
+  console.log(availablePackages);
+
   const latestPkgToUpdate = availablePackages[0];
 
   if (localVersion === latestPkgToUpdate?.name) {

--- a/scripts/gh/update/latest-version-of.js
+++ b/scripts/gh/update/latest-version-of.js
@@ -25,14 +25,11 @@ module.exports = async ({exec, github, dependencyName}) => {
   };
   await exec.exec(`npm dist-tag ls @alfresco/${dependencyName}`, [], options);
   const tagsType = packageDistTag.split('\n');
-  console.log(tagsType);
   const latestPkgTag = tagsType.find((tag) => tag.includes(latestPkgToUpdate.name))?.split(':')[0];
-  console.log(latestPkgTag);
 
   if (latestPkgTag !== 'alpha') {
     const alphaPackageVersion = tagsType.find((tag) => tag.includes('alpha'))?.split(':')[1].trim();
     latestPkgToUpdate = availablePackages.find((item) => item.name === alphaPackageVersion);
-    console.log(latestPkgToUpdate);
   }
 
   if (localVersion === latestPkgToUpdate?.name) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8659

**What is the new behaviour?**

ADF upstream now properly verifies the tag of latest version and accept alphas only.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
