### PR TITLE
AAE-36484 upgrade to standalone api

### DIFF
--- a/app/src/app/app.components.ts
+++ b/app/src/app/app.components.ts
@@ -24,6 +24,7 @@
 
 import { Component, ViewEncapsulation } from '@angular/core';
 import { AppService } from '@alfresco/aca-shared';
+import { MatIconRegistry } from '@angular/material/icon';
 
 @Component({
   selector: 'app-root',
@@ -33,7 +34,11 @@ import { AppService } from '@alfresco/aca-shared';
   standalone: false
 })
 export class AppComponent {
-  constructor(private appService: AppService) {
+  constructor(
+    private appService: AppService,
+    matIconRegistry: MatIconRegistry
+  ) {
     this.appService.init();
+    matIconRegistry.setDefaultFontSetClass('material-icons-outlined');
   }
 }

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -23,14 +23,12 @@
  */
 
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { importProvidersFrom, NgModule } from '@angular/core';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { AuthGuard, AuthModule, CoreModule, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
+import { AuthGuard, CoreModule, TRANSLATION_PROVIDER, AuthModule } from '@alfresco/adf-core';
 import { AppService } from '@alfresco/aca-shared';
-
 import { AppExtensionsModule } from './extensions.module';
 import { environment } from '../environments/environment';
-
 import { registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
 import localeDe from '@angular/common/locales/de';
@@ -86,8 +84,7 @@ registerLocaleData(localeSv);
       enableTracing: false // enable for debug only
     }),
     AppExtensionsModule,
-    ContentServiceExtensionModule,
-    AuthModule.forRoot({ useHash: true })
+    ContentServiceExtensionModule
   ],
   providers: [
     provideShellRoutes(CONTENT_LAYOUT_ROUTES),
@@ -107,7 +104,8 @@ registerLocaleData(localeSv);
         name: 'app',
         source: 'assets'
       }
-    }
+    },
+    importProvidersFrom(AuthModule.forRoot({ useHash: true }))
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent]

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -53,7 +53,6 @@ import { ContentVersionService } from '@alfresco/adf-content-services';
 import { SHELL_APP_SERVICE, SHELL_AUTH_TOKEN, provideShellRoutes } from '@alfresco/adf-core/shell';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { APP_ROUTES } from './app.routes';
-import { MatIconRegistry } from '@angular/material/icon';
 
 registerLocaleData(localeFr);
 registerLocaleData(localeDe);
@@ -110,8 +109,4 @@ registerLocaleData(localeSv);
   declarations: [AppComponent],
   bootstrap: [AppComponent]
 })
-export class AppModule {
-  constructor(matIconRegistry: MatIconRegistry) {
-    matIconRegistry.setDefaultFontSetClass('material-icons-outlined');
-  }
-}
+export class AppModule {}

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -48,7 +48,6 @@ import localePl from '@angular/common/locales/pl';
 import localeFi from '@angular/common/locales/fi';
 import localeDa from '@angular/common/locales/da';
 import localeSv from '@angular/common/locales/sv';
-import { TranslateModule } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.components';
 import { CONTENT_LAYOUT_ROUTES, ContentServiceExtensionModule, ContentUrlService, CoreExtensionsModule } from '@alfresco/aca-content';
@@ -78,7 +77,6 @@ registerLocaleData(localeSv);
 @NgModule({
   imports: [
     BrowserModule,
-    TranslateModule.forRoot(),
     CoreModule.forRoot(),
     CoreExtensionsModule.forRoot(),
     environment.e2e ? NoopAnimationsModule : BrowserAnimationsModule,

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -24,7 +24,7 @@
 
 import { BrowserModule } from '@angular/platform-browser';
 import { importProvidersFrom, NgModule } from '@angular/core';
-import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopAnimations, provideAnimations } from '@angular/platform-browser/animations';
 import { AuthGuard, CoreModule, AuthModule, provideTranslations } from '@alfresco/adf-core';
 import { AppService } from '@alfresco/aca-shared';
 import { AppExtensionsModule } from './extensions.module';
@@ -76,7 +76,6 @@ registerLocaleData(localeSv);
     BrowserModule,
     CoreModule.forRoot(),
     CoreExtensionsModule.forRoot(),
-    environment.e2e ? NoopAnimationsModule : BrowserAnimationsModule,
     !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 25 }) : [],
     RouterModule.forRoot(APP_ROUTES, {
       useHash: true,
@@ -86,6 +85,7 @@ registerLocaleData(localeSv);
     ContentServiceExtensionModule
   ],
   providers: [
+    environment.e2e ? provideNoopAnimations() : provideAnimations(),
     provideShellRoutes(CONTENT_LAYOUT_ROUTES),
     { provide: ContentVersionService, useClass: ContentUrlService },
     {

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -25,7 +25,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { importProvidersFrom, NgModule } from '@angular/core';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { AuthGuard, CoreModule, TRANSLATION_PROVIDER, AuthModule } from '@alfresco/adf-core';
+import { AuthGuard, CoreModule, AuthModule, provideTranslations } from '@alfresco/adf-core';
 import { AppService } from '@alfresco/aca-shared';
 import { AppExtensionsModule } from './extensions.module';
 import { environment } from '../environments/environment';
@@ -96,14 +96,7 @@ registerLocaleData(localeSv);
       provide: SHELL_AUTH_TOKEN,
       useValue: AuthGuard
     },
-    {
-      provide: TRANSLATION_PROVIDER,
-      multi: true,
-      useValue: {
-        name: 'app',
-        source: 'assets'
-      }
-    },
+    provideTranslations('app', 'assets'),
     importProvidersFrom(AuthModule.forRoot({ useHash: true }))
   ],
   declarations: [AppComponent],

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -53,7 +53,7 @@ import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.components';
 import { CONTENT_LAYOUT_ROUTES, ContentServiceExtensionModule, ContentUrlService, CoreExtensionsModule } from '@alfresco/aca-content';
 import { ContentVersionService } from '@alfresco/adf-content-services';
-import { SHELL_APP_SERVICE, SHELL_AUTH_TOKEN, ShellModule } from '@alfresco/adf-core/shell';
+import { SHELL_APP_SERVICE, SHELL_AUTH_TOKEN, provideShellRoutes } from '@alfresco/adf-core/shell';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { APP_ROUTES } from './app.routes';
 import { MatIconRegistry } from '@angular/material/icon';
@@ -88,13 +88,11 @@ registerLocaleData(localeSv);
       enableTracing: false // enable for debug only
     }),
     AppExtensionsModule,
