### PR TITLE
[ACS-9536] fix failing unit tests

### DIFF
--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -491,6 +491,10 @@ describe('FilesComponent', () => {
       documentBasePageService = TestBed.inject(DocumentBasePageService);
     });
 
+    afterEach(() => {
+      store.resetSelectors();
+    });
+
     it('should have assigned displayDragAndDropHint to false if currentFolder is selected and uploading is not allowable', () => {
       store.overrideSelector(getCurrentFolder, node);
       spyOn(documentBasePageService, 'canUploadContent').and.returnValue(false);

--- a/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
+++ b/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
@@ -24,22 +24,15 @@
 
 import { Router, ActivatedRoute } from '@angular/router';
 import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
-import { AuthenticationService } from '@alfresco/adf-core';
-import { UploadService, NodesApiService, DiscoveryApiService } from '@alfresco/adf-content-services';
+import { UploadService, NodesApiService } from '@alfresco/adf-content-services';
 import { ClosePreviewAction } from '@alfresco/aca-shared/store';
 import { PreviewComponent } from './preview.component';
 import { of, throwError } from 'rxjs';
-import {
-  ContentApiService,
-  AppHookService,
-  DocumentBasePageService,
-  LibTestingModule,
-  discoveryApiServiceMockValue,
-  DocumentBasePageServiceMock
-} from '@alfresco/aca-shared';
+import { ContentApiService, AppHookService } from '@alfresco/aca-shared';
 import { Store } from '@ngrx/store';
 import { Node } from '@alfresco/js-api';
 import { AcaViewerModule } from '../../viewer.module';
+import { AppTestingModule } from '../../../../../src/lib/testing/app-testing.module';
 
 const clickEvent = new MouseEvent('click');
 
@@ -56,12 +49,7 @@ describe('PreviewComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LibTestingModule, AcaViewerModule],
-      providers: [
-        { provide: DocumentBasePageService, useValue: DocumentBasePageServiceMock },
-        { provide: DiscoveryApiService, useValue: discoveryApiServiceMockValue },
-        { provide: AuthenticationService, useValue: {} }
-      ]
+      imports: [AppTestingModule, AcaViewerModule]
     });
 
     fixture = TestBed.createComponent(PreviewComponent);

--- a/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
+++ b/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
@@ -28,7 +28,7 @@ import { UploadService, NodesApiService } from '@alfresco/adf-content-services';
 import { ClosePreviewAction } from '@alfresco/aca-shared/store';
 import { PreviewComponent } from './preview.component';
 import { of, throwError } from 'rxjs';
-import { ContentApiService, AppHookService } from '@alfresco/aca-shared';
+import { ContentApiService, AppHookService, DocumentBasePageService, DocumentBasePageServiceMock } from '@alfresco/aca-shared';
 import { Store } from '@ngrx/store';
 import { Node } from '@alfresco/js-api';
 import { AcaViewerModule } from '../../viewer.module';
@@ -49,7 +49,13 @@ describe('PreviewComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AppTestingModule, AcaViewerModule]
+      imports: [AppTestingModule, AcaViewerModule],
+      providers: [
+        {
+          provide: DocumentBasePageService,
+          useClass: DocumentBasePageServiceMock
+        }
+      ]
     });
 
     fixture = TestBed.createComponent(PreviewComponent);


### PR DESCRIPTION
### Ticket 
[ACS-9536 Unit tests are randomly failing sometimes on ACA](https://hyland.atlassian.net/browse/ACS-9536)


### Changes

- Reset overridden selectors affecting global store state
- Use correct testing module in other suite


### Testing

- Run tests locally multiple times
![image](https://github.com/user-attachments/assets/4ac6540b-c8ae-4601-81a9-86ecbc7da24e)

- Run tests on PR workflow multiple times
[5 attempts of Test All step skipping cache](https://github.com/Alfresco/alfresco-content-app/actions/runs/14907556727)