### PR TITLE
ACS-8603 hide undo if there is hold selected

### DIFF
--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -657,6 +657,7 @@ export class ContentManagementService {
 
   deleteNodes(items: NodeEntry[]): void {
     const batch: Observable<DeletedNodeInfo>[] = [];
+    const isHoldInCollection = items.some((node) => node.entry.nodeType === 'rma:hold');
 
     items.forEach((node) => {
       batch.push(this.deleteNode(node));
@@ -666,7 +667,7 @@ export class ContentManagementService {
       const status = this.processStatus(data);
       const message = this.getDeleteMessage(status);
 
-      if (message && status.someSucceeded) {
+      if (!isHoldInCollection && message && status.someSucceeded) {
         message.userAction = new SnackbarUserAction('APP.ACTIONS.UNDO', new UndoDeleteNodesAction([...status.success]));
       }
 


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-8603

Now, if any selected item on the list is a hold, the UNDO button in notification is hidden, because holds do not go to trash can.