### PR TITLE
Prevent failure in debug ingress logs step when local cluster didn't run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -168,6 +168,7 @@ jobs:
           key: cache-dist-${{ github.run_id }}
 
       - name: Deploy local ACS
+        id: deploy-local-acs
         uses: ./.github/actions/deploy-local-acs
         with:
           docker_username: ${{ secrets.DOCKER_USERNAME }}
@@ -189,7 +190,7 @@ jobs:
           test-runner: playwright
 
       - name: Debug Ingress Controller Logs
-        if: always()
+        if: always() && steps.deploy-local-acs.outcome == 'success'
         run: |
             kubectl logs -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx --tail=-1
 


### PR DESCRIPTION
Avoid spurious step failure when build failed before running the local test cluster.
