### PR TITLE
[ACS-9158] Remove 'View Details' button from node Details page

### DIFF
--- a/docs/extending/rules.md
+++ b/docs/extending/rules.md
@@ -248,7 +248,7 @@ for example mixing `core.every` and `core.not`.
 `!app.navigation.isTrashcan` is the opposite of the `app.navigation.isTrashcan`.
 
 | Version | Key                               | Description                                                      |
-| ------- | --------------------------------- | ---------------------------------------------------------------- |
+|---------|-----------------------------------|------------------------------------------------------------------|
 | 1.7.0   | app.navigation.folder.canCreate   | User can create content in the currently opened folder.          |
 | 1.7.0   | app.navigation.folder.canUpload   | User can upload content to the currently opened folder.          |
 | 1.7.0   | app.navigation.isTrashcan         | User is using the **Trashcan** page.                             |
@@ -269,6 +269,7 @@ for example mixing `core.every` and `core.not`.
 | 1.7.0   | app.navigation.isPreview          | Current page is **Preview**.                                     |
 | 1.7.0   | app.navigation.isPersonalFiles    | Current page is **Personal Files**.                              |
 | 1.7.0   | app.navigation.isLibraryFiles     | Current page is **Library Files**.                               |
+| 5.3.0   | app.navigation.isNotDetails       | Current page is not **Details**.                                 |
 
 **Tip:** See the [Registration](./registration) section for more details
 on how to register your own entries to be re-used at runtime.

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -495,7 +495,7 @@
         "order": 700,
         "component": "app.toolbar.toggleInfoDrawer",
         "rules": {
-          "visible": "canShowInfoDrawer"
+          "visible": ["canShowInfoDrawer", "app.navigation.isNotDetails"]
         }
       },
       {
@@ -1084,7 +1084,7 @@
           "order": 500,
           "component": "app.toolbar.toggleInfoDrawer",
           "rules": {
-            "visible": "canShowInfoDrawer"
+            "visible": ["canShowInfoDrawer", "app.navigation.isNotDetails"]
           }
         },
         {

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -223,6 +223,7 @@ export class ContentServiceExtensionModule {
       'app.navigation.isSharedPreview': rules.isSharedPreview,
       'app.navigation.isFavoritesPreview': rules.isFavoritesPreview,
       'app.navigation.isSharedFileViewer': rules.isSharedFileViewer,
+      'app.navigation.isNotDetails': rules.isNotDetails,
 
       'repository.isQuickShareEnabled': rules.hasQuickShareEnabled,
       'user.isAdmin': rules.isAdmin,

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -25,12 +25,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppTestingModule } from '../../testing/app-testing.module';
 import { DetailsComponent } from './details.component';
-import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { DefaultProjectorFn, MemoizedSelector, Store } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { ContentApiService } from '@alfresco/aca-shared';
-import { AppStore, isInfoDrawerOpened, NavigateToFolder, NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
+import { NavigateToFolder, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { Node, NodeEntry, PathElement } from '@alfresco/js-api';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService, CORE_PIPES, PageTitleService } from '@alfresco/adf-core';
@@ -257,46 +257,5 @@ describe('DetailsComponent', () => {
 
     component.setActiveTab('permissions');
     expect(component.activeTab).not.toBe(2);
-  });
-
-  describe('infoDrawerOpened$ event', () => {
-    let infoDrawerOpened$: Subject<boolean>;
-
-    beforeEach(() => {
-      infoDrawerOpened$ = new Subject<boolean>();
-      spyOn(store, 'select').and.callFake((mapFn: MemoizedSelector<AppStore, boolean, DefaultProjectorFn<boolean>>) =>
-        mapFn === isInfoDrawerOpened ? infoDrawerOpened$ : mockStream
-      );
-    });
-
-    it('should dispatch store NavigateToPreviousPage by store if info drawer is closed', () => {
-      component.ngOnInit();
-
-      infoDrawerOpened$.next(false);
-      expect(storeMock.dispatch).toHaveBeenCalledWith(jasmine.any(NavigateToPreviousPage));
-    });
-
-    it('should not dispatch store NavigateToPreviousPage by store if info drawer is opened', () => {
-      component.ngOnInit();
-
-      infoDrawerOpened$.next(true);
-      expect(storeMock.dispatch).not.toHaveBeenCalledWith(jasmine.any(NavigateToPreviousPage));
-    });
-
-    it('should not dispatch store NavigateToPreviousPage by store if info drawer opening state is not changed', () => {
-      component.ngOnInit();
-
-      expect(storeMock.dispatch).not.toHaveBeenCalledWith(jasmine.any(NavigateToPreviousPage));
-    });
-
-    it('should not dispatch store NavigateToPreviousPage by store if info drawer is closed but there occurred NavigationStart event', () => {
-      Object.defineProperty(TestBed.inject(Router), 'events', {
-        value: of(new NavigationStart(1, ''))
-      });
-      component.ngOnInit();
-
-      infoDrawerOpened$.next(false);
-      expect(storeMock.dispatch).not.toHaveBeenCalledWith(jasmine.any(NavigateToPreviousPage));
-    });
   });
 });

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -23,10 +23,10 @@
  */
 
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { ActivatedRoute, NavigationStart } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent } from '@alfresco/aca-shared';
 import { NavigateToFolder, NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { merge, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { BreadcrumbComponent, ContentService, NodesApiService, PermissionListComponent } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
@@ -37,7 +37,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MetadataTabComponent } from '../info-drawer/metadata-tab/metadata-tab.component';
 import { CommentsTabComponent } from '../info-drawer/comments-tab/comments-tab.component';
 import { NodeEntry, PathElement } from '@alfresco/js-api';
-import { first, takeUntil } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { FileSizePipe, InfoDrawerButtonsDirective } from '@alfresco/adf-core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -110,20 +110,6 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
       .subscribe((aspectActions) => {
         this.aspectActions = aspectActions;
       });
-    this.infoDrawerOpened$
-      .pipe(
-        first((opened) => !opened),
-        takeUntil(
-          merge(
-            this.onDestroy$,
-            this.router.events.pipe(
-              first((event) => event instanceof NavigationStart),
-              takeUntil(this.onDestroy$)
-            )
-          )
-        )
-      )
-      .subscribe(() => this.goBack());
   }
 
   setActiveTab(tabName: string) {

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -26,7 +26,6 @@ import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ContentApiService, PageComponent, PageLayoutComponent, ToolbarComponent } from '@alfresco/aca-shared';
 import { NavigateToFolder, NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { Subject } from 'rxjs';
 import { BreadcrumbComponent, ContentService, NodesApiService, PermissionListComponent } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
@@ -72,8 +71,6 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
   aspectActions: Array<ContentActionRef> = [];
   nodeIcon: string;
   canManagePermissions = true;
-
-  private readonly onDestroy$: Subject<void> = new Subject<void>();
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -139,8 +136,6 @@ export class DetailsComponent extends PageComponent implements OnInit, OnDestroy
   }
 
   ngOnDestroy(): void {
-    this.onDestroy$.next();
-    this.onDestroy$.complete();
     this.store.dispatch(new SetSelectedNodesAction([]));
     super.ngOnDestroy();
   }

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1412,16 +1412,19 @@ describe('app.evaluators', () => {
       expect(app.canShowInfoDrawer(context)).toBeFalse();
     });
 
