### PR TITLE
[ACS-8706] split context menu to allow injecting actions

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -26,3 +26,4 @@ This application simplifies the complexity of Content Management and provides co
 - [Search results](/features/search-results)
 - [Search forms](/features/search-forms)
 - [Application Hook](/extending/application-hook)
+- [Context Menu actions](context-menu-actions)

--- a/docs/features/context-menu-actions.md
+++ b/docs/features/context-menu-actions.md
@@ -1,0 +1,69 @@
+---
+Title: Context Menu Actions
+---
+
+# Context Menu Actions
+
+Context Menu Component, appearing on right-clicking a document list item, contains Actions executable on particular file or folder. This entry describes two ways of populating Context Menu.
+
+**Important:** Those two ways are ***mutually exclusive***.
+
+## Default behavior
+
+When using `acaContextActions` directive as shown below, Context Menu actions are loaded from `app.extensions.json` by default.
+
+```html
+<adf-document-list
+    #documentList
+    acaContextActions>
+</adf-document-list>
+```
+
+*Note:* To learn more, see [Extensibility features](../extending/extensibility-features.md) and [Extension format](../extending/extension-format.md).
+
+## Injecting Context Menu Actions
+
+In order to inject custom actions into Context Menu, assign an array of rules, formatted as described in [Extension format](../extending/extension-format.md), to an attribute of a Component using [Document List Component](https://github.com/Alfresco/alfresco-ng2-components/blob/develop/docs/content-services/components/document-list.component.md).
+
+```ts
+const contextMenuAction = [
+  {
+    "id": "custom.action.id",
+    "title": "CUSTOM_ACTION",
+    "order": 1,
+    "icon": "adf:custom-icon",
+    "actions": {
+      "click": "CUSTOM_ACTION"
+    },
+    "rules": {
+      "visible": "show.custom.action"
+    }
+  },
+  {
+    "id": "another.custom.action.id"
+
+    ...
+  }
+]
+
+...
+
+@Component({...})
+export class ComponentWithDocumentList {
+    customContextMenuActions = contextMenuActions;
+    
+    ...
+}
+```
+
+Next, pass them to `customActions` input of `acaContextActions` directive inside component's template.
+
+```html
+<adf-document-list
+    #documentList
+    acaContextActions
+    customActions="customContextMenuActions">
+</adf-document-list>
+```
+
+*Note:* Refer to [Application Actions](../extending/application-actions.md) and [Rules](../extending/rules.md) for information on creating custom *"actions"* and *"rules"* for Context Menu actions.

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.component.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { OnDestroy, HostListener, ViewChild, AfterViewInit, Inject, Directive } from '@angular/core';
+import { MatMenuTrigger } from '@angular/material/menu';
+import { Subject } from 'rxjs';
+import { ContentActionRef } from '@alfresco/adf-extensions';
+import { ContextMenuOverlayRef } from './context-menu-overlay';
+import { CONTEXT_MENU_DIRECTION } from './direction.token';
+import { Direction } from '@angular/cdk/bidi';
+import { AppExtensionService } from '@alfresco/aca-shared';
+
+@Directive()
+export abstract class BaseContextMenuComponent implements OnDestroy, AfterViewInit {
+  protected onDestroy$: Subject<boolean> = new Subject<boolean>();
+  actions: Array<ContentActionRef> = [];
+
+  @ViewChild(MatMenuTrigger)
+  trigger: MatMenuTrigger;
+
+  @HostListener('document:keydown.Escape', ['$event'])
+  handleKeydownEscape(event: KeyboardEvent) {
+    if (event) {
+      if (this.contextMenuOverlayRef) {
+        this.contextMenuOverlayRef.close();
+      }
+    }
+  }
+
+  constructor(
+    private contextMenuOverlayRef: ContextMenuOverlayRef,
+    protected extensions: AppExtensionService,
+    @Inject(CONTEXT_MENU_DIRECTION) public direction: Direction
+  ) {}
+
+  onClickOutsideEvent() {
+    if (this.contextMenuOverlayRef) {
+      this.contextMenuOverlayRef.close();
+    }
+  }
+
+  runAction(contentActionRef: ContentActionRef) {
+    this.extensions.runActionById(contentActionRef.actions.click, {
+      focusedElementOnCloseSelector: '.adf-context-menu-source'
+    });
+  }
+
+  ngOnDestroy() {
+    this.onDestroy$.next(true);
+    this.onDestroy$.complete();
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.trigger.openMenu(), 0);
+  }
+
+  trackByActionId(_: number, obj: ContentActionRef): string {
+    return obj.id;
+  }
+}

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
@@ -27,26 +27,24 @@ import { ContentActionType } from '@alfresco/adf-extensions';
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { BaseContextMenuDirective } from './base-context-menu.directive';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
+import { Component } from '@angular/core';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { OutsideEventDirective } from './context-menu-outside-event.directive';
+import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-test-component',
-  template: '<div acaBaseContextMenu acaContextMenuOutsideEvent (clickOutside)="onClickOutsideEvent()"></div>',
+  template: '<div acaContextMenuOutsideEvent (clickOutside)="onClickOutsideEvent()"></div>',
   standalone: true,
