### PR TITLE
[ACS-9012] Truncate text in saved searches description

### DIFF
--- a/extension.schema.json
+++ b/extension.schema.json
@@ -590,6 +590,14 @@
           "description": "Toggles resizable state of the column",
           "type": "boolean"
         },
+        "draggable": {
+          "description": "Toggles draggable state of the column",
+          "type": "boolean"
+        },
+        "isHidden": {
+          "description": "Toggles hidden state of the column",
+          "type": "boolean"
+        },
         "template": {
           "description": "Column template id",
           "type": "string"
@@ -597,6 +605,14 @@
         "desktopOnly": {
           "description": "Display column only for large screens",
           "type": "boolean"
+        },
+        "truncated": {
+          "description": "Should text in the column be truncated?",
+          "type": "boolean"
+        },
+        "maxTextLength": {
+          "description": "Maximum text length before truncation",
+          "type": "number"
         }
       }
     },

--- a/extension.schema.json
+++ b/extension.schema.json
@@ -606,10 +606,6 @@
           "description": "Display column only for large screens",
           "type": "boolean"
         },
-        "truncated": {
-          "description": "Should text in the column be truncated?",
-          "type": "boolean"
-        },
         "maxTextLength": {
           "description": "Maximum text length before truncation",
           "type": "number"

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
@@ -51,7 +51,9 @@ describe('UniqueSearchNameValidator', () => {
     });
 
     it('should return error when name is not unique', (done) => {
-      validator.validate(new FormControl({ value: 'test', disabled: false })).subscribe((result) => {
+      const form = new FormControl({ value: 'test', disabled: false });
+      form.markAsDirty();
+      validator.validate(form).subscribe((result) => {
         expect(result).toEqual({ message: 'APP.BROWSE.SEARCH.SAVE_SEARCH.SEARCH_NAME_NOT_UNIQUE_ERROR' });
         done();
       });

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
@@ -34,7 +34,9 @@ export class UniqueSearchNameValidator implements AsyncValidator {
   validate(control: AbstractControl): Observable<ValidationErrors | null> {
     return this.savedSearchesService.getSavedSearches().pipe(
       map((searches) =>
-        searches.some((search) => search.name === control.value) ? { message: 'APP.BROWSE.SEARCH.SAVE_SEARCH.SEARCH_NAME_NOT_UNIQUE_ERROR' } : null
+        searches.some((search) => search.name === control.value && control.dirty)
+          ? { message: 'APP.BROWSE.SEARCH.SAVE_SEARCH.SEARCH_NAME_NOT_UNIQUE_ERROR' }
+          : null
       ),
       catchError(() => of(null))
     );

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
@@ -38,7 +38,8 @@ export const savedSearchesListSchema = {
       title: 'APP.BROWSE.SEARCH.SAVE_SEARCH.LIST.DESCRIPTION',
       class: 'adf-ellipsis-cell',
       sortable: false,
-      draggable: false
+      draggable: false,
+      truncated: true
     }
   ]
 };

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
@@ -30,7 +30,8 @@ export const savedSearchesListSchema = {
       title: 'APP.BROWSE.SEARCH.SAVE_SEARCH.LIST.NAME',
       class: 'adf-ellipsis-cell',
       sortable: false,
-      draggable: false
+      draggable: false,
+      maxTextLength: 250
     },
     {
       type: 'text',
@@ -39,7 +40,7 @@ export const savedSearchesListSchema = {
       class: 'adf-ellipsis-cell',
       sortable: false,
       draggable: false,
-      truncated: true
+      maxTextLength: 250
     }
   ]
 };

--- a/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.spec.ts
@@ -67,6 +67,7 @@ describe('SaveSearchSidenavComponent', () => {
           id: 'manage-saved-searches',
           icon: '',
           title: 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAVBAR.MANAGE_BUTTON',
+          description: 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAVBAR.MANAGE_BUTTON',
           route: 'saved-searches',
           url: 'saved-searches'
         }
@@ -84,6 +85,7 @@ describe('SaveSearchSidenavComponent', () => {
     expect(component.item.children[0]).toEqual({
       icon: '',
       title: '1',
+      description: '1',
       route: 'search?q=abc',
       url: 'search?q=abc',
       id: 'search1'

--- a/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.ts
@@ -69,6 +69,7 @@ export class SaveSearchSidenavComponent implements OnInit {
         id: 'search' + child.name,
         icon: '',
         title: child.name,
+        description: child.name,
         route: `search?q=${child.encodedUrl}`,
         url: `search?q=${child.encodedUrl}`
       }))
@@ -78,6 +79,7 @@ export class SaveSearchSidenavComponent implements OnInit {
       id: this.manageSearchesId,
       icon: '',
       title: 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAVBAR.MANAGE_BUTTON',
+      description: 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAVBAR.MANAGE_BUTTON',
       route: 'saved-searches',
       url: 'saved-searches'
     });

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
@@ -1,3 +1,5 @@
+@import '@alfresco/adf-core/lib/styles/mat-selectors';
+
 .aca-sidenav {
   display: flex;
   flex: 1;
@@ -107,6 +109,11 @@
       border-radius: 0;
       line-height: 32px;
       justify-content: start;
+
+      #{$mat-button-label} {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
       &--active {
         color: var(--theme-sidenav-active-text-color);


### PR DESCRIPTION
Add text truncation in saved searches description column, added missing docs in `extension.schema.json` and fixed one small bug in unique saved search name validator. 
https://hyland.atlassian.net/browse/ACS-9012