-    it('should return false when user is in libraries or trashcan', () => {
+    it('should return false when user is in libraries or trashcan or details', () => {
       context.selection.isEmpty = false;
       context.navigation.url = '/trashcan/test';
       expect(app.canShowInfoDrawer(context)).toBeFalse();
 
       context.navigation.url = '/test/libraries';
       expect(app.canShowInfoDrawer(context)).toBeFalse();
+
+      context.navigation.url = '/test/details';
+      expect(app.canShowInfoDrawer(context)).toBeFalse();
     });
 
-    it('should return true when selection exists and user is not in trashcan or libraries', () => {
+    it('should return true when selection exists and user is not in trashcan, libraries or details', () => {
       context.navigation.url = '/personal-files/test';
       context.selection.isEmpty = false;
       expect(app.canShowInfoDrawer(context)).toBeTrue();

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -461,7 +461,7 @@ export const canToggleSharedLink = (context: RuleContext): boolean =>
  * @param context Rule execution context
  */
 export const canShowInfoDrawer = (context: RuleContext): boolean =>
-  [hasSelection(context), navigation.isNotLibraries(context), navigation.isNotTrashcan(context)].every(Boolean);
+  [hasSelection(context), navigation.isNotLibraries(context), navigation.isNotTrashcan(context), navigation.isNotDetails(context)].every(Boolean);
 
 /**
  * Checks if user can manage file versions for the selected node.

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -461,7 +461,7 @@ export const canToggleSharedLink = (context: RuleContext): boolean =>
  * @param context Rule execution context
  */
 export const canShowInfoDrawer = (context: RuleContext): boolean =>
-  [hasSelection(context), navigation.isNotLibraries(context), navigation.isNotTrashcan(context), navigation.isNotDetails(context)].every(Boolean);
+  [hasSelection(context), navigation.isNotLibraries(context), navigation.isNotTrashcan(context)].every(Boolean);
 
 /**
  * Checks if user can manage file versions for the selected node.

--- a/projects/aca-shared/rules/src/navigation.rules.spec.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.spec.ts
@@ -247,6 +247,28 @@ describe('navigation.evaluators', () => {
     });
   });
 
+  describe('isNotDetails', () => {
+    it('should return true if url does not include `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: '/path'
+        }
+      };
+
+      expect(app.isNotDetails(context)).toBe(true);
+    });
+
+    it('should return false if url includes `/details`', () => {
+      const context: any = {
+        navigation: {
+          url: 'personal-files/details/path'
+        }
+      };
+
+      expect(app.isNotDetails(context)).toBe(false);
+    });
+  });
+
   describe('isRecentFiles', () => {
     it('should return [true] if url starts with `/recent-files`', () => {
       const context: any = {

--- a/projects/aca-shared/rules/src/navigation.rules.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.ts
@@ -116,6 +116,12 @@ export function isDetails(context: RuleContext): boolean {
 }
 
 /**
+ * Checks if the activated route is not **Details**.
+ * JSON ref: `app.navigation.isNotDetails`
+ */
+export const isNotDetails = (context: RuleContext): boolean => !isDetails(context);
+
+/**
  * Checks if the activated route is neither **Libraries** nor **Library Search Results**.
  * JSON ref: `app.navigation.isNotLibraries`
  */


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-9158

The "View Details" button has been removed from the Details page because the button's logic causes the page to redirect on refresh and the link cannot be accessed directly. At the same time "Reduce panel" button is retained and performs the same action.

![Screenshot 2025-01-22 at 09 41 16](https://github.com/user-attachments/assets/635a5baf-2712-4005-8a82-e075a7b745d8)