-  imports: [BaseContextMenuDirective, OutsideEventDirective]
+  imports: [OutsideEventDirective]
 })
 class TestComponent extends BaseContextMenuDirective {}
 
 describe('BaseContextMenuComponent', () => {
   let contextMenuOverlayRef: ContextMenuOverlayRef;
   let extensionsService: AppExtensionService;
-  let baseContextMenuDirective: BaseContextMenuDirective;
-  let clickOutsideEventDirective: OutsideEventDirective;
   let fixture: ComponentFixture<TestComponent>;
-  let element: DebugElement;
+  let component: TestComponent;
 
   const contextItem = {
     type: ContentActionType.button,
@@ -59,35 +57,36 @@ describe('BaseContextMenuComponent', () => {
 
   beforeEach(() => {
     void TestBed.configureTestingModule({
-      imports: [AppTestingModule, TestComponent, BaseContextMenuDirective, OutsideEventDirective],
+      imports: [AppTestingModule, TestComponent],
       providers: [
         {
           provide: ContextMenuOverlayRef,
           useValue: {
             close: jasmine.createSpy('close')
           }
-        }
+        },
+        BaseContextMenuDirective,
+        OutsideEventDirective
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);
-    element = fixture.debugElement.query(By.directive(BaseContextMenuDirective));
+    component = fixture.componentInstance;
     contextMenuOverlayRef = TestBed.inject(ContextMenuOverlayRef);
     extensionsService = TestBed.inject(AppExtensionService);
-    baseContextMenuDirective = element.injector.get(BaseContextMenuDirective);
-    clickOutsideEventDirective = element.injector.get(OutsideEventDirective);
 
     fixture.detectChanges();
   });
 
   it('should close context menu on Escape event', () => {
-    element.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(contextMenuOverlayRef.close).toHaveBeenCalled();
   });
 
   it('should close context menu on click outside event', () => {
-    clickOutsideEventDirective.clickOutside.emit();
+    fixture.debugElement.query(By.directive(OutsideEventDirective)).injector.get(OutsideEventDirective).clickOutside.emit();
+    fixture.detectChanges();
 
     expect(contextMenuOverlayRef.close).toHaveBeenCalled();
   });
@@ -95,7 +94,7 @@ describe('BaseContextMenuComponent', () => {
   it('should run action with provided action id and correct payload', () => {
     spyOn(extensionsService, 'runActionById');
 
-    baseContextMenuDirective.runAction(contextItem);
+    component.runAction(contextItem);
 
     expect(extensionsService.runActionById).toHaveBeenCalledWith(contextItem.actions.click, {
       focusedElementOnCloseSelector: '.adf-context-menu-source'
@@ -103,7 +102,7 @@ describe('BaseContextMenuComponent', () => {
   });
 
   it('should return action id on trackByActionId', () => {
-    const actionId = baseContextMenuDirective.trackByActionId(0, contextItem);
+    const actionId = component.trackByActionId(0, contextItem);
     expect(actionId).toBe(contextItem.id);
   });
 });

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
@@ -56,7 +56,7 @@ describe('BaseContextMenuComponent', () => {
   };
 
   beforeEach(() => {
-    void TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [AppTestingModule, TestComponent],
       providers: [
         {
@@ -68,7 +68,7 @@ describe('BaseContextMenuComponent', () => {
         BaseContextMenuDirective,
         OutsideEventDirective
       ]
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
@@ -26,13 +26,27 @@ import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { ContentActionType } from '@alfresco/adf-extensions';
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { BaseContextMenuDirective } from './base-context-menu.directive';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { AppTestingModule } from '../../testing/app-testing.module';
+import { OutsideEventDirective } from './context-menu-outside-event.directive';
+
+@Component({
+  selector: 'app-test-component',
+  template: '<div acaBaseContextMenu acaContextMenuOutsideEvent (clickOutside)="onClickOutsideEvent()"></div>',
+  standalone: true,
+  imports: [BaseContextMenuDirective, OutsideEventDirective]
+})
+class TestComponent extends BaseContextMenuDirective {}
 
 describe('BaseContextMenuComponent', () => {
   let contextMenuOverlayRef: ContextMenuOverlayRef;
   let extensionsService: AppExtensionService;
   let baseContextMenuDirective: BaseContextMenuDirective;
+  let clickOutsideEventDirective: OutsideEventDirective;
+  let fixture: ComponentFixture<TestComponent>;
+  let element: DebugElement;
 
   const contextItem = {
     type: ContentActionType.button,
@@ -44,8 +58,8 @@ describe('BaseContextMenuComponent', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [AppTestingModule],
+    void TestBed.configureTestingModule({
+      imports: [AppTestingModule, TestComponent, BaseContextMenuDirective, OutsideEventDirective],
       providers: [
         {
           provide: ContextMenuOverlayRef,
@@ -54,21 +68,27 @@ describe('BaseContextMenuComponent', () => {
           }
         }
       ]
-    });
+    }).compileComponents();
 
+    fixture = TestBed.createComponent(TestComponent);
+    element = fixture.debugElement.query(By.directive(BaseContextMenuDirective));
     contextMenuOverlayRef = TestBed.inject(ContextMenuOverlayRef);
     extensionsService = TestBed.inject(AppExtensionService);
+    baseContextMenuDirective = element.injector.get(BaseContextMenuDirective);
+    clickOutsideEventDirective = element.injector.get(OutsideEventDirective);
 
-    baseContextMenuDirective = new BaseContextMenuDirective(contextMenuOverlayRef, extensionsService, null);
+    fixture.detectChanges();
   });
 
   it('should close context menu on Escape event', () => {
-    baseContextMenuDirective.handleKeydownEscape(new KeyboardEvent('keydown', { key: 'Escape' }));
+    element.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
     expect(contextMenuOverlayRef.close).toHaveBeenCalled();
   });
 
   it('should close context menu on click outside event', () => {
-    baseContextMenuDirective.onClickOutsideEvent();
+    clickOutsideEventDirective.clickOutside.emit();
+
     expect(contextMenuOverlayRef.close).toHaveBeenCalled();
   });
 

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -31,10 +31,7 @@ import { CONTEXT_MENU_DIRECTION } from './direction.token';
 import { Direction } from '@angular/cdk/bidi';
 import { AppExtensionService } from '@alfresco/aca-shared';
 
-@Directive({
-  selector: '[acaBaseContextMenu]',
-  standalone: true
-})
+@Directive()
 export class BaseContextMenuDirective implements OnDestroy {
   protected onDestroy$: Subject<boolean> = new Subject<boolean>();
   actions: Array<ContentActionRef> = [];

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -22,9 +22,8 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { OnDestroy, HostListener, ViewChild, Inject, Directive } from '@angular/core';
+import { HostListener, ViewChild, Inject, Directive } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
-import { Subject } from 'rxjs';
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { CONTEXT_MENU_DIRECTION } from './direction.token';
@@ -32,8 +31,7 @@ import { Direction } from '@angular/cdk/bidi';
 import { AppExtensionService } from '@alfresco/aca-shared';
 
 @Directive()
-export class BaseContextMenuDirective implements OnDestroy {
-  protected onDestroy$: Subject<boolean> = new Subject<boolean>();
+export class BaseContextMenuDirective {
   actions: Array<ContentActionRef> = [];
 
   @ViewChild(MatMenuTrigger)
@@ -62,11 +60,6 @@ export class BaseContextMenuDirective implements OnDestroy {
     this.extensions.runActionById(contentActionRef.actions.click, {
       focusedElementOnCloseSelector: '.adf-context-menu-source'
     });
-  }
-
-  ngOnDestroy() {
-    this.onDestroy$.next(true);
-    this.onDestroy$.complete();
   }
 
   trackByActionId(_: number, obj: ContentActionRef): string {

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { OnDestroy, HostListener, ViewChild, AfterViewInit, Inject, Directive } from '@angular/core';
+import { OnDestroy, HostListener, ViewChild, Inject, Directive } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Subject } from 'rxjs';
 import { ContentActionRef } from '@alfresco/adf-extensions';
@@ -32,7 +32,7 @@ import { Direction } from '@angular/cdk/bidi';
 import { AppExtensionService } from '@alfresco/aca-shared';
 
 @Directive()
-export abstract class BaseContextMenuComponent implements OnDestroy, AfterViewInit {
+export class BaseContextMenuDirective implements OnDestroy {
   protected onDestroy$: Subject<boolean> = new Subject<boolean>();
   actions: Array<ContentActionRef> = [];
 
@@ -69,10 +69,6 @@ export abstract class BaseContextMenuComponent implements OnDestroy, AfterViewIn
   ngOnDestroy() {
     this.onDestroy$.next(true);
     this.onDestroy$.complete();
-  }
-
-  ngAfterViewInit() {
-    setTimeout(() => this.trigger.openMenu(), 0);
   }
 
   trackByActionId(_: number, obj: ContentActionRef): string {

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -31,7 +31,10 @@ import { CONTEXT_MENU_DIRECTION } from './direction.token';
 import { Direction } from '@angular/cdk/bidi';
 import { AppExtensionService } from '@alfresco/aca-shared';
 
-@Directive()
+@Directive({
+  selector: '[acaBaseContextMenu]',
+  standalone: true
+})
 export class BaseContextMenuDirective implements OnDestroy {
   protected onDestroy$: Subject<boolean> = new Subject<boolean>();
   actions: Array<ContentActionRef> = [];
@@ -39,12 +42,10 @@ export class BaseContextMenuDirective implements OnDestroy {
   @ViewChild(MatMenuTrigger)
   trigger: MatMenuTrigger;
 
-  @HostListener('document:keydown.Escape', ['$event'])
+  @HostListener('keydown.escape', ['$event'])
   handleKeydownEscape(event: KeyboardEvent) {
-    if (event) {
-      if (this.contextMenuOverlayRef) {
-        this.contextMenuOverlayRef.close();
-      }
+    if (event && this.contextMenuOverlayRef) {
+      this.contextMenuOverlayRef.close();
     }
   }
 

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -47,7 +47,7 @@ export class BaseContextMenuDirective implements OnDestroy {
   }
 
   constructor(
-    private contextMenuOverlayRef: ContextMenuOverlayRef,
+    private readonly contextMenuOverlayRef: ContextMenuOverlayRef,
     protected extensions: AppExtensionService,
     @Inject(CONTEXT_MENU_DIRECTION) public direction: Direction
   ) {}

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
@@ -59,7 +59,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   encapsulation: ViewEncapsulation.None
 })
 export class ContextMenuComponent extends BaseContextMenuDirective implements OnInit, AfterViewInit {
-  private destroyRef = inject(DestroyRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(contextMenuOverlayRef: ContextMenuOverlayRef, extensions: AppExtensionService, @Inject(CONTEXT_MENU_DIRECTION) direction: Direction) {
     super(contextMenuOverlayRef, extensions, direction);

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, ViewEncapsulation, OnInit, OnDestroy, AfterViewInit, Inject } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit, AfterViewInit, Inject } from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { takeUntil } from 'rxjs/operators';
 import { DynamicExtensionComponent } from '@alfresco/adf-extensions';
@@ -36,7 +36,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { IconComponent } from '@alfresco/adf-core';
 import { ContextMenuItemComponent } from './context-menu-item.component';
 import { OutsideEventDirective } from './context-menu-outside-event.directive';
-import { BaseContextMenuComponent } from './base-context-menu.component';
+import { BaseContextMenuDirective } from './base-context-menu.directive';
 
 @Component({
   standalone: true,
@@ -58,7 +58,7 @@ import { BaseContextMenuComponent } from './base-context-menu.component';
   },
   encapsulation: ViewEncapsulation.None
 })
-export class ContextMenuComponent extends BaseContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
+export class ContextMenuComponent extends BaseContextMenuDirective implements OnInit, AfterViewInit {
   constructor(contextMenuOverlayRef: ContextMenuOverlayRef, extensions: AppExtensionService, @Inject(CONTEXT_MENU_DIRECTION) direction: Direction) {
     super(contextMenuOverlayRef, extensions, direction);
   }
@@ -70,5 +70,9 @@ export class ContextMenuComponent extends BaseContextMenuComponent implements On
       .subscribe((actions) => {
         this.actions = actions;
       });
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.trigger.openMenu(), 0);
   }
 }

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
@@ -22,9 +22,8 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, ViewEncapsulation, OnInit, AfterViewInit, Inject } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit, AfterViewInit, Inject, inject, DestroyRef } from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
-import { takeUntil } from 'rxjs/operators';
 import { DynamicExtensionComponent } from '@alfresco/adf-extensions';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { CONTEXT_MENU_DIRECTION } from './direction.token';
@@ -37,6 +36,7 @@ import { IconComponent } from '@alfresco/adf-core';
 import { ContextMenuItemComponent } from './context-menu-item.component';
 import { OutsideEventDirective } from './context-menu-outside-event.directive';
 import { BaseContextMenuDirective } from './base-context-menu.directive';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   standalone: true,
@@ -59,6 +59,8 @@ import { BaseContextMenuDirective } from './base-context-menu.directive';
   encapsulation: ViewEncapsulation.None
 })
 export class ContextMenuComponent extends BaseContextMenuDirective implements OnInit, AfterViewInit {
+  private destroyRef = inject(DestroyRef);
+
   constructor(contextMenuOverlayRef: ContextMenuOverlayRef, extensions: AppExtensionService, @Inject(CONTEXT_MENU_DIRECTION) direction: Direction) {
     super(contextMenuOverlayRef, extensions, direction);
   }
@@ -66,7 +68,7 @@ export class ContextMenuComponent extends BaseContextMenuDirective implements On
   ngOnInit() {
     this.extensions
       .getAllowedContextMenuActions()
-      .pipe(takeUntil(this.onDestroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((actions) => {
         this.actions = actions;
       });

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
@@ -32,12 +32,24 @@ import { ContextMenuService } from './context-menu.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { ContextMenuComponent } from './context-menu.component';
 import { ContextmenuOverlayConfig } from './interfaces';
+import { ContentActionRef, ContentActionType } from '@alfresco/adf-extensions';
 
 describe('ContextMenuService', () => {
   let contextMenuService: ContextMenuService;
   let overlay: Overlay;
   let injector: Injector;
   let userPreferencesService: UserPreferencesService;
+
+  const customActionMock: ContentActionRef[] = [
+    {
+      type: ContentActionType.default,
+      id: 'action',
+      title: 'action',
+      actions: {
+        click: 'event'
+      }
+    }
+  ];
 
   const overlayConfig: ContextmenuOverlayConfig = {
     hasBackdrop: false,
@@ -92,5 +104,21 @@ describe('ContextMenuService', () => {
     contextMenuService.open(overlayConfig);
 
     expect(document.body.querySelector('div[dir="rtl"]')).not.toBe(null);
+  });
+
+  it('should render custom context menu component', () => {
+    contextMenuService = new ContextMenuService(injector, overlay, userPreferencesService);
+
+    contextMenuService.open(overlayConfig, customActionMock);
+
+    expect(document.querySelector('aca-custom-context-menu')).not.toBe(null);
+  });
+
+  it('should not render custom context menu when no custom actions are provided', () => {
+    contextMenuService = new ContextMenuService(injector, overlay, userPreferencesService);
+
+    contextMenuService.open(overlayConfig, []);
+
+    expect(document.querySelector('aca-custom-context-menu')).toBe(null);
   });
 });

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu-actions.token.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu-actions.token.ts
@@ -22,7 +22,6 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export enum ContextMenuActionTypes {
-  ContextMenu = 'CONTEXT_MENU',
-  CustomContextMenu = 'CUSTOM_CONTEXT_MENU'
-}
+import { InjectionToken } from '@angular/core';
+
+export const CONTEXT_MENU_CUSTOM_ACTIONS = new InjectionToken('CONTEXT_MENU_CUSTOM_ACTIONS');

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
@@ -30,7 +30,7 @@ import { ContentActionType } from '@alfresco/adf-extensions';
 import { CONTEXT_MENU_CUSTOM_ACTIONS } from './custom-context-menu-actions.token';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Store } from '@ngrx/store';
-import { initialState } from '../../../../../aca-shared/src/lib/testing/lib-testing-module';
+import { initialState } from '@alfresco/aca-shared';
 
 describe('ContextMenuComponent', () => {
   let fixture: ComponentFixture<CustomContextMenuComponent>;

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
@@ -24,27 +24,36 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppTestingModule } from '../../testing/app-testing.module';
-import { ContextMenuComponent } from './context-menu.component';
+import { CustomContextMenuComponent } from './custom-context-menu.component';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { ContentActionType } from '@alfresco/adf-extensions';
 
 import { of } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { AppExtensionService } from '@alfresco/aca-shared';
+import { CONTEXT_MENU_CUSTOM_ACTIONS } from './custom-context-menu-actions.token';
 
 describe('ContextMenuComponent', () => {
-  let fixture: ComponentFixture<ContextMenuComponent>;
-  let component: ContextMenuComponent;
-  let extensionsService: AppExtensionService;
+  let fixture: ComponentFixture<CustomContextMenuComponent>;
+  let component: CustomContextMenuComponent;
 
-  const contextItem = {
-    type: ContentActionType.button,
-    id: 'action-button',
-    title: 'Test Button',
-    actions: {
-      click: 'TEST_EVENT'
+  const contextMenuActionsMock = [
+    {
+      type: ContentActionType.button,
+      id: 'action1',
+      title: 'action1',
+      actions: {
+        click: 'event1'
+      }
+    },
+    {
+      type: ContentActionType.button,
+      id: 'action2',
+      title: 'action2',
+      actions: {
+        click: 'event2'
+      }
     }
-  };
+  ];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -62,31 +71,31 @@ describe('ContextMenuComponent', () => {
             dispatch: () => {},
             select: () => of({ count: 1 })
           }
+        },
+        {
+          provide: CONTEXT_MENU_CUSTOM_ACTIONS,
+          useValue: contextMenuActionsMock
         }
       ]
     });
 
-    fixture = TestBed.createComponent(ContextMenuComponent);
+    fixture = TestBed.createComponent(CustomContextMenuComponent);
     component = fixture.componentInstance;
-
-    extensionsService = TestBed.inject(AppExtensionService);
-
-    spyOn(extensionsService, 'getAllowedContextMenuActions').and.returnValue(of([contextItem]));
 
     fixture.detectChanges();
   });
 
-  it('should load context menu actions on init', () => {
-    expect(component.actions.length).toBe(1);
+  it('should set context menu actions from Injection Token', () => {
+    expect(component.actions.length).toBe(2);
   });
 
   it('should render defined context menu actions items', async () => {
     await fixture.whenStable();
 
     const contextMenuElements = document.body.querySelector('.aca-context-menu')?.querySelectorAll('button');
-    const actionButtonLabel: HTMLElement = contextMenuElements?.[0].querySelector(`[data-automation-id="${contextItem.id}-label"]`);
+    const actionButtonLabel: HTMLElement = contextMenuElements?.[0].querySelector(`[data-automation-id="${contextMenuActionsMock[0].id}-label"]`);
 
-    expect(contextMenuElements?.length).toBe(1);
-    expect(actionButtonLabel.innerText).toBe(contextItem.title);
+    expect(contextMenuElements?.length).toBe(2);
+    expect(actionButtonLabel.innerText).toBe(contextMenuActionsMock[0].title);
   });
 });

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
@@ -27,10 +27,10 @@ import { AppTestingModule } from '../../testing/app-testing.module';
 import { CustomContextMenuComponent } from './custom-context-menu.component';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { ContentActionType } from '@alfresco/adf-extensions';
-
-import { of } from 'rxjs';
-import { Store } from '@ngrx/store';
 import { CONTEXT_MENU_CUSTOM_ACTIONS } from './custom-context-menu-actions.token';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Store } from '@ngrx/store';
+import { initialState } from '../../../../../aca-shared/src/lib/testing/lib-testing-module';
 
 describe('ContextMenuComponent', () => {
   let fixture: ComponentFixture<CustomContextMenuComponent>;
@@ -67,11 +67,9 @@ describe('ContextMenuComponent', () => {
         },
         {
           provide: Store,
-          useValue: {
-            dispatch: () => {},
-            select: () => of({ count: 1 })
-          }
+          useValue: MockStore
         },
+        provideMockStore({ initialState }),
         {
           provide: CONTEXT_MENU_CUSTOM_ACTIONS,
           useValue: contextMenuActionsMock

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
@@ -22,24 +22,26 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, ViewEncapsulation, OnInit, OnDestroy, AfterViewInit, Inject } from '@angular/core';
-import { MatMenuModule } from '@angular/material/menu';
-import { takeUntil } from 'rxjs/operators';
-import { DynamicExtensionComponent } from '@alfresco/adf-extensions';
-import { ContextMenuOverlayRef } from './context-menu-overlay';
-import { CONTEXT_MENU_DIRECTION } from './direction.token';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { Direction } from '@angular/cdk/bidi';
+import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { AppExtensionService } from '@alfresco/aca-shared';
+import { CONTEXT_MENU_DIRECTION } from './direction.token';
+import { ContentActionRef, DynamicExtensionComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatDividerModule } from '@angular/material/divider';
-import { IconComponent } from '@alfresco/adf-core';
+import { MatMenuModule } from '@angular/material/menu';
 import { ContextMenuItemComponent } from './context-menu-item.component';
 import { OutsideEventDirective } from './context-menu-outside-event.directive';
+import { MatDividerModule } from '@angular/material/divider';
+import { IconComponent } from '@alfresco/adf-core';
+import { CONTEXT_MENU_CUSTOM_ACTIONS } from './custom-context-menu-actions.token';
 import { BaseContextMenuComponent } from './base-context-menu.component';
 
 @Component({
-  standalone: true,
+  selector: 'aca-custom-context-menu',
+  templateUrl: './context-menu.component.html',
+  styleUrls: ['./context-menu.component.scss'],
   imports: [
     CommonModule,
     TranslateModule,
@@ -50,25 +52,20 @@ import { BaseContextMenuComponent } from './base-context-menu.component';
     IconComponent,
     DynamicExtensionComponent
   ],
-  selector: 'aca-context-menu',
-  templateUrl: './context-menu.component.html',
-  styleUrls: ['./context-menu.component.scss'],
   host: {
     class: 'aca-context-menu-holder'
   },
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true
 })
-export class ContextMenuComponent extends BaseContextMenuComponent implements OnInit, OnDestroy, AfterViewInit {
-  constructor(contextMenuOverlayRef: ContextMenuOverlayRef, extensions: AppExtensionService, @Inject(CONTEXT_MENU_DIRECTION) direction: Direction) {
+export class CustomContextMenuComponent extends BaseContextMenuComponent {
+  constructor(
+    contextMenuOverlayRef: ContextMenuOverlayRef,
+    extensions: AppExtensionService,
+    @Inject(CONTEXT_MENU_DIRECTION) direction: Direction,
+    @Inject(CONTEXT_MENU_CUSTOM_ACTIONS) customActions: ContentActionRef[]
+  ) {
     super(contextMenuOverlayRef, extensions, direction);
-  }
-
-  ngOnInit() {
-    this.extensions
-      .getAllowedContextMenuActions()
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe((actions) => {
-        this.actions = actions;
-      });
+    this.actions = customActions;
   }
 }

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, Inject, ViewEncapsulation } from '@angular/core';
 import { Direction } from '@angular/cdk/bidi';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { AppExtensionService } from '@alfresco/aca-shared';
@@ -36,7 +36,7 @@ import { OutsideEventDirective } from './context-menu-outside-event.directive';
 import { MatDividerModule } from '@angular/material/divider';
 import { IconComponent } from '@alfresco/adf-core';
 import { CONTEXT_MENU_CUSTOM_ACTIONS } from './custom-context-menu-actions.token';
-import { BaseContextMenuComponent } from './base-context-menu.component';
+import { BaseContextMenuDirective } from './base-context-menu.directive';
 
 @Component({
   selector: 'aca-custom-context-menu',
@@ -58,7 +58,7 @@ import { BaseContextMenuComponent } from './base-context-menu.component';
   encapsulation: ViewEncapsulation.None,
   standalone: true
 })
-export class CustomContextMenuComponent extends BaseContextMenuComponent {
+export class CustomContextMenuComponent extends BaseContextMenuDirective implements AfterViewInit {
   constructor(
     contextMenuOverlayRef: ContextMenuOverlayRef,
     extensions: AppExtensionService,
@@ -67,5 +67,9 @@ export class CustomContextMenuComponent extends BaseContextMenuComponent {
   ) {
     super(contextMenuOverlayRef, extensions, direction);
     this.actions = customActions;
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.trigger.openMenu(), 0);
   }
 }

--- a/projects/aca-content/src/lib/store/app-store.module.ts
+++ b/projects/aca-content/src/lib/store/app-store.module.ts
@@ -71,7 +71,6 @@ import { SearchAiEffects } from './effects/search-ai.effects';
       TemplateEffects,
       ContextMenuEffects,
       SearchAiEffects,
-      ContextMenuEffects,
       SnackbarEffects,
       RouterEffects
     ])

--- a/projects/aca-content/src/lib/store/effects/contextmenu.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/contextmenu.effects.spec.ts
@@ -27,10 +27,22 @@ import { AppTestingModule } from '../../testing/app-testing.module';
 import { ContextMenuEffects } from './contextmenu.effects';
 import { EffectsModule } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { ContextMenu } from '@alfresco/aca-shared/store';
+import { ContextMenu, CustomContextMenu } from '@alfresco/aca-shared/store';
 import { ContextMenuService } from '../../components/context-menu/context-menu.service';
 import { OverlayModule, OverlayRef } from '@angular/cdk/overlay';
 import { ContextMenuOverlayRef } from '../../components/context-menu/context-menu-overlay';
+import { ContentActionRef, ContentActionType } from '@alfresco/adf-extensions';
+
+const actionPayloadMock: ContentActionRef[] = [
+  {
+    type: ContentActionType.default,
+    id: 'action',
+    title: 'action',
+    actions: {
+      click: 'event'
+    }
+  }
+];
 
 describe('ContextMenuEffects', () => {
   let store: Store<any>;
@@ -60,6 +72,24 @@ describe('ContextMenuEffects', () => {
     expect(contextMenuService.open).toHaveBeenCalled();
 
     store.dispatch(new ContextMenu(new MouseEvent('click')));
+    expect(overlayRefMock.close).toHaveBeenCalled();
+  });
+
+  it('should open custom context menu on customContextMenu$ action', () => {
+    store.dispatch(new CustomContextMenu(new MouseEvent('click'), actionPayloadMock));
+    expect(contextMenuService.open).toHaveBeenCalled();
+  });
+
+  it('should not open custom context menu on customContextMenu$ action if no action provided', () => {
+    store.dispatch(new CustomContextMenu(new MouseEvent('click'), []));
+    expect(contextMenuService.open).not.toHaveBeenCalled();
+  });
+
+  it('should close custom context menu if a new one is opened', () => {
+    store.dispatch(new CustomContextMenu(new MouseEvent('click'), actionPayloadMock));
+    expect(contextMenuService.open).toHaveBeenCalled();
+
+    store.dispatch(new CustomContextMenu(new MouseEvent('click'), actionPayloadMock));
     expect(overlayRefMock.close).toHaveBeenCalled();
   });
 });

--- a/projects/aca-content/src/lib/store/effects/contextmenu.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/contextmenu.effects.ts
@@ -22,7 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ContextMenu, ContextMenuActionTypes } from '@alfresco/aca-shared/store';
+import { ContextMenu, ContextMenuActionTypes, CustomContextMenu } from '@alfresco/aca-shared/store';
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { map } from 'rxjs/operators';
@@ -51,6 +51,30 @@ export class ContextMenuEffects {
             backdropClass: 'cdk-overlay-transparent-backdrop',
             panelClass: 'cdk-overlay-pane'
           });
+        })
+      ),
+    { dispatch: false }
+  );
+
+  customContextMenu$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType<CustomContextMenu>(ContextMenuActionTypes.CustomContextMenu),
+        map((action) => {
+          if (action.payload?.length) {
+            if (this.overlayRef) {
+              this.overlayRef.close();
+            }
+            this.overlayRef = this.contextMenuService.open(
+              {
+                source: action.event,
+                hasBackdrop: false,
+                backdropClass: 'cdk-overlay-transparent-backdrop',
+                panelClass: 'cdk-overlay-pane'
+              },
+              action.payload
+            );
+          }
         })
       ),
     { dispatch: false }

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
@@ -23,8 +23,20 @@
  */
 
 import { ContextActionsDirective } from './contextmenu.directive';
-import { ContextMenu } from '@alfresco/aca-shared/store';
+import { ContextMenu, CustomContextMenu } from '@alfresco/aca-shared/store';
+import { ContentActionRef, ContentActionType } from '@alfresco/adf-extensions';
 import { fakeAsync, tick } from '@angular/core/testing';
+
+const customActionsMock: ContentActionRef[] = [
+  {
+    type: ContentActionType.default,
+    id: 'action',
+    title: 'action',
+    actions: {
+      click: 'event'
+    }
+  }
+];
 
 describe('ContextActionsDirective', () => {
   let directive: ContextActionsDirective;
@@ -45,24 +57,6 @@ describe('ContextActionsDirective', () => {
     expect(directive.execute).not.toHaveBeenCalled();
   });
 
-  it('should call service to render context menu', fakeAsync(() => {
-    const el = document.createElement('div');
-    el.className = 'adf-datatable-cell adf-datatable-cell--text adf-datatable-row';
-
-    const fragment = document.createDocumentFragment();
-    fragment.appendChild(el);
-    const target = fragment.querySelector('div');
-    const mouseEventMock: any = { preventDefault: () => {}, target };
-
-    directive.ngOnInit();
-
-    directive.onContextMenuEvent(mouseEventMock);
-
-    tick(500);
-
-    expect(storeMock.dispatch).toHaveBeenCalledWith(new ContextMenu(mouseEventMock));
-  }));
-
   it('should not call service to render context menu if the datatable is empty', fakeAsync(() => {
     storeMock.dispatch.calls.reset();
     const el = document.createElement('div');
@@ -82,4 +76,34 @@ describe('ContextActionsDirective', () => {
 
     expect(storeMock.dispatch).not.toHaveBeenCalled();
   }));
+
+  describe('Context Menu rendering', () => {
+    let mouseEventMock: any;
+    beforeEach(() => {
+      const el = document.createElement('div');
+      el.className = 'adf-datatable-cell adf-datatable-cell--text adf-datatable-row';
+
+      const fragment = document.createDocumentFragment();
+      fragment.appendChild(el);
+      const target = fragment.querySelector('div');
+      mouseEventMock = { preventDefault: () => {}, target };
+    });
+
+    it('should call service to render context menu', fakeAsync(() => {
+      directive.ngOnInit();
+      directive.onContextMenuEvent(mouseEventMock);
+      tick(500);
+
+      expect(storeMock.dispatch).toHaveBeenCalledWith(new ContextMenu(mouseEventMock));
+    }));
+
+    it('should call service to render custom context menu if custom actions are provided', fakeAsync(() => {
+      directive.customActions = customActionsMock;
+      directive.ngOnInit();
+      directive.onContextMenuEvent(mouseEventMock);
+      tick(500);
+
+      expect(storeMock.dispatch).toHaveBeenCalledWith(new CustomContextMenu(mouseEventMock, customActionsMock));
+    }));
+  });
 });

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
@@ -42,8 +42,7 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
   @Input('acaContextEnable')
   enabled = true;
 
-  // eslint-disable-next-line
-  @Input('customActions')
+  @Input()
   customActions: ContentActionRef[] = [];
 
   @HostListener('contextmenu', ['$event'])

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
@@ -26,7 +26,8 @@ import { Directive, HostListener, Input, OnInit, OnDestroy } from '@angular/core
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { AppStore, ContextMenu } from '@alfresco/aca-shared/store';
+import { AppStore, ContextMenu, CustomContextMenu } from '@alfresco/aca-shared/store';
+import { ContentActionRef } from '@alfresco/adf-extensions';
 
 @Directive({
   standalone: true,
@@ -40,6 +41,10 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
   // eslint-disable-next-line
   @Input('acaContextEnable')
   enabled = true;
+
+  // eslint-disable-next-line
+  @Input('customActions')
+  customActions: ContentActionRef[] = [];
 
   @HostListener('contextmenu', ['$event'])
   onContextMenuEvent(event: MouseEvent) {
@@ -59,7 +64,11 @@ export class ContextActionsDirective implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.execute$.pipe(debounceTime(300), takeUntil(this.onDestroy$)).subscribe((event: MouseEvent) => {
-      this.store.dispatch(new ContextMenu(event));
+      if (this.customActions?.length) {
+        this.store.dispatch(new CustomContextMenu(event, this.customActions));
+      } else {
+        this.store.dispatch(new ContextMenu(event));
+      }
     });
   }
 

--- a/projects/aca-shared/store/src/actions/contextmenu.actions.ts
+++ b/projects/aca-shared/store/src/actions/contextmenu.actions.ts
@@ -24,9 +24,16 @@
 
 import { Action } from '@ngrx/store';
 import { ContextMenuActionTypes } from './context-menu-action-types';
+import { ContentActionRef } from '@alfresco/adf-extensions';
 
 export class ContextMenu implements Action {
   readonly type = ContextMenuActionTypes.ContextMenu;
 
   constructor(public event: MouseEvent) {}
+}
+
+export class CustomContextMenu implements Action {
+  readonly type = ContextMenuActionTypes.CustomContextMenu;
+
+  constructor(public event: MouseEvent, public payload: ContentActionRef[] = []) {}
 }


### PR DESCRIPTION
**JIRA ticket link or changeset's description**

https://hyland.atlassian.net/browse/ACS-8706

Context menu is split into separate components: base component, default context menu used in ACA and custom context menu, allowing to inject custom actions.
