### PR TITLE
[ACS-9235] a11y testing: Breadcrumbs / Back Arrow / Buttons must have discernible text

### DIFF
--- a/projects/aca-content/folder-rules/assets/i18n/en.json
+++ b/projects/aca-content/folder-rules/assets/i18n/en.json
@@ -122,6 +122,7 @@
       "LOAD_MORE_RULE_SETS": "Load rules from other folders",
       "LOAD_MORE_RULES": "Load more rules",
       "LOADING_RULES": "Loading rules",
+      "TOGGLE_RULE_STATE": "Toggle rule enabled state",
       "INHERITED_RULES_WILL_BE_RUN_FIRST": "Inherited rules will be run first",
       "ALL_LINKED_RULES_ARE_DISABLED": "All rules linked from this rule set are disabled"
     },

--- a/projects/aca-content/folder-rules/assets/i18n/en.json
+++ b/projects/aca-content/folder-rules/assets/i18n/en.json
@@ -1,7 +1,8 @@
 {
   "ACA_FOLDER_RULES": {
     "ACTIONS": {
-      "MANAGE_RULES": "Manage Rules"
+      "MANAGE_RULES": "Manage Rules",
+      "GO_BACK": "Go back"
     },
     "EDIT_RULE_DIALOG": {
       "CANCEL": "Cancel",

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.html
@@ -2,7 +2,7 @@
 
   <div class="aca-page-layout-header">
     <adf-toolbar class="adf-toolbar--inline">
-      <button mat-icon-button (click)="goBack()">
+      <button mat-icon-button (click)="goBack()" [attr.aria-label]="'ACA_FOLDER_RULES.ACTIONS.GO_BACK' | translate">
         <mat-icon>arrow_back</mat-icon>
       </button>
     </adf-toolbar>
@@ -87,7 +87,8 @@
 
                 <div class="aca-manage-rules__container__rule-details__header__buttons">
                   <ng-container *ngIf="canEditSelectedRule; else goToFolderButton">
-                    <button mat-stroked-button (click)="onRuleDeleteButtonClicked(selectedRule)" id="delete-rule-btn">
+                    <button mat-stroked-button (click)="onRuleDeleteButtonClicked(selectedRule)" id="delete-rule-btn"
+                            [attr.aria-label]="'ACA_FOLDER_RULES.CONFIRMATION_DIALOG.DELETE_RULE.TITLE' | translate">
                       <mat-icon>delete_outline</mat-icon>
                     </button>
                     <button mat-stroked-button (click)="openCreateUpdateRuleDialog(selectedRule)" id="edit-rule-btn">

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.html
@@ -5,7 +5,7 @@
   <mat-slide-toggle
     *ngIf="showEnabledToggle"
     [checked]="rule.isEnabled"
-    [aria-label]="'ACA_FOLDER_RULES.ACTIONS.GO_BACK' | translate"
+    [aria-label]="'ACA_FOLDER_RULES.RULE_LIST.TOGGLE_RULE_STATE' | translate"
     (click)="onToggleClick(!rule.isEnabled, $event)" />
 
 </div>

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.html
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.html
@@ -5,6 +5,7 @@
   <mat-slide-toggle
     *ngIf="showEnabledToggle"
     [checked]="rule.isEnabled"
+    [aria-label]="'ACA_FOLDER_RULES.ACTIONS.GO_BACK' | translate"
     (click)="onToggleClick(!rule.isEnabled, $event)" />
 
 </div>

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
@@ -26,10 +26,11 @@ import { Component, EventEmitter, HostBinding, Input, Output, ViewEncapsulation 
 import { Rule } from '../../model/rule.model';
 import { CommonModule } from '@angular/common';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, MatSlideToggleModule],
+  imports: [CommonModule, MatSlideToggleModule, TranslateModule],
   selector: 'aca-rule-list-item',
   templateUrl: 'rule-list-item.ui-component.html',
   styleUrls: ['rule-list-item.ui-component.scss'],


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-9235