### PR TITLE
[ACS-8634] Add new option to edit changes in saved search or save as new

### DIFF
--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -211,6 +211,8 @@
               "RESET_ACTION": "Reset search filters",
               "SAVE_SEARCH": {
                 "ACTION_BUTTON": "Save Search",
+                "SAVE_CHANGES": "Save changes",
+                "SAVE_AS_NEW": "Save as new",
                 "MODAL_HEADER": "Save this search",
                 "NAME_LABEL": "Name",
                 "NAME_REQUIRED_ERROR": "This field is required",

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -217,6 +217,7 @@
                 "DESCRIPTION_LABEL": "Description",
                 "SAVE_SUCCESS": "Search Saved",
                 "SAVE_ERROR": "Error occurred. Search could not be saved.",
+                "SEARCH_NAME_NOT_UNIQUE_ERROR": "Saved Search with {{ name }} name already exists.",
                 "NAVBAR": {
                   "TITLE": "Saved Searches ({{ number }})",
                   "MANAGE_BUTTON": "Manage searches"

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -27,15 +27,45 @@
                 <p>{{ 'APP.BROWSE.SEARCH.ADVANCED_FILTERS' | translate }}</p>
                 <div class="aca-content__advanced-filters--header--action-buttons">
                   <button
+                    *ngIf="initialSavedSearch !== undefined else saveSearchButton"
                     mat-button
-                    acaSaveSearch
-                    [acaSaveSearchQuery]="encodedQuery"
                     [disabled]="!encodedQuery"
                     class="aca-content__save-search-action"
                     title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}"
-                    [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate ">
+                    [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate "
+                    [matMenuTriggerFor]="saveSearchOptionsMenu">
                     {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
+                    <mat-icon iconPositionEnd>keyboard_arrow_down</mat-icon>
                   </button>
+                  <mat-menu #saveSearchOptionsMenu="matMenu">
+                    <button
+                      mat-menu-item
+                      (click)="editSavedSearch(initialSavedSearch)"
+                      title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_CHANGES' | translate }}"
+                      [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_CHANGES' | translate ">
+                      {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_CHANGES' | translate }}
+                    </button>
+                    <button
+                      mat-menu-item
+                      acaSaveSearch
+                      [acaSaveSearchQuery]="encodedQuery"
+                      title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_AS_NEW' | translate }}"
+                      [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_AS_NEW' | translate ">
+                      {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.SAVE_AS_NEW' | translate }}
+                    </button>
+                  </mat-menu>
+                  <ng-template #saveSearchButton>
+                    <button
+                      mat-button
+                      acaSaveSearch
+                      [acaSaveSearchQuery]="encodedQuery"
+                      [disabled]="!encodedQuery"
+                      class="aca-content__save-search-action"
+                      title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}"
+                      [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate ">
+                      {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
+                    </button>
+                  </ng-template>
                   <button
                     mat-button
                     adf-reset-search

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -22,13 +22,15 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ChangeDetectorRef, Component, inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit, ViewEncapsulation } from '@angular/core';
 import { NodeEntry, Pagination, ResultSetPaging } from '@alfresco/js-api';
 import { ActivatedRoute, Params } from '@angular/router';
 import {
   AlfrescoViewerComponent,
   DocumentListComponent,
   ResetSearchDirective,
+  SavedSearch,
+  SavedSearchesService,
   SearchConfiguration,
   SearchFilterChipsComponent,
   SearchFormComponent,
@@ -41,7 +43,9 @@ import {
   SetInfoDrawerPreviewStateAction,
   SetInfoDrawerStateAction,
   SetSearchItemsTotalCountAction,
-  ShowInfoDrawerPreviewAction
+  ShowInfoDrawerPreviewAction,
+  SnackbarErrorAction,
+  SnackbarInfoAction
 } from '@alfresco/aca-shared/store';
 import {
   CustomEmptyContentTemplateDirective,
@@ -62,7 +66,7 @@ import {
   ToolbarComponent
 } from '@alfresco/aca-shared';
 import { SearchSortingDefinition } from '@alfresco/adf-content-services/lib/search/models/search-sorting-definition.interface';
-import { takeUntil } from 'rxjs/operators';
+import { first, take, takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { SearchInputComponent } from '../search-input/search-input.component';
@@ -86,6 +90,8 @@ import {
 } from '../../../utils/aca-search-utils';
 import { SaveSearchDirective } from '../search-save/directive/save-search.directive';
 import { Subject } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   standalone: true,
@@ -96,6 +102,7 @@ import { Subject } from 'rxjs';
     MatProgressBarModule,
     MatDividerModule,
     MatButtonModule,
+    MatMenuModule,
     DocumentListDirective,
     ContextActionsDirective,
     ThumbnailColumnComponent,
@@ -140,18 +147,21 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
   isLoading = false;
   totalResults: number;
   isTagsEnabled = false;
+  initialSavedSearch = undefined;
   columns: DocumentListPresetRef[] = [];
   encodedQuery: string;
   searchConfig: SearchConfiguration;
 
   private readonly loadedFilters$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     tagsService: TagService,
     private readonly queryBuilder: SearchQueryBuilderService,
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly route: ActivatedRoute,
-    private readonly translationService: TranslationService
+    private readonly translationService: TranslationService,
+    private readonly savedSearchesService: SavedSearchesService
   ) {
     super();
 
@@ -164,7 +174,7 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
 
     this.queryBuilder.configUpdated
       .asObservable()
-      .pipe(takeUntil(this.onDestroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((searchConfig) => {
         this.searchConfig = searchConfig;
         this.updateUserQuery();
@@ -202,7 +212,14 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
     this.columns = this.extensions.documentListPresets.searchResults || [];
 
     if (this.route) {
-      this.route.queryParams.pipe(takeUntil(this.onDestroy$)).subscribe((params: Params) => {
+      this.savedSearchesService
+        .getSavedSearches()
+        .pipe(first())
+        .subscribe((savedSearches) => {
+          this.initialSavedSearch = savedSearches.find((savedSearch) => savedSearch.encodedUrl === this.route.snapshot.queryParams['q']);
+        });
+
+      this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: Params) => {
         if (params[this.queryParamName]) {
           this.isLoading = true;
         }
@@ -216,7 +233,7 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
           let loadedFilters = this.searchedWord === '' ? 0 : 1;
           this.queryBuilder.filterLoaded
             .asObservable()
-            .pipe(takeUntil(this.onDestroy$), takeUntil(this.loadedFilters$))
+            .pipe(takeUntilDestroyed(this.destroyRef), takeUntil(this.loadedFilters$))
             .subscribe(() => {
               loadedFilters++;
               if (filtersToLoad === loadedFilters) {
@@ -305,6 +322,21 @@ export class SearchResultsComponent extends PageComponent implements OnInit {
   onSearchSortingUpdate(option: SearchSortingDefinition) {
     this.queryBuilder.sorting = [{ ...option, ascending: option.ascending }];
     this.queryBuilder.update();
+  }
+
+  editSavedSearch(searchToSave: SavedSearch) {
+    searchToSave.encodedUrl = this.encodedQuery;
+    this.savedSearchesService
+      .editSavedSearch(searchToSave)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.store.dispatch(new SnackbarInfoAction('APP.BROWSE.SEARCH.SAVE_SEARCH.EDIT_DIALOG.SUCCESS_MESSAGE'));
+        },
+        error: () => {
+          this.store.dispatch(new SnackbarErrorAction('APP.BROWSE.SEARCH.SAVE_SEARCH.EDIT_DIALOG.ERROR_MESSAGE'));
+        }
+      });
   }
 
   private updateUserQuery(): void {

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.html
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.html
@@ -25,7 +25,7 @@
           {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAME_REQUIRED_ERROR' | translate }}
         </span>
         <span *ngIf="!form.controls['name'].errors?.required && form.controls['name'].errors?.message">
-          {{ form.controls['name'].errors?.message | translate }}
+          {{ form.controls['name'].errors?.message | translate : { name: form.controls.name.value } }}
         </span>
       </mat-error>
     </mat-form-field>

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
@@ -55,7 +55,7 @@ describe('SaveSearchEditDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         provideMockStore(),
-        { provide: SavedSearchesService, useValue: { editSavedSearch: () => of() } },
+        { provide: SavedSearchesService, useValue: { editSavedSearch: () => of(), getSavedSearches: () => of([]) } },
         { provide: MAT_DIALOG_DATA, useValue: savedSearchToDelete }
       ]
     });

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.ts
@@ -30,6 +30,7 @@ import { AppStore, SnackbarErrorAction, SnackbarInfoAction } from '@alfresco/aca
 import { Store } from '@ngrx/store';
 import { CoreModule } from '@alfresco/adf-core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { UniqueSearchNameValidator } from '../unique-search-name-validator';
 
 @Component({
   standalone: true,
@@ -42,7 +43,11 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 })
 export class SavedSearchEditDialogComponent {
   form = new FormGroup({
-    name: new FormControl('', [Validators.required, forbidOnlySpaces]),
+    name: new FormControl('', {
+      validators: [Validators.required, forbidOnlySpaces],
+      asyncValidators: [this.uniqueSearchNameValidator.validate.bind(this.uniqueSearchNameValidator)],
+      updateOn: 'blur'
+    }),
     description: new FormControl('')
   });
 
@@ -52,6 +57,7 @@ export class SavedSearchEditDialogComponent {
     private readonly dialog: MatDialogRef<SavedSearchEditDialogComponent>,
     private readonly store: Store<AppStore>,
     private readonly savedSearchesService: SavedSearchesService,
+    private uniqueSearchNameValidator: UniqueSearchNameValidator,
     @Inject(MAT_DIALOG_DATA) private readonly data: SavedSearch
   ) {
     this.form.patchValue({

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.html
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.html
@@ -22,7 +22,7 @@
                     {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAME_REQUIRED_ERROR' | translate }}
                 </span>
                 <span *ngIf="!form.controls['name'].errors?.required && form.controls['name'].errors?.message">
-                    {{ form.controls['name'].errors?.message | translate }}
+                    {{ form.controls['name'].errors?.message | translate : { name: form.controls.name.value } }}
                 </span>
       </mat-error>
     </mat-form-field>

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
@@ -49,7 +49,7 @@ describe('SaveSearchDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         provideMockStore(),
-        { provide: SavedSearchesService, useValue: { saveSearch: () => of() } },
+        { provide: SavedSearchesService, useValue: { saveSearch: () => of(), getSavedSearches: () => of([]) } },
         { provide: MAT_DIALOG_DATA, useValue: { searchUrl: 'abcdef' } }
       ]
     });

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
@@ -40,6 +40,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { take } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { AppStore, SnackbarErrorAction, SnackbarInfoAction } from '@alfresco/aca-shared/store';
+import { UniqueSearchNameValidator } from './unique-search-name-validator';
 
 @Component({
   standalone: true,
@@ -66,7 +67,11 @@ import { AppStore, SnackbarErrorAction, SnackbarInfoAction } from '@alfresco/aca
 })
 export class SaveSearchDialogComponent {
   form = new FormGroup({
-    name: new FormControl('', [Validators.required, forbidOnlySpaces]),
+    name: new FormControl('', {
+      validators: [Validators.required, forbidOnlySpaces],
+      asyncValidators: [this.uniqueSearchNameValidator.validate.bind(this.uniqueSearchNameValidator)],
+      updateOn: 'blur'
+    }),
     description: new FormControl('')
   });
 
@@ -76,6 +81,7 @@ export class SaveSearchDialogComponent {
     private readonly dialog: MatDialogRef<SaveSearchDialogComponent>,
     private readonly store: Store<AppStore>,
     private readonly savedSearchesService: SavedSearchesService,
+    private uniqueSearchNameValidator: UniqueSearchNameValidator,
     @Inject(MAT_DIALOG_DATA) private readonly data: { searchUrl: string }
   ) {}
 

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { UniqueSearchNameValidator } from './unique-search-name-validator';
+import { ContentTestingModule, SavedSearchesService } from '@alfresco/adf-content-services';
+import { of } from 'rxjs';
+
+describe('UniqueSearchNameValidator', () => {
+  let validator: UniqueSearchNameValidator;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ContentTestingModule]
+    });
+  });
+
+  describe('Save searches returns results', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(SavedSearchesService, { useValue: { getSavedSearches: () => of([{ name: 'test' }]) } });
+      validator = TestBed.inject(UniqueSearchNameValidator);
+    });
+
+    it('should return null when name is unique', (done) => {
+      validator.validate({ value: 'unique' } as any).subscribe((result) => {
+        expect(result).toBe(null);
+        done();
+      });
+    });
+
+    it('should return error when name is not unique', (done) => {
+      validator.validate({ value: 'test' } as any).subscribe((result) => {
+        expect(result).toEqual({ message: 'APP.BROWSE.SEARCH.SAVE_SEARCH.SEARCH_NAME_NOT_UNIQUE_ERROR' });
+        done();
+      });
+    });
+  });
+
+  describe('Save searches returns error', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(SavedSearchesService, { useValue: { getSavedSearches: () => of(null) } });
+      validator = TestBed.inject(UniqueSearchNameValidator);
+    });
+
+    it('should return null when error occurs', (done) => {
+      validator.validate({ value: 'test' } as any).subscribe((result) => {
+        expect(result).toBe(null);
+        done();
+      });
+    });
+  });
+});

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SavedSearchesService } from '@alfresco/adf-content-services';
+import { Injectable } from '@angular/core';
+import { AbstractControl, AsyncValidator, ValidationErrors } from '@angular/forms';
+import { catchError, map, Observable, of } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class UniqueSearchNameValidator implements AsyncValidator {
+  constructor(private savedSearchesService: SavedSearchesService) {}
+
+  validate(control: AbstractControl): Observable<ValidationErrors | null> {
+    return this.savedSearchesService.getSavedSearches().pipe(
+      map((searches) =>
+        searches.some((search) => search.name === control.value) ? { message: 'APP.BROWSE.SEARCH.SAVE_SEARCH.SEARCH_NAME_NOT_UNIQUE_ERROR' } : null
+      ),
+      catchError(() => of(null))
+    );
+  }
+}


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-8634

Previously there was no option to edit params of saved search, now when user navigates from saved search we can choose to either save changes or save new search.