### PR TITLE
[ACS-8902] Fixed incorrect icon for join library option

### DIFF
--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
@@ -44,7 +44,7 @@ import { MatMenuModule } from '@angular/material/menu';
       [isAdmin]="(profile$ | async).isAdmin"
       [attr.title]="(membership.isJoinRequested | async) ? ('APP.ACTIONS.CANCEL_JOIN' | translate) : ('APP.ACTIONS.JOIN' | translate)"
     >
-      <mat-icon>{{ membership.isJoinRequested ? 'cancel' : 'library_add' }}</mat-icon>
+      <mat-icon>{{ (membership.isJoinRequested | async) ? 'cancel' : 'library_add' }}</mat-icon>
       <span>{{ (membership.isJoinRequested | async) ? ('APP.ACTIONS.CANCEL_JOIN' | translate) : ('APP.ACTIONS.JOIN' | translate) }}</span>
     </button>
   `,


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-8902

Fixed issue where Join library option was showing incorrect icon in the context menu