### PR TITLE
Release from branch workflow fix

### DIFF
--- a/.github/actions/update-library-versions/action.yml
+++ b/.github/actions/update-library-versions/action.yml
@@ -17,7 +17,7 @@ runs:
       run: |
         VERSION_IN_PACKAGE_JSON=$(jq -cr '.version' < package.json)
 
-        if [[ ${{ inputs.branch_name }} =~ ^master.*?$ ]] ; then
+        if [[ ${{ inputs.branch_name }} =~ ^master.*?$ ]] || [[ "${{ inputs.branch_name }}" == release/* ]] ; then
           NEW_LIBRARY_VERSION="$VERSION_IN_PACKAGE_JSON"
         else
           NEW_LIBRARY_VERSION="${VERSION_IN_PACKAGE_JSON}-${{ github.run_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ on:
     branches:
       - master
       - develop
-      - release/**
 
 env:
   BASE_URL: ${{ secrets.PIPELINE_ENV_URL }}


### PR DESCRIPTION
When releasing from HF branches libraries version were incorrectly bumped, also the workflow was triggered upon push on release branches