### PR TITLE
[ACS-7970] Add the option to select a tag for ADF upstream

### DIFF
--- a/.github/workflows/upstream-adf.yml
+++ b/.github/workflows/upstream-adf.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '0 */3 * * *' # “At minute 0 past every 3rd hour.”
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Type of the tag the latest version should be fetched with'
+        required: false
+        type: string
+        default: 'alpha'
 
 env:
   GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -30,11 +36,11 @@ jobs:
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
             const getLatestVersionOf = require('./scripts/gh/update/latest-version-of.js');
-            const { hasNewVersion: hasNewADFVersion , remoteVersion: latestADFVersion } = await getLatestVersionOf({exec, github, dependencyName: 'adf-core'});
+            const { hasNewVersion: hasNewADFVersion , remoteVersion: latestADFVersion } = await getLatestVersionOf({exec, github, dependencyName: 'adf-core', tag: '${{ inputs.tag }}'});
             console.log('hasNewADFVersion', hasNewADFVersion);
             console.log('latestADFVersion', latestADFVersion?.name);
 
-            const { hasNewVersion: hasNewJSVersion, remoteVersion: latestJSVersion } = await getLatestVersionOf({exec, github, dependencyName: 'js-api'});
+            const { hasNewVersion: hasNewJSVersion, remoteVersion: latestJSVersion } = await getLatestVersionOf({exec, github, dependencyName: 'js-api', tag: '${{ inputs.tag }}'});
             console.log('hasNewJSVersion', hasNewJSVersion);
             console.log('latestJSVersion', latestJSVersion?.name);
             if (hasNewADFVersion === 'true' || hasNewJSVersion  === 'true' ) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-7970

**What is the new behaviour?**

When upstream is triggered manually there is a new option to select a tag that new version should be fetched with e.g. `branch`, default is `alpha`

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