-    ShellModule.withRoutes({
-      shellChildren: [CONTENT_LAYOUT_ROUTES]
-    }),
     ContentServiceExtensionModule,
     AuthModule.forRoot({ useHash: true })
   ],
   providers: [
+    provideShellRoutes(CONTENT_LAYOUT_ROUTES),
     { provide: ContentVersionService, useClass: ContentUrlService },
     {
       provide: SHELL_APP_SERVICE,

--- a/app/src/app/components/login/app-login.component.ts
+++ b/app/src/app/components/login/app-login.component.ts
@@ -24,11 +24,11 @@
 
 import { LoginComponent } from '@alfresco/adf-core';
 import { Component, inject, ViewEncapsulation } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { AppSettingsService } from '@alfresco/aca-shared';
 
 @Component({
-  imports: [LoginComponent, TranslateModule],
+  imports: [LoginComponent, TranslatePipe],
   templateUrl: './app-login.component.html',
   styles: [
     `

--- a/projects/aca-content/about/src/about.component.ts
+++ b/projects/aca-content/about/src/about.component.ts
@@ -27,7 +27,7 @@ import { DEV_MODE_TOKEN } from './dev-mode.tokens';
 import { AboutModule, AuthenticationService, RepositoryInfo } from '@alfresco/adf-core';
 import { DiscoveryApiService } from '@alfresco/adf-content-services';
 import { PACKAGE_JSON } from './package-json.token';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { AppExtensionService, AppSettingsService, PageLayoutComponent } from '@alfresco/aca-shared';
 import { RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -35,7 +35,7 @@ import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  imports: [CommonModule, TranslateModule, AboutModule, RouterModule, MatIconModule, MatButtonModule, PageLayoutComponent],
+  imports: [CommonModule, TranslatePipe, AboutModule, RouterModule, MatIconModule, MatButtonModule, PageLayoutComponent],
   selector: 'app-about-page',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss'],

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.spec.ts
@@ -25,7 +25,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ManageRulesSmartComponent } from './manage-rules.smart-component';
 import { DebugElement, Predicate } from '@angular/core';
-import { CoreTestingModule } from '@alfresco/adf-core';
 import { FolderRulesService } from '../services/folder-rules.service';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
@@ -42,13 +41,15 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
 import { ruleMock, ruleSettingsMock } from '../mock/rules.mock';
-import { Store } from '@ngrx/store';
 import { AppService } from '@alfresco/aca-shared';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
+import { provideHttpClient } from '@angular/common/http';
+import { NoopTranslateModule } from '@alfresco/adf-core';
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('ManageRulesSmartComponent', () => {
   let fixture: ComponentFixture<ManageRulesSmartComponent>;
@@ -63,8 +64,9 @@ describe('ManageRulesSmartComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, ManageRulesSmartComponent],
+      imports: [NoopTranslateModule, ManageRulesSmartComponent],
       providers: [
+        provideHttpClient(),
         {
           provide: AppService,
           useValue: {
@@ -73,7 +75,7 @@ describe('ManageRulesSmartComponent', () => {
           }
         },
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
-        { provide: Store, useValue: { dispatch: () => {} } },
+        provideMockStore({}),
         { provide: ActivatedRoute, useValue: { params: of({ nodeId: owningFolderIdMock }) } }
       ]
     });

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
@@ -32,7 +32,7 @@ import { NodeInfo } from '@alfresco/aca-shared/store';
 import { delay } from 'rxjs/operators';
 import { EditRuleDialogUiComponent } from '../rule-details/edit-rule-dialog.ui-component';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { ConfirmDialogComponent, NotificationService, TemplateModule, ToolbarModule } from '@alfresco/adf-core';
+import { ConfirmDialogComponent, EmptyContentComponent, NotificationService, ToolbarComponent, ToolbarTitleComponent } from '@alfresco/adf-core';
 import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ActionsService } from '../services/actions.service';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
@@ -40,7 +40,7 @@ import { RuleSet } from '../model/rule-set.model';
 import { RuleSetPickerSmartComponent } from '../rule-set-picker/rule-set-picker.smart-component';
 import { MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { GenericErrorComponent, PageLayoutComponent } from '@alfresco/aca-shared';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -53,9 +53,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     PageLayoutComponent,
-    ToolbarModule,
     MatButtonModule,
     MatIconModule,
     MatProgressBarModule,
@@ -63,10 +62,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     MatDividerModule,
     RuleListUiComponent,
     RouterModule,
-    TemplateModule,
     GenericErrorComponent,
     RuleDetailsUiComponent,
-    MatDialogModule
+    MatDialogModule,
+    EmptyContentComponent,
+    ToolbarTitleComponent,
+    ToolbarComponent
   ],
   selector: 'aca-manage-rules',
   templateUrl: 'manage-rules.smart-component.html',

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 import { RuleActionListUiComponent } from './rule-action-list.ui-component';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
@@ -39,7 +39,7 @@ describe('RuleActionListUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule],
+      imports: [NoopTranslateModule, RuleActionListUiComponent],
       providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.ts
@@ -29,14 +29,14 @@ import { Subscription } from 'rxjs';
 import { ruleActionValidator } from '../validators/rule-actions.validator';
 import { ActionParameterConstraint } from '../../model/action-parameter-constraint.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  imports: [CommonModule, TranslateModule, RuleActionUiComponent, ReactiveFormsModule, MatButtonModule, MatMenuModule, MatIconModule],
+  imports: [CommonModule, TranslatePipe, RuleActionUiComponent, ReactiveFormsModule, MatButtonModule, MatMenuModule, MatIconModule],
   selector: 'aca-rule-action-list',
   templateUrl: './rule-action-list.ui-component.html',
   styleUrls: ['./rule-action-list.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CardViewBoolItemModel, CardViewComponent, CardViewSelectItemModel, CardViewTextItemModel, CoreTestingModule } from '@alfresco/adf-core';
+import { CardViewBoolItemModel, CardViewComponent, CardViewSelectItemModel, CardViewTextItemModel, NoopTranslateModule } from '@alfresco/adf-core';
 import { RuleActionUiComponent } from './rule-action.ui-component';
 import {
   actionLinkToCategoryTransformedMock,
@@ -63,7 +63,7 @@ describe('RuleActionUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, RuleActionUiComponent],
+      imports: [NoopTranslateModule, RuleActionUiComponent],
       providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
@@ -27,8 +27,8 @@ import { ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR, Reacti
 import { ActionDefinitionTransformed, RuleAction } from '../../model/rule-action.model';
 import {
   CardViewBoolItemModel,
+  CardViewComponent,
   CardViewItem,
-  CardViewModule,
   CardViewSelectItemModel,
   CardViewSelectItemOption,
   CardViewTextItemModel,
@@ -50,14 +50,14 @@ import {
   TagService
 } from '@alfresco/adf-content-services';
 import { MatDialog } from '@angular/material/dialog';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, ReactiveFormsModule, MatFormFieldModule, MatSelectModule, CardViewModule],
+  imports: [CommonModule, TranslatePipe, ReactiveFormsModule, MatFormFieldModule, MatSelectModule, CardViewComponent],
   selector: 'aca-rule-action',
   templateUrl: './rule-action.ui-component.html',
   styleUrls: ['./rule-action.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.ts
@@ -27,7 +27,7 @@ import { RuleCompositeCondition } from '../../model/rule-composite-condition.mod
 import { ControlValueAccessor, FormArray, FormControl, FormGroup, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { RuleSimpleCondition } from '../../model/rule-simple-condition.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
@@ -38,7 +38,7 @@ import { RuleSimpleConditionUiComponent } from './rule-simple-condition.ui-compo
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatSelectModule,

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
@@ -24,7 +24,6 @@
 
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RuleSimpleConditionUiComponent } from './rule-simple-condition.ui-component';
-import { CoreTestingModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { tagMock, mimeTypeMock, simpleConditionUnknownFieldMock, categoriesListMock } from '../../mock/conditions.mock';
@@ -38,6 +37,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 import { AlfrescoMimeType } from '@alfresco/aca-shared';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('RuleSimpleConditionUiComponent', () => {
   let fixture: ComponentFixture<RuleSimpleConditionUiComponent>;
@@ -83,7 +83,7 @@ describe('RuleSimpleConditionUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, RuleSimpleConditionUiComponent],
+      imports: [NoopTranslateModule, RuleSimpleConditionUiComponent],
       providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -28,7 +28,7 @@ import { RuleSimpleCondition } from '../../model/rule-simple-condition.model';
 import { comparatorHiddenForConditionFieldType, RuleConditionField, ruleConditionFields } from './rule-condition-fields';
 import { RuleConditionComparator, ruleConditionComparators } from './rule-condition-comparators';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
@@ -52,7 +52,7 @@ const AUTOCOMPLETE_OPTIONS_DEBOUNCE_TIME = 500;
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatSelectModule,

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
@@ -29,7 +29,7 @@ import { Observable } from 'rxjs';
 import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { RuleDetailsUiComponent } from './rule-details.ui-component';
@@ -42,7 +42,7 @@ export interface EditRuleDialogOptions {
 }
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatDialogModule, MatButtonModule, MatIconModule, RuleDetailsUiComponent],
+  imports: [CommonModule, TranslatePipe, MatDialogModule, MatButtonModule, MatIconModule, RuleDetailsUiComponent],
   selector: 'aca-edit-rule-dialog',
   templateUrl: './edit-rule-dialog.ui-component.html',
   styleUrls: ['./edit-rule-dialog.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
@@ -23,13 +23,11 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA, DebugElement, SimpleChange } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DebugElement, SimpleChange } from '@angular/core';
 import { RuleOptionsUiComponent } from './rule-options.ui-component';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { errorScriptConstraintMock } from '../../mock/actions.mock';
-import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
@@ -61,18 +59,8 @@ describe('RuleOptionsUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [FormsModule, ReactiveFormsModule, CoreTestingModule, RuleOptionsUiComponent],
-      providers: [
-        {
-          provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
-          useValue: { floatLabel: 'auto' }
-        },
-        {
-          provide: AlfrescoApiService,
-          useClass: AlfrescoApiServiceMock
-        }
-      ]
+      imports: [NoopTranslateModule, RuleOptionsUiComponent],
+      providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 
     fixture = TestBed.createComponent(RuleOptionsUiComponent);

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
@@ -28,12 +28,12 @@ import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox
 import { RuleOptions } from '../../model/rule.model';
 import { ActionParameterConstraint, ConstraintValue } from '../../model/action-parameter-constraint.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 
 @Component({
-  imports: [CommonModule, TranslateModule, ReactiveFormsModule, MatCheckboxModule, MatFormFieldModule, MatSelectModule],
+  imports: [CommonModule, TranslatePipe, ReactiveFormsModule, MatCheckboxModule, MatFormFieldModule, MatSelectModule],
   selector: 'aca-rule-options',
   templateUrl: 'rule-options.ui-component.html',
   styleUrls: ['rule-options.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.spec.ts
@@ -23,7 +23,6 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreTestingModule } from '@alfresco/adf-core';
 import { RuleDetailsUiComponent } from './rule-details.ui-component';
 import { Rule } from '../model/rule.model';
 import { By } from '@angular/platform-browser';
@@ -31,6 +30,7 @@ import { RuleTriggersUiComponent } from './triggers/rule-triggers.ui-component';
 import { RuleOptionsUiComponent } from './options/rule-options.ui-component';
 import { RuleActionListUiComponent } from './actions/rule-action-list.ui-component';
 import { AlfrescoApiService, AlfrescoApiServiceMock, CategoryService } from '@alfresco/adf-content-services';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('RuleDetailsUiComponent', () => {
   let fixture: ComponentFixture<RuleDetailsUiComponent>;
@@ -55,7 +55,7 @@ describe('RuleDetailsUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, RuleDetailsUiComponent],
+      imports: [NoopTranslateModule, RuleDetailsUiComponent],
       providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.ts
@@ -32,7 +32,7 @@ import { ActionDefinitionTransformed } from '../model/rule-action.model';
 import { ruleActionsValidator } from './validators/rule-actions.validator';
 import { ActionParameterConstraint } from '../model/action-parameter-constraint.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { RuleTriggersUiComponent } from './triggers/rule-triggers.ui-component';
@@ -45,7 +45,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,

--- a/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.spec.ts
@@ -24,7 +24,7 @@
 
 import { RuleTriggersUiComponent } from './rule-triggers.ui-component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
@@ -42,7 +42,7 @@ describe('RuleTriggerUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, RuleTriggersUiComponent],
+      imports: [NoopTranslateModule, RuleTriggersUiComponent],
       providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.ts
@@ -26,11 +26,11 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Component, forwardRef, ViewEncapsulation } from '@angular/core';
 import { RuleTrigger } from '../../model/rule.model';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatCheckboxModule],
+  imports: [CommonModule, TranslatePipe, MatCheckboxModule],
   selector: 'aca-rule-triggers',
   templateUrl: './rule-triggers.ui-component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.spec.ts
@@ -27,8 +27,7 @@ import { RuleListGroupingUiComponent } from './rule-list-grouping.ui-component';
 import { ruleListGroupingItemsMock, rulesMock } from '../../mock/rules.mock';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { CoreTestingModule } from '@alfresco/adf-core';
-import { AcaFolderRulesModule } from '../../folder-rules.module';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('RuleListGroupingUiComponent', () => {
   let component: RuleListGroupingUiComponent;
@@ -37,7 +36,7 @@ describe('RuleListGroupingUiComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, AcaFolderRulesModule, RuleListGroupingUiComponent]
+      imports: [NoopTranslateModule, RuleListGroupingUiComponent]
     });
 
     fixture = TestBed.createComponent(RuleListGroupingUiComponent);

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.ts
@@ -29,11 +29,11 @@ import { RuleSet } from '../../model/rule-set.model';
 import { CommonModule } from '@angular/common';
 import { RuleListItemUiComponent } from '../rule-list-item/rule-list-item.ui-component';
 import { MatRippleModule } from '@angular/material/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @Component({
-  imports: [CommonModule, TranslateModule, RuleListItemUiComponent, MatRippleModule, MatProgressSpinnerModule],
+  imports: [CommonModule, TranslatePipe, RuleListItemUiComponent, MatRippleModule, MatProgressSpinnerModule],
   selector: 'aca-rule-list-grouping',
   templateUrl: 'rule-list-grouping.ui-component.html',
   styleUrls: ['rule-list-grouping.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
@@ -26,10 +26,10 @@ import { Component, EventEmitter, HostBinding, Input, Output, ViewEncapsulation 
 import { Rule } from '../../model/rule.model';
 import { CommonModule } from '@angular/common';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
-  imports: [CommonModule, MatSlideToggleModule, TranslateModule],
+  imports: [CommonModule, MatSlideToggleModule, TranslatePipe],
   selector: 'aca-rule-list-item',
   templateUrl: 'rule-list-item.ui-component.html',
   styleUrls: ['rule-list-item.ui-component.scss'],

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.ts
@@ -28,7 +28,7 @@ import { Rule } from '../../model/rule.model';
 import { RuleGroupingItem } from '../../model/rule-grouping-item.model';
 import { FolderRuleSetsService } from '../../services/folder-rule-sets.service';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -41,7 +41,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatRippleModule,
     MatIconModule,
     MatTooltipModule,

--- a/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.spec.ts
@@ -24,7 +24,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RuleSetPickerOptions, RuleSetPickerSmartComponent } from './rule-set-picker.smart-component';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { NoopAuthModule, NoopTranslateModule } from '@alfresco/adf-core';
 import { folderToLinkMock, otherFolderMock } from '../mock/node.mock';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { FolderRuleSetsService } from '../services/folder-rule-sets.service';
@@ -33,6 +33,7 @@ import { ownedRuleSetMock, ruleSetWithLinkMock, ruleSetWithNoRulesToLinkMock, ru
 import { ContentApiService } from '@alfresco/aca-shared';
 import { By } from '@angular/platform-browser';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
+import { provideRouter } from '@angular/router';
 
 describe('RuleSetPickerSmartComponent', () => {
   let fixture: ComponentFixture<RuleSetPickerSmartComponent>;
@@ -54,8 +55,9 @@ describe('RuleSetPickerSmartComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, RuleSetPickerSmartComponent],
+      imports: [NoopTranslateModule, NoopAuthModule, RuleSetPickerSmartComponent],
       providers: [
+        provideRouter([]),
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
         { provide: MatDialogRef, useValue: dialogRef },
         { provide: MAT_DIALOG_DATA, useValue: dialogOptions },

--- a/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.ts
@@ -29,15 +29,15 @@ import { Node } from '@alfresco/js-api';
 import { RuleSet } from '../model/rule-set.model';
 import { BehaviorSubject, combineLatest, from, of } from 'rxjs';
 import { finalize, map, switchMap } from 'rxjs/operators';
-import { NotificationService, TemplateModule } from '@alfresco/adf-core';
+import { EmptyContentComponent, NotificationService } from '@alfresco/adf-core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { ContentNodeSelectorModule } from '@alfresco/adf-content-services';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { RuleListItemUiComponent } from '../rule-list/rule-list-item/rule-list-item.ui-component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ContentNodeSelectorPanelComponent } from '@alfresco/adf-content-services';
 
 export interface RuleSetPickerOptions {
   nodeId: string;
@@ -48,14 +48,14 @@ export interface RuleSetPickerOptions {
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatDialogModule,
     MatButtonModule,
     MatIconModule,
-    ContentNodeSelectorModule,
     MatProgressSpinnerModule,
     RuleListItemUiComponent,
-    TemplateModule
+    EmptyContentComponent,
+    ContentNodeSelectorPanelComponent
   ],
   selector: 'aca-rule-set-picker',
   templateUrl: './rule-set-picker.smart-component.html',

--- a/projects/aca-content/folder-rules/src/services/actions.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/actions.service.spec.ts
@@ -24,7 +24,7 @@
 
 import { ActionsService } from './actions.service';
 import { TestBed } from '@angular/core/testing';
-import { CoreTestingModule } from '@alfresco/adf-core';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 import { ActionsApi } from '@alfresco/js-api';
 import { actionDefListMock, actionsTransformedListMock } from '../mock/actions.mock';
 import { take } from 'rxjs/operators';
@@ -37,7 +37,7 @@ describe('ActionsService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule],
+      imports: [NoopTranslateModule],
       providers: [ActionsService, { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.spec.ts
@@ -24,7 +24,6 @@
 
 import { FolderRuleSetsService } from './folder-rule-sets.service';
 import { TestBed } from '@angular/core/testing';
-import { CoreTestingModule } from '@alfresco/adf-core';
 import { FolderRulesService } from './folder-rules.service';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { getOtherFolderEntryMock, getOwningFolderEntryMock, otherFolderIdMock, owningFolderIdMock, owningFolderMock } from '../mock/node.mock';
@@ -33,6 +32,7 @@ import { getDefaultRuleSetResponseMock, getRuleSetsResponseMock, inheritedRuleSe
 import { take } from 'rxjs/operators';
 import { inheritedRulesMock, linkedRulesMock, ownedRulesMock, ruleMock } from '../mock/rules.mock';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('FolderRuleSetsService', () => {
   let folderRuleSetsService: FolderRuleSetsService;
@@ -45,7 +45,7 @@ describe('FolderRuleSetsService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule],
+      imports: [NoopTranslateModule],
       providers: [FolderRuleSetsService, FolderRulesService, ContentApiService, { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/folder-rules/src/services/folder-rules.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rules.service.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { CoreTestingModule, NotificationService } from '@alfresco/adf-core';
+import { NoopTranslateModule, NotificationService } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { FolderRulesService } from './folder-rules.service';
 import {
@@ -57,7 +57,7 @@ describe('FolderRulesService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule],
+      imports: [NoopTranslateModule],
       providers: [FolderRulesService, { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
     });
 

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -25,7 +25,7 @@
 import { HammerModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { AuthGuardEcm, LanguagePickerComponent, NotificationHistoryComponent, TRANSLATION_PROVIDER } from '@alfresco/adf-core';
+import { AuthGuardEcm, LanguagePickerComponent, NotificationHistoryComponent, provideTranslations } from '@alfresco/adf-core';
 import {
   ContentModule,
   ContentVersionService,
@@ -105,14 +105,7 @@ import { SaveSearchSidenavComponent } from './components/search/search-save/side
   providers: [
     { provide: ContentVersionService, useClass: ContentUrlService },
     { provide: DocumentBasePageService, useExisting: ContentManagementService },
-    {
-      provide: TRANSLATION_PROVIDER,
-      multi: true,
-      useValue: {
-        name: 'app',
-        source: 'assets'
-      }
-    },
+    provideTranslations('app', 'assets'),
     { provide: SHELL_NAVBAR_MIN_WIDTH, useValue: 0 },
     {
       provide: MAT_DIALOG_DEFAULT_OPTIONS,

--- a/projects/aca-content/src/lib/aca-content.routes.ts
+++ b/projects/aca-content/src/lib/aca-content.routes.ts
@@ -104,270 +104,272 @@ const createViewRoutes = (navigateSource: string, additionalData: Data = {}): Ro
   }
 ];
 
-export const CONTENT_LAYOUT_ROUTES: Route = {
-  path: '',
-  canActivate: [ExtensionsDataLoaderGuard],
-  children: [
-    {
-      path: 'profile',
-      canActivate: [ViewProfileRuleGuard],
-      component: ViewProfileComponent
-    },
-    {
-      path: '',
-      component: HomeComponent
-    },
-    {
-      path: 'personal-files',
-      children: [
-        {
-          path: '',
-          component: FilesComponent,
-          data: {
-            sortingPreferenceKey: 'personal-files',
-            title: 'APP.BROWSE.PERSONAL.TITLE',
-            defaultNodeId: '-my-'
-          }
-        },
-        {
-          path: 'details/:nodeId',
-          children: [
-            {
-              path: '',
-              component: DetailsComponent,
-              data: {
-                navigateSource: 'personal-files'
-              }
-            },
-            {
-              path: ':activeTab',
-              component: DetailsComponent,
-              data: {
-                title: 'APP.BROWSE.PERSONAL.PERMISSIONS.TITLE',
-                navigateSource: 'personal-files'
-              }
+export const CONTENT_LAYOUT_ROUTES: Route[] = [
+  {
+    path: '',
+    canActivate: [ExtensionsDataLoaderGuard],
+    children: [
+      {
+        path: 'profile',
+        canActivate: [ViewProfileRuleGuard],
+        component: ViewProfileComponent
+      },
+      {
+        path: '',
+        component: HomeComponent
+      },
+      {
+        path: 'personal-files',
+        children: [
+          {
+            path: '',
+            component: FilesComponent,
+            data: {
+              sortingPreferenceKey: 'personal-files',
+              title: 'APP.BROWSE.PERSONAL.TITLE',
+              defaultNodeId: '-my-'
             }
-          ]
-        },
-        ...createViewRoutes('personal-files')
-      ]
-    },
-    {
-      path: 'personal-files/:folderId',
-      children: [
-        {
-          path: '',
-          component: FilesComponent,
-          data: {
-            title: 'APP.BROWSE.PERSONAL.TITLE',
-            sortingPreferenceKey: 'personal-files'
-          }
-        },
-        ...createViewRoutes('personal-files')
-      ]
-    },
-    {
-      path: 'libraries',
-      children: [
-        {
-          path: '',
-          component: LibrariesComponent,
-          data: {
-            title: 'APP.BROWSE.LIBRARIES.MENU.MY_LIBRARIES.TITLE',
-            sortingPreferenceKey: 'libraries'
-          }
-        }
-      ]
-    },
-    {
-      path: 'libraries/:folderId',
-      children: [
-        {
-          path: '',
-          component: FilesComponent,
-          data: {
-            title: 'APP.BROWSE.LIBRARIES.MENU.MY_LIBRARIES.TITLE',
-            sortingPreferenceKey: 'libraries-files'
-          }
-        },
-        ...createViewRoutes('libraries', {
-          data: {
-            navigateSource: 'libraries'
-          }
-        })
-      ]
-    },
-    {
-      path: 'favorite',
-      children: [
-        {
-          path: '',
-          pathMatch: 'full',
-          redirectTo: 'libraries'
-        },
-        {
-          path: 'libraries',
-          component: FavoriteLibrariesComponent,
-          data: {
-            title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
-            sortingPreferenceKey: 'favorite-libraries'
-          }
-        }
-      ]
-    },
-    {
-      path: 'favorite/libraries/:folderId',
-      children: [
-        {
-          path: '',
-          component: FilesComponent,
-          data: {
-            title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
-            sortingPreferenceKey: 'libraries-files'
-          }
-        },
-        ...createViewRoutes('libraries')
-      ]
-    },
-    {
-      path: 'favorites',
-      data: {
-        sortingPreferenceKey: 'favorites'
-      },
-      children: [
-        {
-          path: '',
-          component: FavoritesComponent,
-          data: {
-            title: 'APP.BROWSE.FAVORITES.TITLE',
-            sortingPreferenceKey: 'favorites'
-          }
-        },
-        ...createViewRoutes('favorites')
-      ]
-    },
-    {
-      path: 'recent-files',
-      data: {
-        sortingPreferenceKey: 'recent-files'
-      },
-      children: [
-        {
-          path: '',
-          component: RecentFilesComponent,
-          data: {
-            title: 'APP.BROWSE.RECENT.TITLE'
-          }
-        },
-        ...createViewRoutes('recent-files')
-      ]
-    },
-    {
-      path: 'shared',
-      children: [
-        {
-          path: '',
-          data: {
-            title: 'APP.BROWSE.SHARED.TITLE',
-            sortingPreferenceKey: 'shared-files'
           },
-          component: SharedFilesComponent
-        },
-        ...createViewRoutes('shared')
-      ],
-      canActivateChild: [AppSharedRuleGuard],
-      canActivate: [AppSharedRuleGuard]
-    },
-    {
-      path: 'trashcan',
-      children: [
-        {
-          path: '',
-          component: TrashcanComponent,
-          data: {
-            title: 'APP.BROWSE.TRASHCAN.TITLE',
-            sortingPreferenceKey: 'trashcan'
-          }
-        }
-      ]
-    },
-    {
-      path: 'search',
-      children: [
-        {
-          path: '',
-          component: SearchResultsComponent,
-          data: {
-            title: 'APP.BROWSE.SEARCH.TITLE',
-            sortingPreferenceKey: 'search'
-          }
-        },
-        ...createViewRoutes('search')
-      ]
-    },
-    {
-      path: 'search-libraries',
-      children: [
-        {
-          path: '',
-          component: SearchLibrariesResultsComponent,
-          data: {
-            title: 'APP.BROWSE.SEARCH.TITLE',
-            sortingPreferenceKey: 'search-libraries'
-          }
-        },
-        {
-          path: 'view/:nodeId',
-          outlet: 'viewer',
-          children: [
-            {
-              path: '',
-              data: {
-                navigateSource: 'search'
+          {
+            path: 'details/:nodeId',
+            children: [
+              {
+                path: '',
+                component: DetailsComponent,
+                data: {
+                  navigateSource: 'personal-files'
+                }
               },
-              loadChildren: () => import('@alfresco/aca-content/viewer').then((m) => m.AcaViewerModule)
-            }
-          ]
-        }
-      ]
-    },
-    {
-      path: 'nodes/:nodeId',
-      children: [
-        {
-          path: '',
-          loadChildren: () => import('@alfresco/aca-content/folder-rules').then((m) => m.AcaFolderRulesModule)
-        }
-      ]
-    },
-    {
-      path: 'knowledge-retrieval',
-      canDeactivate: [UnsavedChangesGuard],
-      canActivate: [PluginEnabledGuard],
-      data: {
-        plugin: 'plugins.knowledgeRetrievalEnabled'
+              {
+                path: ':activeTab',
+                component: DetailsComponent,
+                data: {
+                  title: 'APP.BROWSE.PERSONAL.PERMISSIONS.TITLE',
+                  navigateSource: 'personal-files'
+                }
+              }
+            ]
+          },
+          ...createViewRoutes('personal-files')
+        ]
       },
-      children: [
-        {
-          path: '',
-          component: SearchAiResultsComponent
+      {
+        path: 'personal-files/:folderId',
+        children: [
+          {
+            path: '',
+            component: FilesComponent,
+            data: {
+              title: 'APP.BROWSE.PERSONAL.TITLE',
+              sortingPreferenceKey: 'personal-files'
+            }
+          },
+          ...createViewRoutes('personal-files')
+        ]
+      },
+      {
+        path: 'libraries',
+        children: [
+          {
+            path: '',
+            component: LibrariesComponent,
+            data: {
+              title: 'APP.BROWSE.LIBRARIES.MENU.MY_LIBRARIES.TITLE',
+              sortingPreferenceKey: 'libraries'
+            }
+          }
+        ]
+      },
+      {
+        path: 'libraries/:folderId',
+        children: [
+          {
+            path: '',
+            component: FilesComponent,
+            data: {
+              title: 'APP.BROWSE.LIBRARIES.MENU.MY_LIBRARIES.TITLE',
+              sortingPreferenceKey: 'libraries-files'
+            }
+          },
+          ...createViewRoutes('libraries', {
+            data: {
+              navigateSource: 'libraries'
+            }
+          })
+        ]
+      },
+      {
+        path: 'favorite',
+        children: [
+          {
+            path: '',
+            pathMatch: 'full',
+            redirectTo: 'libraries'
+          },
+          {
+            path: 'libraries',
+            component: FavoriteLibrariesComponent,
+            data: {
+              title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
+              sortingPreferenceKey: 'favorite-libraries'
+            }
+          }
+        ]
+      },
+      {
+        path: 'favorite/libraries/:folderId',
+        children: [
+          {
+            path: '',
+            component: FilesComponent,
+            data: {
+              title: 'APP.BROWSE.LIBRARIES.MENU.FAVORITE_LIBRARIES.TITLE',
+              sortingPreferenceKey: 'libraries-files'
+            }
+          },
+          ...createViewRoutes('libraries')
+        ]
+      },
+      {
+        path: 'favorites',
+        data: {
+          sortingPreferenceKey: 'favorites'
         },
-        ...createViewRoutes('knowledge-retrieval')
-      ]
-    },
-    {
-      path: 'saved-searches',
-      children: [
-        {
-          path: '',
-          component: SavedSearchesSmartListComponent
-        }
-      ]
-    },
-    {
-      path: '**',
-      component: GenericErrorComponent
-    }
-  ],
-  canActivateChild: [AuthGuard]
-};
+        children: [
+          {
+            path: '',
+            component: FavoritesComponent,
+            data: {
+              title: 'APP.BROWSE.FAVORITES.TITLE',
+              sortingPreferenceKey: 'favorites'
+            }
+          },
+          ...createViewRoutes('favorites')
+        ]
+      },
+      {
+        path: 'recent-files',
+        data: {
+          sortingPreferenceKey: 'recent-files'
+        },
+        children: [
+          {
+            path: '',
+            component: RecentFilesComponent,
+            data: {
+              title: 'APP.BROWSE.RECENT.TITLE'
+            }
+          },
+          ...createViewRoutes('recent-files')
+        ]
+      },
+      {
+        path: 'shared',
+        children: [
+          {
+            path: '',
+            data: {
+              title: 'APP.BROWSE.SHARED.TITLE',
+              sortingPreferenceKey: 'shared-files'
+            },
+            component: SharedFilesComponent
+          },
+          ...createViewRoutes('shared')
+        ],
+        canActivateChild: [AppSharedRuleGuard],
+        canActivate: [AppSharedRuleGuard]
+      },
+      {
+        path: 'trashcan',
+        children: [
+          {
+            path: '',
+            component: TrashcanComponent,
+            data: {
+              title: 'APP.BROWSE.TRASHCAN.TITLE',
+              sortingPreferenceKey: 'trashcan'
+            }
+          }
+        ]
+      },
+      {
+        path: 'search',
+        children: [
+          {
+            path: '',
+            component: SearchResultsComponent,
+            data: {
+              title: 'APP.BROWSE.SEARCH.TITLE',
+              sortingPreferenceKey: 'search'
+            }
+          },
+          ...createViewRoutes('search')
+        ]
+      },
+      {
+        path: 'search-libraries',
+        children: [
+          {
+            path: '',
+            component: SearchLibrariesResultsComponent,
+            data: {
+              title: 'APP.BROWSE.SEARCH.TITLE',
+              sortingPreferenceKey: 'search-libraries'
+            }
+          },
+          {
+            path: 'view/:nodeId',
+            outlet: 'viewer',
+            children: [
+              {
+                path: '',
+                data: {
+                  navigateSource: 'search'
+                },
+                loadChildren: () => import('@alfresco/aca-content/viewer').then((m) => m.AcaViewerModule)
+              }
+            ]
+          }
+        ]
+      },
+      {
+        path: 'nodes/:nodeId',
+        children: [
+          {
+            path: '',
+            loadChildren: () => import('@alfresco/aca-content/folder-rules').then((m) => m.AcaFolderRulesModule)
+          }
+        ]
+      },
+      {
+        path: 'knowledge-retrieval',
+        canDeactivate: [UnsavedChangesGuard],
+        canActivate: [PluginEnabledGuard],
+        data: {
+          plugin: 'plugins.knowledgeRetrievalEnabled'
+        },
+        children: [
+          {
+            path: '',
+            component: SearchAiResultsComponent
+          },
+          ...createViewRoutes('knowledge-retrieval')
+        ]
+      },
+      {
+        path: 'saved-searches',
+        children: [
+          {
+            path: '',
+            component: SavedSearchesSmartListComponent
+          }
+        ]
+      },
+      {
+        path: '**',
+        component: GenericErrorComponent
+      }
+    ],
+    canActivateChild: [AuthGuard]
+  }
+];

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
@@ -28,7 +28,7 @@ import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { MatSelectModule } from '@angular/material/select';
 import { Store } from '@ngrx/store';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { combineLatest, Observable } from 'rxjs';
 import { IconComponent, TranslationService } from '@alfresco/adf-core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
@@ -40,7 +40,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   selector: 'aca-bulk-actions-dropdown',
   templateUrl: './bulk-actions-dropdown.component.html',
   styleUrls: ['./bulk-actions-dropdown.component.scss'],
-  imports: [CommonModule, TranslateModule, MatSelectModule, IconComponent, ReactiveFormsModule],
+  imports: [CommonModule, TranslatePipe, MatSelectModule, IconComponent, ReactiveFormsModule],
   encapsulation: ViewEncapsulation.None
 })
 export class BulkActionsDropdownComponent implements OnInit {

--- a/projects/aca-content/src/lib/components/common/language-picker/language-picker.component.ts
+++ b/projects/aca-content/src/lib/components/common/language-picker/language-picker.component.ts
@@ -22,14 +22,14 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { LanguageMenuModule } from '@alfresco/adf-core';
+import { LanguageMenuComponent } from '@alfresco/adf-core';
 import { Component, ViewEncapsulation } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
-  imports: [TranslateModule, MatIconModule, MatMenuModule, LanguageMenuModule],
+  imports: [TranslatePipe, MatIconModule, MatMenuModule, LanguageMenuComponent],
   selector: 'aca-language-picker',
   template: `
     <button mat-menu-item [matMenuTriggerFor]="langMenu">

--- a/projects/aca-content/src/lib/components/common/location-link/location-link.component.ts
+++ b/projects/aca-content/src/lib/components/common/location-link/location-link.component.ts
@@ -30,10 +30,10 @@ import { NavigateToParentFolder } from '@alfresco/aca-shared/store';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { TranslationService } from '@alfresco/adf-core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
-  imports: [CommonModule, TranslateModule],
+  imports: [CommonModule, TranslatePipe],
   selector: 'aca-location-link',
   template: `
     <a

--- a/projects/aca-content/src/lib/components/common/logout/logout.component.ts
+++ b/projects/aca-content/src/lib/components/common/logout/logout.component.ts
@@ -25,13 +25,13 @@
 import { Component, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { SetSelectedNodesAction } from '@alfresco/aca-shared/store';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { LogoutDirective } from '@alfresco/adf-core';
 
 @Component({
-  imports: [TranslateModule, MatIconModule, MatMenuModule, LogoutDirective],
+  imports: [TranslatePipe, MatIconModule, MatMenuModule, LogoutDirective],
   selector: 'aca-logout',
   template: `
     <button mat-menu-item (click)="onLogoutEvent()" adf-logout>

--- a/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
+++ b/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
@@ -30,12 +30,12 @@ import { AppStore, getAppSelection, ShareNodeAction } from '@alfresco/aca-shared
 import { CommonModule } from '@angular/common';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, MatMenuModule, MatIconModule, TranslateModule, MatButtonModule],
+  imports: [CommonModule, MatMenuModule, MatIconModule, TranslatePipe, MatButtonModule],
   selector: 'app-toggle-shared',
   templateUrl: './toggle-shared.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/common/user-info/user-info.component.ts
+++ b/projects/aca-content/src/lib/components/common/user-info/user-info.component.ts
@@ -26,11 +26,11 @@ import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { UserProfileService } from '@alfresco/aca-shared';
 
 @Component({
-  imports: [CommonModule, RouterModule, MatMenuModule, TranslateModule],
+  imports: [CommonModule, RouterModule, MatMenuModule, TranslatePipe],
   selector: 'app-user-info',
   templateUrl: './user-info.component.html',
   styleUrls: ['./user-info.component.scss'],

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.ts
@@ -27,12 +27,12 @@ import { ContentActionRef, DynamicExtensionComponent } from '@alfresco/adf-exten
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
 import { MatMenuModule } from '@angular/material/menu';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { IconComponent } from '@alfresco/adf-core';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatMenuModule, MatDividerModule, IconComponent, DynamicExtensionComponent],
+  imports: [CommonModule, TranslatePipe, MatMenuModule, MatDividerModule, IconComponent, DynamicExtensionComponent],
   selector: 'app-context-menu-item',
   templateUrl: './context-menu-item.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
@@ -30,7 +30,7 @@ import { CONTEXT_MENU_DIRECTION } from './direction.token';
 import { Direction } from '@angular/cdk/bidi';
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { IconComponent } from '@alfresco/adf-core';
 import { ContextMenuItemComponent } from './context-menu-item.component';
@@ -41,7 +41,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatMenuModule,
     MatDividerModule,
     ContextMenuItemComponent,

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
@@ -27,9 +27,8 @@ import { Overlay } from '@angular/cdk/overlay';
 import { Injector } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
-import { AuthModule, CoreModule, UserPreferencesService } from '@alfresco/adf-core';
+import { NoopTranslateModule, UserPreferencesService, NoopAuthModule } from '@alfresco/adf-core';
 import { ContextMenuService } from './context-menu.service';
-import { TranslateModule } from '@ngx-translate/core';
 import { ContextMenuComponent } from './context-menu.component';
 import { ContextmenuOverlayConfig } from './interfaces';
 import { ContentActionRef, ContentActionType } from '@alfresco/adf-extensions';
@@ -63,7 +62,7 @@ describe('ContextMenuService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), CoreModule.forRoot(), ContextMenuComponent, AuthModule.forRoot()],
+      imports: [NoopTranslateModule, ContextMenuComponent, NoopAuthModule],
       providers: [Overlay, { provide: Store, useValue: { select: () => of() } }, UserPreferencesService]
     });
 

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
@@ -29,7 +29,7 @@ import { AppExtensionService } from '@alfresco/aca-shared';
 import { CONTEXT_MENU_DIRECTION } from './direction.token';
 import { ContentActionRef, DynamicExtensionComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { ContextMenuItemComponent } from './context-menu-item.component';
 import { OutsideEventDirective } from './context-menu-outside-event.directive';
@@ -44,7 +44,7 @@ import { BaseContextMenuDirective } from './base-context-menu.directive';
   styleUrls: ['./context-menu.component.scss'],
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatMenuModule,
     MatDividerModule,
     ContextMenuItemComponent,

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -28,7 +28,7 @@ import { AppHookService, ContentApiService, PageComponent, PageLayoutComponent, 
 import { NavigateToFolder, NavigateToPreviousPage, SetSelectedNodesAction } from '@alfresco/aca-shared/store';
 import { BreadcrumbComponent, ContentService, NodesApiService, PermissionListComponent } from '@alfresco/adf-content-services';
 import { CommonModule, Location } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -44,7 +44,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatIconModule,
     MatTabsModule,
     MatProgressBarModule,

--- a/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.spec.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.spec.ts
@@ -25,8 +25,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatatableCellBadgesComponent } from './datatable-cell-badges.component';
 import { AppExtensionService } from '@alfresco/aca-shared';
-import { TranslateModule } from '@ngx-translate/core';
-import { AuthModule } from '@alfresco/adf-core';
+import { NoopAuthModule, NoopTranslateModule } from '@alfresco/adf-core';
 import { Actions } from '@ngrx/effects';
 import { NodeEntry } from '@alfresco/js-api';
 import { of } from 'rxjs';
@@ -57,8 +56,8 @@ describe('DatatableCellBadgesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot(),
-        AuthModule.forRoot(),
+        NoopTranslateModule,
+        NoopAuthModule,
         StoreModule.forRoot(
           { app: (state) => state },
           {
@@ -73,7 +72,8 @@ describe('DatatableCellBadgesComponent', () => {
               }
             }
           }
-        )
+        ),
+        DatatableCellBadgesComponent
       ],
       providers: [Actions, provideHttpClient(withInterceptorsFromDi())]
     });

--- a/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.ts
@@ -28,7 +28,7 @@ import { DynamicExtensionComponent } from '@alfresco/adf-extensions';
 import { NodeEntry } from '@alfresco/js-api';
 import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -37,7 +37,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrls: ['./datatable-cell-badges.component.scss'],
   host: { class: 'aca-datatable-cell-badges' },
   encapsulation: ViewEncapsulation.None,
-  imports: [CommonModule, TranslateModule, DynamicExtensionComponent, IconComponent]
+  imports: [CommonModule, TranslatePipe, DynamicExtensionComponent, IconComponent]
 })
 export class DatatableCellBadgesComponent implements OnInit {
   @Input({ required: true }) node: NodeEntry;

--- a/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.spec.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.spec.ts
@@ -27,9 +27,8 @@ import { Actions } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { TranslateModule } from '@ngx-translate/core';
 import { By } from '@angular/platform-browser';
-import { AuthModule } from '@alfresco/adf-core';
+import { AuthModule, NoopTranslateModule } from '@alfresco/adf-core';
 import { Component, Input } from '@angular/core';
 import { NodeEntry } from '@alfresco/js-api';
 
@@ -49,7 +48,7 @@ describe('CustomNameColumnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot(),
+        NoopTranslateModule,
         CustomNameColumnComponent,
         MockDatatableCellBadgesComponent,
         AuthModule.forRoot(),

--- a/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.ts
@@ -29,12 +29,12 @@ import { filter } from 'rxjs/operators';
 import { NodeActionTypes } from '@alfresco/aca-shared/store';
 import { isLocked, LockedByComponent } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { DatatableCellBadgesComponent } from '../datatable-cell-badges/datatable-cell-badges.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, LockedByComponent, NodeNameTooltipPipe, DatatableCellBadgesComponent],
+  imports: [CommonModule, TranslatePipe, LockedByComponent, NodeNameTooltipPipe, DatatableCellBadgesComponent],
   selector: 'aca-custom-name-column',
   templateUrl: './name-column.component.html',
   styleUrls: ['./name-column.component.scss'],

--- a/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.ts
+++ b/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.ts
@@ -45,7 +45,7 @@ import {
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
 import { DocumentListDirective } from '../../directives/document-list.directive';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({
@@ -56,7 +56,7 @@ import { DocumentListComponent } from '@alfresco/adf-content-services';
     PaginationComponent,
     InfoDrawerComponent,
     PageLayoutComponent,
-    TranslateModule,
+    TranslatePipe,
     ToolbarComponent,
     EmptyContentComponent,
     DynamicColumnComponent,

--- a/projects/aca-content/src/lib/components/favorites/favorites.component.ts
+++ b/projects/aca-content/src/lib/components/favorites/favorites.component.ts
@@ -44,7 +44,7 @@ import {
   PaginationComponent
 } from '@alfresco/adf-core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentListComponent } from '@alfresco/adf-content-services';
 import { SearchAiInputContainerComponent } from '../knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component';
 
@@ -57,7 +57,7 @@ import { SearchAiInputContainerComponent } from '../knowledge-retrieval/search-a
     PaginationDirective,
     InfoDrawerComponent,
     PageLayoutComponent,
-    TranslateModule,
+    TranslatePipe,
     ToolbarComponent,
     SearchAiInputContainerComponent,
     EmptyContentComponent,

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -55,7 +55,7 @@ import {
 } from '@alfresco/adf-content-services';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { SearchAiInputContainerComponent } from '../knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component';
@@ -65,7 +65,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     GenericErrorComponent,
     DocumentListDirective,
     ContextActionsDirective,

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -44,7 +44,7 @@ import { from, Observable } from 'rxjs';
 import { ErrorStateMatcher, MatOptionModule } from '@angular/material/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
@@ -63,7 +63,7 @@ export class InstantErrorStateMatcher implements ErrorStateMatcher {
   imports: [
     CommonModule,
     MatCardModule,
-    TranslateModule,
+    TranslatePipe,
     MatFormFieldModule,
     FormsModule,
     ReactiveFormsModule,

--- a/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.spec.ts
@@ -25,9 +25,11 @@
 import { VersionsTabComponent } from './versions-tab.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppSettingsService } from '@alfresco/aca-shared';
-import { ContentTestingModule, VersionListDataSource, VersionManagerComponent } from '@alfresco/adf-content-services';
+import { VersionListDataSource, VersionManagerComponent } from '@alfresco/adf-content-services';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
+import { NoopAuthModule, NoopTranslateModule } from '@alfresco/adf-core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('VersionsTabComponent', () => {
   let component: VersionsTabComponent;
@@ -36,7 +38,7 @@ describe('VersionsTabComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [VersionsTabComponent, ContentTestingModule]
+      imports: [NoopTranslateModule, NoopAuthModule, NoopAnimationsModule, VersionsTabComponent]
     });
 
     fixture = TestBed.createComponent(VersionsTabComponent);

--- a/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.ts
@@ -24,17 +24,16 @@
 
 import { Component, inject, Input, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { CommonModule } from '@angular/common';
-import { VersionManagerModule } from '@alfresco/adf-content-services';
 import { MatIconModule } from '@angular/material/icon';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { AppSettingsService } from '@alfresco/aca-shared';
+import { VersionManagerComponent } from '@alfresco/adf-content-services';
 
 @Component({
-  imports: [CommonModule, VersionManagerModule, MatIconModule, TranslateModule],
+  imports: [MatIconModule, TranslatePipe, VersionManagerComponent],
   selector: 'app-versions-tab',
   template: `
-    <ng-container *ngIf="isFileSelected; else empty">
+    @if (isFileSelected) {
       <adf-version-manager
         [showComments]="settings.uploadAllowComments"
         [allowDownload]="settings.uploadAllowDownload"
@@ -43,14 +42,12 @@ import { AppSettingsService } from '@alfresco/aca-shared';
         [allowVersionDelete]="settings.versionManagerAllowVersionDelete"
         [showActions]="settings.versionManagerShowActions"
       />
-    </ng-container>
-
-    <ng-template #empty>
+    } @else {
       <div class="adf-manage-versions-empty">
         <mat-icon class="adf-manage-versions-empty-icon">face</mat-icon>
         {{ 'VERSION.SELECTION.EMPTY' | translate }}
       </div>
-    </ng-template>
+    }
   `,
   encapsulation: ViewEncapsulation.None
 })

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/agents-button/agents-button.component.spec.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/agents-button/agents-button.component.spec.ts
@@ -24,12 +24,12 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AgentsButtonComponent } from './agents-button.component';
-import { AgentService, ContentTestingModule, SearchAiService } from '@alfresco/adf-content-services';
+import { AgentService, SearchAiService } from '@alfresco/adf-content-services';
 import { Subject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { getAppSelection, SearchAiActionTypes } from '@alfresco/aca-shared/store';
-import { AvatarComponent, NotificationService } from '@alfresco/adf-core';
+import { AvatarComponent, NoopTranslateModule, NotificationService } from '@alfresco/adf-core';
 import { SelectionState } from '@alfresco/adf-extensions';
 import { MatMenu, MatMenuPanel, MatMenuTrigger } from '@angular/material/menu';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -40,6 +40,7 @@ import { MatSelectionList } from '@angular/material/list';
 import { MatSnackBarRef } from '@angular/material/snack-bar';
 import { ChangeDetectorRef } from '@angular/core';
 import { Agent, KnowledgeRetrievalConfigEntry } from '@alfresco/js-api';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 describe('AgentsButtonComponent', () => {
   let component: AgentsButtonComponent;
@@ -174,7 +175,7 @@ describe('AgentsButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AgentsButtonComponent, ContentTestingModule],
+      imports: [NoopTranslateModule, MatIconTestingModule, AgentsButtonComponent],
       providers: [provideMockStore({})]
     });
 

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/agents-button/agents-button.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/agents-button/agents-button.component.ts
@@ -32,14 +32,14 @@ import { forkJoin, throwError } from 'rxjs';
 import { catchError, take } from 'rxjs/operators';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatListModule, MatSelectionListChange } from '@angular/material/list';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { Agent } from '@alfresco/js-api';
 import { AgentService, SearchAiService } from '@alfresco/adf-content-services';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, MatMenuModule, MatListModule, TranslateModule, AvatarComponent, IconComponent, MatTooltipModule],
+  imports: [CommonModule, MatMenuModule, MatListModule, TranslatePipe, AvatarComponent, IconComponent, MatTooltipModule],
   selector: 'aca-agents-button',
   templateUrl: './agents-button.component.html',
   styleUrls: ['./agents-button.component.scss'],

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.spec.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.spec.ts
@@ -26,7 +26,7 @@ import { SearchAiInputContainerComponent } from './search-ai-input-container.com
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SearchAiInputComponent } from '../search-ai-input/search-ai-input.component';
 import { By } from '@angular/platform-browser';
-import { AgentService, ContentTestingModule, SearchAiService } from '@alfresco/adf-content-services';
+import { AgentService, SearchAiService } from '@alfresco/adf-content-services';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of, Subject } from 'rxjs';
 import { MatDivider } from '@angular/material/divider';
@@ -34,8 +34,10 @@ import { DebugElement } from '@angular/core';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { SearchAiNavigationService } from '../../../../services/search-ai-navigation.service';
-import { NavigationEnd, Router, RouterEvent } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, RouterEvent } from '@angular/router';
 import { getAppSelection } from '@alfresco/aca-shared/store';
+import { NoopTranslateModule } from '@alfresco/adf-core';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 describe('SearchAiInputContainerComponent', () => {
   const routingEvents$: Subject<RouterEvent> = new Subject();
@@ -63,8 +65,9 @@ describe('SearchAiInputContainerComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [SearchAiInputContainerComponent, ContentTestingModule],
+      imports: [NoopTranslateModule, MatIconTestingModule, SearchAiInputContainerComponent],
       providers: [
+        provideRouter([]),
         { provide: Router, useValue: mockRouter },
         provideMockStore(),
         { provide: SearchAiService, useValue: mockSearchAiService },

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component.ts
@@ -29,13 +29,13 @@ import { SearchAiInputComponent } from '../search-ai-input/search-ai-input.compo
 import { MatDividerModule } from '@angular/material/divider';
 import { SearchAiNavigationService } from '../../../../services/search-ai-navigation.service';
 import { SearchAiInputState, SearchAiService } from '@alfresco/adf-content-services';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { Router } from '@angular/router';
 
 @Component({
-  imports: [SearchAiInputComponent, MatIconModule, MatDividerModule, MatButtonModule, TranslateModule, AsyncPipe],
+  imports: [SearchAiInputComponent, MatIconModule, MatDividerModule, MatButtonModule, TranslatePipe, AsyncPipe],
   selector: 'aca-search-ai-input-container',
   templateUrl: './search-ai-input-container.component.html',
   styleUrls: ['./search-ai-input-container.component.scss'],

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input/search-ai-input.component.spec.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input/search-ai-input.component.spec.ts
@@ -27,13 +27,20 @@ import { SearchAiInputComponent } from './search-ai-input.component';
 import { MatSelect, MatSelectModule } from '@angular/material/select';
 import { By } from '@angular/platform-browser';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { AgentService, ContentTestingModule, SearchAiService } from '@alfresco/adf-content-services';
+import { AgentService, SearchAiService } from '@alfresco/adf-content-services';
 import { getAppSelection, SearchByTermAiAction, ToggleAISearchInput } from '@alfresco/aca-shared/store';
 import { of, Subject } from 'rxjs';
 import { Agent, NodeEntry } from '@alfresco/js-api';
 import { FormControlDirective } from '@angular/forms';
 import { DebugElement } from '@angular/core';
-import { AvatarComponent, IconComponent, NotificationService, UnsavedChangesDialogComponent, UserPreferencesService } from '@alfresco/adf-core';
+import {
+  AvatarComponent,
+  IconComponent,
+  NoopTranslateModule,
+  NotificationService,
+  UnsavedChangesDialogComponent,
+  UserPreferencesService
+} from '@alfresco/adf-core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
@@ -46,6 +53,7 @@ import { MatSnackBarRef } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { ModalAiService } from '../../../../services/modal-ai.service';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 describe('SearchAiInputComponent', () => {
   let component: SearchAiInputComponent;
@@ -83,7 +91,7 @@ describe('SearchAiInputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SearchAiInputComponent, ContentTestingModule, MatSelectModule],
+      imports: [NoopTranslateModule, MatIconTestingModule, SearchAiInputComponent, MatSelectModule],
       providers: [
         provideMockStore(),
         {

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input/search-ai-input.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-input/search-ai-input.component.ts
@@ -24,7 +24,7 @@
 
 import { Component, DestroyRef, inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -56,7 +56,7 @@ const MatTooltipOptions: MatTooltipDefaultOptions = {
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatButtonModule,
     MatIconModule,
     MatFormFieldModule,

--- a/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-retrieval/search-ai/search-ai-results/search-ai-results.component.ts
@@ -30,7 +30,7 @@ import { ClipboardService, EmptyContentComponent, ThumbnailService, UnsavedChang
 import { AiAnswer, Node } from '@alfresco/js-api';
 import { CommonModule } from '@angular/common';
 import { SearchAiInputContainerComponent } from '../search-ai-input-container/search-ai-input-container.component';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { NodesApiService } from '@alfresco/adf-content-services';
 import { forkJoin, Observable, of, throwError } from 'rxjs';
 import { SelectionState } from '@alfresco/adf-extensions';
@@ -51,7 +51,7 @@ import { searchAiMarkedOptions } from './search-ai-marked-options';
     CommonModule,
     PageLayoutComponent,
     SearchAiInputContainerComponent,
-    TranslateModule,
+    TranslatePipe,
     MatIconModule,
     MatButtonModule,
     MatListModule,

--- a/projects/aca-content/src/lib/components/libraries/libraries.component.ts
+++ b/projects/aca-content/src/lib/components/libraries/libraries.component.ts
@@ -36,26 +36,34 @@ import {
 } from '@alfresco/aca-shared';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { DocumentListModule } from '@alfresco/adf-content-services';
-import { DataTableModule, EmptyContentComponent, PaginationComponent } from '@alfresco/adf-core';
+import {
+  CustomEmptyContentTemplateDirective,
+  DataColumnComponent,
+  DataColumnListComponent,
+  EmptyContentComponent,
+  PaginationComponent
+} from '@alfresco/adf-core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({
   imports: [
     CommonModule,
-    DocumentListModule,
     DocumentListDirective,
     ContextActionsDirective,
-    DataTableModule,
     PaginationComponent,
     PaginationDirective,
     InfoDrawerComponent,
     PageLayoutComponent,
-    TranslateModule,
+    TranslatePipe,
     ToolbarComponent,
     EmptyContentComponent,
-    DynamicColumnComponent
+    DynamicColumnComponent,
+    DocumentListComponent,
+    DataColumnComponent,
+    DataColumnListComponent,
+    CustomEmptyContentTemplateDirective
   ],
   templateUrl: './libraries.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/recent-files/recent-files.component.ts
+++ b/projects/aca-content/src/lib/components/recent-files/recent-files.component.ts
@@ -35,28 +35,36 @@ import {
 } from '@alfresco/aca-shared';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { DocumentListModule } from '@alfresco/adf-content-services';
-import { DataTableModule, EmptyContentComponent, PaginationComponent } from '@alfresco/adf-core';
+import {
+  CustomEmptyContentTemplateDirective,
+  DataColumnComponent,
+  DataColumnListComponent,
+  EmptyContentComponent,
+  PaginationComponent
+} from '@alfresco/adf-core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SearchAiInputContainerComponent } from '../knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component';
+import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({
   imports: [
     CommonModule,
-    DocumentListModule,
     DocumentListDirective,
     ContextActionsDirective,
-    DataTableModule,
     PaginationComponent,
     PaginationDirective,
     InfoDrawerComponent,
     PageLayoutComponent,
-    TranslateModule,
+    TranslatePipe,
     ToolbarComponent,
     SearchAiInputContainerComponent,
     EmptyContentComponent,
-    DynamicColumnComponent
+    DynamicColumnComponent,
+    DocumentListComponent,
+    CustomEmptyContentTemplateDirective,
+    DataColumnComponent,
+    DataColumnListComponent
   ],
   templateUrl: './recent-files.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.ts
@@ -26,13 +26,13 @@ import { SearchQueryBuilderService } from '@alfresco/adf-content-services';
 import { SearchSortingDefinition } from '@alfresco/adf-content-services/lib/search/models/search-sorting-definition.interface';
 import { Component, EventEmitter, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatMenuModule, MatIconModule, MatButtonModule],
+  imports: [CommonModule, TranslatePipe, MatMenuModule, MatIconModule, MatButtonModule],
   selector: 'aca-search-action-menu',
   templateUrl: './search-action-menu.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-input-control/search-input-control.component.ts
@@ -24,7 +24,7 @@
 
 import { Component, EventEmitter, Input, Output, ViewEncapsulation, ViewChild, ElementRef, OnInit, inject, DestroyRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -33,7 +33,7 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, MatFormFieldModule, MatInputModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule, MatFormFieldModule, MatInputModule, FormsModule, ReactiveFormsModule],
   selector: 'app-search-input-control',
   templateUrl: './search-input-control.component.html',
   styleUrls: ['./search-input-control.component.scss'],

--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
@@ -34,7 +34,7 @@ import { SearchInputControlComponent } from '../search-input-control/search-inpu
 import { SearchNavigationService } from '../search-navigation.service';
 import { SearchLibrariesQueryBuilderService } from '../search-libraries-results/search-libraries-query-builder.service';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -48,7 +48,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatMenuModule,
     MatButtonModule,
     MatIconModule,

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.ts
@@ -39,7 +39,7 @@ import {
 } from '@alfresco/aca-shared';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SearchInputComponent } from '../search-input/search-input.component';
 import { CustomEmptyContentTemplateDirective, DataColumnComponent, DataColumnListComponent, PaginationComponent } from '@alfresco/adf-core';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -51,7 +51,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     SearchInputComponent,
     MatProgressBarModule,
     PaginationComponent,

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -66,7 +66,7 @@ import {
 import { SearchSortingDefinition } from '@alfresco/adf-content-services/lib/search/models/search-sorting-definition.interface';
 import { take, takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SearchInputComponent } from '../search-input/search-input.component';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatDividerModule } from '@angular/material/divider';
@@ -92,7 +92,7 @@ import { MatMenuModule } from '@angular/material/menu';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     SearchInputComponent,
     MatProgressBarModule,
     MatDividerModule,

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
@@ -26,7 +26,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
 import { SavedSearchDeleteDialogComponent } from './saved-search-delete-dialog.component';
-import { ContentTestingModule, SavedSearch, SavedSearchesService } from '@alfresco/adf-content-services';
+import { SavedSearch, SavedSearchesService } from '@alfresco/adf-content-services';
 import { NotificationService } from '@alfresco/adf-core';
 import { AppTestingModule } from '../../../../../testing/app-testing.module';
 
@@ -49,7 +49,7 @@ describe('SaveSearchDeleteDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, AppTestingModule, SavedSearchDeleteDialogComponent],
+      imports: [AppTestingModule, SavedSearchDeleteDialogComponent],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         { provide: SavedSearchesService, useValue: { deleteSavedSearch: () => of({}) } },

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
@@ -49,7 +49,7 @@ describe('SaveSearchDeleteDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, AppTestingModule],
+      imports: [ContentTestingModule, AppTestingModule, SavedSearchDeleteDialogComponent],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         { provide: SavedSearchesService, useValue: { deleteSavedSearch: () => of({}) } },

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.html
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.html
@@ -20,14 +20,20 @@
           required
           [formControlName]="'name'"
           adf-auto-focus/>
-      <mat-error *ngIf="form.controls['name'].touched">
-        <span *ngIf="form.controls['name'].errors?.required">
+      @if (form.controls['name'].touched) {
+      <mat-error>
+        @if (form.controls['name'].errors?.required) {
+        <span>
           {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.NAME_REQUIRED_ERROR' | translate }}
         </span>
-        <span *ngIf="!form.controls['name'].errors?.required && form.controls['name'].errors?.message">
+        }
+        @if (!form.controls['name'].errors?.required && form.controls['name'].errors?.message) {
+        <span>
           {{ form.controls['name'].errors?.message | translate : { name: form.controls.name.value } }}
         </span>
+        }
       </mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field class="aca-saved-search-edit-dialog__form-field">

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
@@ -50,7 +50,7 @@ describe('SaveSearchEditDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, AppTestingModule],
+      imports: [ContentTestingModule, AppTestingModule, SavedSearchEditDialogComponent],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         provideMockStore(),

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
@@ -26,7 +26,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
 import { SavedSearchEditDialogComponent } from './saved-search-edit-dialog.component';
-import { ContentTestingModule, SavedSearch, SavedSearchesService } from '@alfresco/adf-content-services';
+import { SavedSearch, SavedSearchesService } from '@alfresco/adf-content-services';
 import { provideMockStore } from '@ngrx/store/testing';
 import { NotificationService } from '@alfresco/adf-core';
 import { AppTestingModule } from '../../../../../testing/app-testing.module';
@@ -50,7 +50,7 @@ describe('SaveSearchEditDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, AppTestingModule, SavedSearchEditDialogComponent],
+      imports: [AppTestingModule, SavedSearchEditDialogComponent],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         provideMockStore(),

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
@@ -26,10 +26,10 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
 import { SaveSearchDialogComponent } from './save-search-dialog.component';
-import { ContentTestingModule, SavedSearchesService } from '@alfresco/adf-content-services';
+import { SavedSearchesService } from '@alfresco/adf-content-services';
 import { provideMockStore } from '@ngrx/store/testing';
 import { AppTestingModule } from '../../../../testing/app-testing.module';
-import { NotificationService } from '@alfresco/adf-core';
+import { NoopTranslateModule, NotificationService } from '@alfresco/adf-core';
 
 describe('SaveSearchDialogComponent', () => {
   let fixture: ComponentFixture<SaveSearchDialogComponent>;
@@ -44,7 +44,7 @@ describe('SaveSearchDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, AppTestingModule],
+      imports: [NoopTranslateModule, AppTestingModule],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         provideMockStore(),

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
@@ -25,7 +25,7 @@
 import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -43,7 +43,7 @@ import { SavedSearchForm } from './saved-search-form.interface';
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
+    TranslatePipe,
     MatMenuModule,
     MatButtonModule,
     MatIconModule,

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
@@ -24,16 +24,17 @@
 
 import { TestBed } from '@angular/core/testing';
 import { UniqueSearchNameValidator } from './unique-search-name-validator';
-import { ContentTestingModule, SavedSearchesService } from '@alfresco/adf-content-services';
+import { SavedSearchesService } from '@alfresco/adf-content-services';
 import { of } from 'rxjs';
 import { FormControl } from '@angular/forms';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('UniqueSearchNameValidator', () => {
   let validator: UniqueSearchNameValidator;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule]
+      imports: [NoopTranslateModule]
     });
   });
 

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CORE_PIPES, CoreTestingModule } from '@alfresco/adf-core';
+import { NoopAuthModule, NoopTranslateModule } from '@alfresco/adf-core';
 import { BehaviorSubject, ReplaySubject, Subject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { SavedSearchesService, SavedSearch } from '@alfresco/adf-content-services';
@@ -56,12 +56,11 @@ describe('SavedSearchesSmartListComponent', () => {
       infoDrawerOpened: false
     };
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, SavedSearchesSmartListComponent],
+      imports: [NoopTranslateModule, NoopAuthModule, SavedSearchesSmartListComponent],
       providers: [
         provideMockStore({
           initialState: { app: appState }
         }),
-        ...CORE_PIPES,
         { provide: DocumentBasePageService, useClass: DocumentBasePageServiceMock },
         { provide: SavedSearchesService, useValue: { savedSearches$: fakeSavedSearches$ } },
         { provide: AppService, useValue: appServiceMock }

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.ts
@@ -24,7 +24,7 @@
 
 import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SavedSearchesListUiComponent } from '../ui-list/saved-searches-list.ui-component';
 import { PageComponent, PageLayoutComponent } from '@alfresco/aca-shared';
 import { SavedSearchesService } from '@alfresco/adf-content-services';
@@ -33,7 +33,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'aca-saved-searches-smart-list',
-  imports: [CommonModule, TranslateModule, SavedSearchesListUiComponent, PageLayoutComponent, EmptyContentComponent, MatProgressSpinnerModule],
+  imports: [CommonModule, TranslatePipe, SavedSearchesListUiComponent, PageLayoutComponent, EmptyContentComponent, MatProgressSpinnerModule],
   templateUrl: './saved-searches-smart-list.component.html',
   styleUrls: ['./saved-searches-smart-list.component.scss'],
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreTestingModule, DataCellEvent, DataTableComponent, NotificationService } from '@alfresco/adf-core';
+import { DataCellEvent, DataTableComponent, NoopTranslateModule, NotificationService } from '@alfresco/adf-core';
 import { SavedSearchesListUiComponent } from './saved-searches-list.ui-component';
 import { SavedSearchesListUiService } from '../saved-searches-list-ui.service';
 import { By } from '@angular/platform-browser';
@@ -42,7 +42,7 @@ describe('SavedSearchesListUiComponent ', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, SavedSearchesListUiComponent],
+      imports: [NoopTranslateModule, SavedSearchesListUiComponent],
       providers: [SavedSearchesListUiService]
     });
 

--- a/projects/aca-content/src/lib/components/shared-files/shared-files.component.ts
+++ b/projects/aca-content/src/lib/components/shared-files/shared-files.component.ts
@@ -36,28 +36,36 @@ import {
 } from '@alfresco/aca-shared';
 import { DocumentListPresetRef, DynamicColumnComponent } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { DocumentListModule } from '@alfresco/adf-content-services';
-import { DataTableModule, EmptyContentComponent, PaginationComponent } from '@alfresco/adf-core';
+import {
+  CustomEmptyContentTemplateDirective,
+  DataColumnComponent,
+  DataColumnListComponent,
+  EmptyContentComponent,
+  PaginationComponent
+} from '@alfresco/adf-core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SearchAiInputContainerComponent } from '../knowledge-retrieval/search-ai/search-ai-input-container/search-ai-input-container.component';
+import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({
   imports: [
     CommonModule,
-    DocumentListModule,
     DocumentListDirective,
     ContextActionsDirective,
-    DataTableModule,
     PaginationComponent,
     InfoDrawerComponent,
     PaginationDirective,
     PageLayoutComponent,
-    TranslateModule,
+    TranslatePipe,
     ToolbarComponent,
     SearchAiInputContainerComponent,
     EmptyContentComponent,
-    DynamicColumnComponent
+    DynamicColumnComponent,
+    DocumentListComponent,
+    CustomEmptyContentTemplateDirective,
+    DataColumnComponent,
+    DataColumnListComponent
   ],
   templateUrl: './shared-files.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.ts
@@ -26,8 +26,8 @@ import { ChangeDetectorRef, Component, Input, OnInit, ViewEncapsulation } from '
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { NavBarLinkRef } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
-import { IconModule } from '@alfresco/adf-core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { IconComponent } from '@alfresco/adf-core';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { ActiveLinkDirective } from '../directives/active-link.directive';
@@ -35,7 +35,7 @@ import { ActionDirective } from '../directives/action.directive';
 import { MenuPanelDirective } from '../directives/menu-panel.directive';
 
 @Component({
-  imports: [CommonModule, TranslateModule, IconModule, MatMenuModule, MatButtonModule, ActiveLinkDirective, ActionDirective, MenuPanelDirective],
+  imports: [CommonModule, TranslatePipe, IconComponent, MatMenuModule, MatButtonModule, ActiveLinkDirective, ActionDirective, MenuPanelDirective],
   selector: 'app-button-menu',
   templateUrl: './button-menu.component.html',
   host: { class: 'app-button-menu' },

--- a/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.ts
@@ -25,15 +25,15 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { NavBarLinkRef } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
-import { IconModule } from '@alfresco/adf-core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { IconComponent } from '@alfresco/adf-core';
 import { MatButtonModule } from '@angular/material/button';
 import { ActiveLinkDirective } from '../directives/active-link.directive';
 import { ActionDirective } from '../directives/action.directive';
 import { MatExpansionModule } from '@angular/material/expansion';
 
 @Component({
-  imports: [CommonModule, TranslateModule, IconModule, MatButtonModule, ActiveLinkDirective, ActionDirective, MatExpansionModule],
+  imports: [CommonModule, TranslatePipe, IconComponent, MatButtonModule, ActiveLinkDirective, ActionDirective, MatExpansionModule],
   selector: 'app-expand-menu',
   encapsulation: ViewEncapsulation.None,
   templateUrl: './expand-menu.component.html',

--- a/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.ts
@@ -26,12 +26,12 @@ import { Component, DestroyRef, EventEmitter, inject, OnInit, Output, ViewEncaps
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { AppExtensionService, AppSettingsService, ToolbarComponent } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, RouterModule, ToolbarComponent],
+  imports: [CommonModule, TranslatePipe, RouterModule, ToolbarComponent],
   selector: 'app-sidenav-header',
   templateUrl: `./sidenav-header.component.html`,
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.spec.ts
@@ -24,7 +24,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatMenuTrigger } from '@angular/material/menu';
-import { CoreTestingModule, UnitTestingUtils } from '@alfresco/adf-core';
+import { NoopTranslateModule, UnitTestingUtils } from '@alfresco/adf-core';
 import { UserMenuComponent } from './user-menu.component';
 import { AppExtensionService } from '@alfresco/aca-shared';
 
@@ -33,14 +33,11 @@ describe('UserMenuComponent', () => {
   let fixture: ComponentFixture<UserMenuComponent>;
   let testingUtils: UnitTestingUtils;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CoreTestingModule, UserMenuComponent],
-      providers: [{ provide: AppExtensionService, useValue: { runActionById() {} } }]
-    }).compileComponents();
-  });
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopTranslateModule, UserMenuComponent],
+      providers: [{ provide: AppExtensionService, useValue: { runActionById() {} } }]
+    });
     fixture = TestBed.createComponent(UserMenuComponent);
     testingUtils = new UnitTestingUtils(fixture.debugElement);
 

--- a/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.ts
@@ -26,12 +26,12 @@ import { AfterViewInit, Component, inject, Input, OnInit, QueryList, ViewChild, 
 import { ContentActionRef } from '@alfresco/adf-extensions';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatMenu, MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { ToolbarMenuItemComponent, UserProfileService } from '@alfresco/aca-shared';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatMenuModule, ToolbarMenuItemComponent],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatMenuModule, ToolbarMenuItemComponent],
   selector: 'aca-user-menu',
   templateUrl: './user-menu.component.html',
   styleUrls: ['./user-menu.component.scss'],

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -30,12 +30,12 @@ import { AppExtensionService, isLocked } from '@alfresco/aca-shared';
 import { NotificationService } from '@alfresco/adf-core';
 import { AlfrescoApiService } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatMenuModule, MatIconModule],
+  imports: [CommonModule, TranslatePipe, MatMenuModule, MatIconModule],
   selector: 'app-toggle-edit-offline',
   template: `
     <button mat-menu-item [attr.title]="nodeTitle | translate" (click)="onClick()">

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.ts
@@ -30,14 +30,14 @@ import { SelectionState } from '@alfresco/adf-extensions';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { LibraryFavoriteDirective } from '@alfresco/adf-content-services';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatIconModule, MatMenuModule, LibraryFavoriteDirective],
+  imports: [CommonModule, TranslatePipe, MatIconModule, MatMenuModule, LibraryFavoriteDirective],
   selector: 'app-toggle-favorite-library',
   template: `
     <button

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
@@ -31,11 +31,11 @@ import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { DocumentListService, NodeFavoriteDirective } from '@alfresco/adf-content-services';
 import { MatIconModule } from '@angular/material/icon';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatIconModule, MatMenuModule, NodeFavoriteDirective],
+  imports: [CommonModule, TranslatePipe, MatIconModule, MatMenuModule, NodeFavoriteDirective],
   selector: 'app-toggle-favorite',
   template: `
     <button mat-menu-item #favorites="adfFavorite" (toggle)="onToggleEvent()" [adf-node-favorite]="(selection$ | async).nodes">

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
@@ -28,11 +28,11 @@ import { Store } from '@ngrx/store';
 import { isInfoDrawerOpened, ToggleInfoDrawerAction } from '@alfresco/aca-shared/store';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule],
   selector: 'app-toggle-info-drawer',
   template: `
     <button

--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
@@ -31,12 +31,12 @@ import { Observable } from 'rxjs';
 import { LibraryMembershipDirective, LibraryMembershipErrorEvent, LibraryMembershipToggleEvent } from '@alfresco/adf-content-services';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { NotificationService } from '@alfresco/adf-core';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, LibraryMembershipDirective],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule, LibraryMembershipDirective],
   selector: 'app-toggle-join-library-button',
   template: `
     <button

--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
@@ -25,13 +25,13 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { ToggleJoinLibraryButtonComponent } from './toggle-join-library-button.component';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { LibraryMembershipDirective } from '@alfresco/adf-content-services';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatIconModule, MatMenuModule, LibraryMembershipDirective],
+  imports: [CommonModule, TranslatePipe, MatIconModule, MatMenuModule, LibraryMembershipDirective],
   selector: 'app-toggle-join-library-menu',
   template: `
     <button

--- a/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
@@ -30,14 +30,14 @@ import { take } from 'rxjs/operators';
 import { SharedLinkEntry } from '@alfresco/js-api';
 import { AppSettingsService, AutoDownloadService } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDialogModule } from '@angular/material/dialog';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, MatMenuModule, MatDialogModule],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule, MatMenuModule, MatDialogModule],
   selector: 'app-view-node',
   template: `
     <button

--- a/projects/aca-content/src/lib/components/trashcan/trashcan.component.ts
+++ b/projects/aca-content/src/lib/components/trashcan/trashcan.component.ts
@@ -33,25 +33,33 @@ import {
   UserProfileService
 } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
-import { DocumentListModule } from '@alfresco/adf-content-services';
-import { DataTableModule, EmptyContentComponent, PaginationComponent } from '@alfresco/adf-core';
+import { TranslatePipe } from '@ngx-translate/core';
+import {
+  CustomEmptyContentTemplateDirective,
+  DataColumnComponent,
+  DataColumnListComponent,
+  EmptyContentComponent,
+  PaginationComponent
+} from '@alfresco/adf-core';
 import { DocumentListDirective } from '../../directives/document-list.directive';
+import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({
   imports: [
     CommonModule,
-    TranslateModule,
-    DocumentListModule,
+    TranslatePipe,
     PaginationComponent,
-    DataTableModule,
     DocumentListDirective,
     ContextActionsDirective,
     PaginationDirective,
     PageLayoutComponent,
     ToolbarComponent,
     EmptyContentComponent,
-    DynamicColumnComponent
+    DynamicColumnComponent,
+    DocumentListComponent,
+    CustomEmptyContentTemplateDirective,
+    DataColumnComponent,
+    DataColumnListComponent
   ],
   templateUrl: './trashcan.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
@@ -32,13 +32,13 @@ import { AppService } from '@alfresco/aca-shared';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, ReactiveFormsModule, MatButtonModule, MatIconModule, MatDividerModule, MatFormFieldModule],
+  imports: [CommonModule, TranslatePipe, ReactiveFormsModule, MatButtonModule, MatIconModule, MatDividerModule, MatFormFieldModule],
   selector: 'app-view-profile',
   templateUrl: './view-profile.component.html',
   styleUrls: ['./view-profile.component.scss'],

--- a/projects/aca-content/src/lib/dialogs/folder-details/folder-information.component.ts
+++ b/projects/aca-content/src/lib/dialogs/folder-details/folder-information.component.ts
@@ -27,7 +27,7 @@ import { CommonModule } from '@angular/common';
 import { DIALOG_COMPONENT_DATA, IconComponent, LocalizedDatePipe, TimeAgoPipe } from '@alfresco/adf-core';
 import { Node, SizeDetails } from '@alfresco/js-api';
 import { MatDividerModule } from '@angular/material/divider';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { ContentService, NodesApiService } from '@alfresco/adf-content-services';
 import { catchError, concatMap, delay, expand, first, switchMap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -47,7 +47,7 @@ class FolderDetails {
 
 @Component({
   selector: 'app-folder-info',
-  imports: [CommonModule, MatDividerModule, TimeAgoPipe, TranslateModule, LocalizedDatePipe, IconComponent],
+  imports: [CommonModule, MatDividerModule, TimeAgoPipe, TranslatePipe, LocalizedDatePipe, IconComponent],
   templateUrl: './folder-information.component.html',
   styleUrls: ['./folder-information.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.ts
+++ b/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.ts
@@ -30,13 +30,13 @@ import { Store } from '@ngrx/store';
 import { AppStore, CreateFromTemplate } from '@alfresco/aca-shared/store';
 import { TranslationService } from '@alfresco/adf-core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatDialogModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [CommonModule, TranslatePipe, MatDialogModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
   templateUrl: './create-from-template.dialog.html',
   styleUrls: ['./create-from-template.dialog.scss'],
   selector: 'app-create-from-template-dialog',

--- a/projects/aca-content/src/lib/services/modal-ai.service.spec.ts
+++ b/projects/aca-content/src/lib/services/modal-ai.service.spec.ts
@@ -24,11 +24,10 @@
 
 import { ModalAiService } from './modal-ai.service';
 import { TestBed } from '@angular/core/testing';
-import { ContentTestingModule } from '@alfresco/adf-content-services';
 import { MatDialog, MatDialogConfig, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Params } from '@angular/router';
 import { of, Subject } from 'rxjs';
-import { StorageService, UnsavedChangesDialogComponent } from '@alfresco/adf-core';
+import { NoopTranslateModule, StorageService, UnsavedChangesDialogComponent } from '@alfresco/adf-core';
 
 describe('ModalAiService', () => {
   const mockQueryParams = new Subject<Params>();
@@ -39,7 +38,7 @@ describe('ModalAiService', () => {
 
   const setupBeforeEach = (query: string, storageGetItem: string) => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule, MatDialogModule],
+      imports: [NoopTranslateModule, MatDialogModule],
       providers: [
         {
           provide: StorageService,

--- a/projects/aca-content/src/lib/services/search-ai-navigation.service.spec.ts
+++ b/projects/aca-content/src/lib/services/search-ai-navigation.service.spec.ts
@@ -25,7 +25,8 @@
 import { SearchAiNavigationService } from './search-ai-navigation.service';
 import { Params, Router } from '@angular/router';
 import { TestBed } from '@angular/core/testing';
-import { ContentTestingModule, SearchAiService } from '@alfresco/adf-content-services';
+import { SearchAiService } from '@alfresco/adf-content-services';
+import { NoopTranslateModule } from '@alfresco/adf-core';
 
 describe('SearchAiNavigationService', () => {
   let service: SearchAiNavigationService;
@@ -36,7 +37,7 @@ describe('SearchAiNavigationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ContentTestingModule]
+      imports: [NoopTranslateModule]
     });
     service = TestBed.inject(SearchAiNavigationService);
     router = TestBed.inject(Router);

--- a/projects/aca-content/src/lib/testing/app-testing.module.ts
+++ b/projects/aca-content/src/lib/testing/app-testing.module.ts
@@ -23,9 +23,8 @@
  */
 
 import { NgModule } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { AuthenticationService, PageTitleService, TranslationMock, TranslationService } from '@alfresco/adf-core';
+import { AuthenticationService, NoopTranslateModule, PageTitleService } from '@alfresco/adf-core';
 import { AlfrescoApiService, AlfrescoApiServiceMock, DiscoveryApiService, SearchQueryBuilderService } from '@alfresco/adf-content-services';
 import { RepositoryInfo, VersionInfo } from '@alfresco/js-api';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
@@ -42,11 +41,11 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 @NgModule({
-  exports: [RouterTestingModule, TranslateModule],
+  exports: [RouterTestingModule],
   imports: [
     NoopAnimationsModule,
+    NoopTranslateModule,
     RouterTestingModule,
-    TranslateModule.forRoot(),
     StoreModule.forRoot(
       { app: appReducer },
       {
@@ -65,7 +64,6 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
   providers: [
     SearchQueryBuilderService,
     { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
-    { provide: TranslationService, useClass: TranslationMock },
     { provide: DocumentBasePageService, useExisting: ContentManagementService },
     {
       provide: DiscoveryApiService,

--- a/projects/aca-content/viewer/src/lib/services/viewer.service.spec.ts
+++ b/projects/aca-content/viewer/src/lib/services/viewer.service.spec.ts
@@ -23,12 +23,11 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { TranslationMock, TranslationService, UserPreferencesService } from '@alfresco/adf-core';
+import { NoopTranslateModule, UserPreferencesService } from '@alfresco/adf-core';
 import { ContentApiService } from '@alfresco/aca-shared';
 import { FavoritePaging, NodePaging, SharedLinkPaging } from '@alfresco/js-api';
 import { ViewerService } from './viewer.service';
 import { of } from 'rxjs';
-import { TranslateModule } from '@ngx-translate/core';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 const list = {
@@ -69,14 +68,8 @@ describe('ViewerService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
-      providers: [
-        { provide: TranslationService, useClass: TranslationMock },
-        ViewerService,
-        UserPreferencesService,
-        ContentApiService,
-        provideHttpClient(withInterceptorsFromDi())
-      ]
+      imports: [NoopTranslateModule],
+      providers: [ViewerService, UserPreferencesService, ContentApiService, provideHttpClient(withInterceptorsFromDi())]
     });
 
     preferences = TestBed.inject(UserPreferencesService);

--- a/projects/aca-shared/src/lib/components/generic-error/generic-error.component.ts
+++ b/projects/aca-shared/src/lib/components/generic-error/generic-error.component.ts
@@ -24,10 +24,10 @@
 
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
-  imports: [MatIconModule, TranslateModule],
+  imports: [MatIconModule, TranslatePipe],
   selector: 'aca-generic-error',
   templateUrl: './generic-error.component.html',
   styleUrls: ['./generic-error.component.scss'],

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
@@ -31,15 +31,24 @@ import { AppExtensionService } from '../../services/app.extension.service';
 import { ContentApiService } from '../../services/content-api.service';
 import { CommonModule } from '@angular/common';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { InfoDrawerModule } from '@alfresco/adf-core';
-import { TranslateModule } from '@ngx-translate/core';
+import { InfoDrawerComponent as AdfInfoDrawerComponent, InfoDrawerTabComponent } from '@alfresco/adf-core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { A11yModule } from '@angular/cdk/a11y';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
 import { ContentService, NodesApiService } from '@alfresco/adf-content-services';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatProgressBarModule, InfoDrawerModule, A11yModule, ToolbarComponent, DynamicTabComponent],
+  imports: [
+    CommonModule,
+    TranslatePipe,
+    MatProgressBarModule,
+    AdfInfoDrawerComponent,
+    A11yModule,
+    ToolbarComponent,
+    DynamicTabComponent,
+    InfoDrawerTabComponent
+  ],
   selector: 'aca-info-drawer',
   templateUrl: './info-drawer.component.html',
   encapsulation: ViewEncapsulation.None

--- a/projects/aca-shared/src/lib/components/locked-by/locked-by.component.ts
+++ b/projects/aca-shared/src/lib/components/locked-by/locked-by.component.ts
@@ -24,11 +24,11 @@
 
 import { ChangeDetectionStrategy, Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { NodeEntry } from '@alfresco/js-api';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  imports: [TranslateModule, MatIconModule],
+  imports: [TranslatePipe, MatIconModule],
   selector: 'aca-locked-by',
   template: `
     <mat-icon class="aca-locked-by--icon">lock</mat-icon>

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -25,7 +25,7 @@
 import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { A11yModule } from '@angular/cdk/a11y';
@@ -35,7 +35,7 @@ export interface OpenInAppDialogOptions {
   appStoreUrl: string;
 }
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule, A11yModule, MatDialogModule],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule, A11yModule, MatDialogModule],
   selector: 'aca-open-in-app',
   templateUrl: './open-in-app.component.html',
   styleUrls: ['./open-in-app.component.scss'],

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
@@ -26,13 +26,13 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AppService } from '../../services/app.service';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatIconModule],
   selector: 'aca-page-layout',
   templateUrl: './page-layout.component.html',
   styleUrls: ['./page-layout.component.scss'],

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
@@ -28,9 +28,9 @@ import { AppExtensionService } from '../../../services/app.extension.service';
 import { ThemePalette } from '@angular/material/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { IconModule } from '@alfresco/adf-core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item.component';
+import { IconComponent } from '@alfresco/adf-core';
 
 export enum ToolbarButtonType {
   ICON_BUTTON = 'icon-button',
@@ -40,7 +40,7 @@ export enum ToolbarButtonType {
 }
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, IconModule, ToolbarMenuItemComponent],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, ToolbarMenuItemComponent, IconComponent],
   selector: 'app-toolbar-button',
   templateUrl: './toolbar-button.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -27,12 +27,12 @@ import { ContentActionRef, DynamicExtensionComponent } from '@alfresco/adf-exten
 import { AppExtensionService } from '../../../services/app.extension.service';
 import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { IconComponent } from '@alfresco/adf-core';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatMenuModule, MatDividerModule, IconComponent, DynamicExtensionComponent],
+  imports: [CommonModule, TranslatePipe, MatMenuModule, MatDividerModule, IconComponent, DynamicExtensionComponent],
   selector: 'app-toolbar-menu-item',
   templateUrl: './toolbar-menu-item.component.html',
   styleUrls: ['./toolbar-menu-item.component.scss'],

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.ts
@@ -29,11 +29,11 @@ import { ThemePalette } from '@angular/material/core';
 import { ToolbarMenuItemComponent } from '../toolbar-menu-item/toolbar-menu-item.component';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { IconComponent } from '@alfresco/adf-core';
 
 @Component({
-  imports: [CommonModule, TranslateModule, MatButtonModule, MatMenuModule, ToolbarMenuItemComponent, IconComponent, DynamicExtensionComponent],
+  imports: [CommonModule, TranslatePipe, MatButtonModule, MatMenuModule, ToolbarMenuItemComponent, IconComponent, DynamicExtensionComponent],
   selector: 'app-toolbar-menu',
   templateUrl: './toolbar-menu.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/aca-shared/src/lib/services/app.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.service.spec.ts
@@ -26,15 +26,14 @@ import { AppService } from './app.service';
 import { TestBed } from '@angular/core/testing';
 import {
   AuthenticationService,
+  NoopAuthModule,
+  NoopTranslateModule,
   NotificationService,
   PageTitleService,
   StorageService,
-  TranslationMock,
-  TranslationService,
   UserPreferencesService
 } from '@alfresco/adf-core';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import {
   AlfrescoApiService,
   AlfrescoApiServiceMock,
@@ -46,11 +45,8 @@ import {
 } from '@alfresco/adf-content-services';
 import { ActivatedRoute } from '@angular/router';
 import { provideMockStore } from '@ngrx/store/testing';
-import { CommonModule } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RepositoryInfo, VersionInfo } from '@alfresco/js-api';
 import { MatDialogModule } from '@angular/material/dialog';
-import { TranslateModule } from '@ngx-translate/core';
 import { Store } from '@ngrx/store';
 import { ContentApiService } from './content-api.service';
 import { AppSettingsService, UserProfileService } from '@alfresco/aca-shared';
@@ -73,7 +69,7 @@ describe('AppService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CommonModule, TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), MatDialogModule, MatSnackBarModule],
+      imports: [NoopTranslateModule, NoopAuthModule, MatDialogModule, MatSnackBarModule],
       providers: [
         SearchQueryBuilderService,
         provideMockStore({}),
@@ -106,23 +102,12 @@ describe('AppService', () => {
           useClass: AlfrescoApiServiceMock
         },
         {
-          provide: AuthenticationService,
-          useValue: {
-            onLogin: new Subject<any>(),
-            onLogout: new Subject<any>(),
-            isLoggedIn: () => false,
-            getUsername: () => null
-          }
-        },
-        { provide: TranslationService, useClass: TranslationMock },
-        {
           provide: UserPreferencesService,
           useValue: {
             setStoragePrefix: () => null,
             getPropertyKey: (property: string) => `prefix__${property}`
           }
-        },
-        provideHttpClient(withInterceptorsFromDi())
+        }
       ]
     });
 

--- a/projects/aca-shared/store/src/effects/router.effects.spec.ts
+++ b/projects/aca-shared/store/src/effects/router.effects.spec.ts
@@ -25,7 +25,7 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { Store, StoreModule } from '@ngrx/store';
-import { CoreTestingModule, SnackbarContentComponent } from '@alfresco/adf-core';
+import { NoopTranslateModule, SnackbarContentComponent } from '@alfresco/adf-core';
 import { RouterEffects } from './router.effects';
 import {
   AppStore,
@@ -46,7 +46,7 @@ describe('NodeEffects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CoreTestingModule, StoreModule.forRoot({}), EffectsModule.forRoot([RouterEffects])]
+      imports: [NoopTranslateModule, StoreModule.forRoot({}), EffectsModule.forRoot([RouterEffects])]
     });
 
     store = TestBed.inject(Store);


### PR DESCRIPTION
Updates related to:
https://github.com/Alfresco/alfresco-ng2-components/pull/10998

Migrate to new i18n layer (`TranslatePipe` instead of `TranslateModule`, use `NoopTranslateModule` for tests)
