### PR TITLE
[ACS-10035] Ensure ADW handles no PUT for preferences API method in ACS below 25.x v. [PoC]

### DIFF
--- a/docs/extending/rules-list.md
+++ b/docs/extending/rules-list.md
@@ -76,4 +76,10 @@ or not.
 | 1.7.0   | app.navigation.isPreview        | Current page is **Preview**.                                     |
 | 5.1.1   | app.navigation.isDetails        | User is currently on the **Folder Details** page.                |
 
+#### ACS Versions compatibility Rules/Evaluators
 
+Rules/Evaluators created for specific features in ADW to be checked if supported in current ACS version. Evaluators are created using  **createVersionRule** helper function locking specific version number into the rule.
+
+| Version | Key                             | Description                                                              |
+|---------|---------------------------------|--------------------------------------------------------------------------|
+| 8.1.0   | isSavedSearchAvailable          | Checks whether current ACS version supports PUT method in Preferences API|

--- a/docs/extending/rules-list.md
+++ b/docs/extending/rules-list.md
@@ -80,6 +80,6 @@ or not.
 
 Rules/Evaluators created for specific features in ADW to be checked if supported in current ACS version. Evaluators are created using  **createVersionRule** helper function locking specific version number into the rule.
 
-| Version | Key                             | Description                                                              |
-|---------|---------------------------------|--------------------------------------------------------------------------|
-| 8.1.0   | isSavedSearchAvailable          | Checks whether current ACS version supports PUT method in Preferences API|
+| Version | Key                             | Description                                                               |
+|---------|---------------------------------|---------------------------------------------------------------------------|
+| 8.1.0   | isSavedSearchAvailable          | Checks whether current ACS version supports PUT method in Preferences API |

--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -212,7 +212,10 @@
         "items": [
           {
             "id": "app.search.navbar",
-            "component": "app.search.navbar"
+            "component": "app.search.navbar",
+            "rules": {
+              "visible": "isSavedSearchAvailable"
+            }
           }
         ]
       }

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -69,7 +69,6 @@ import { SearchResultsRowComponent } from './components/search/search-results-ro
 import { BulkActionsDropdownComponent } from './components/bulk-actions-dropdown/bulk-actions-dropdown.component';
 import { AgentsButtonComponent } from './components/knowledge-retrieval/search-ai/agents-button/agents-button.component';
 import { SaveSearchSidenavComponent } from './components/search/search-save/sidenav/save-search-sidenav.component';
-import { AcsVersionManagerService } from './services/acs-version-manager.service';
 
 @NgModule({
   imports: [ContentModule.forRoot(), AppStoreModule, HammerModule],
@@ -167,8 +166,7 @@ import { AcsVersionManagerService } from './services/acs-version-manager.service
         'app.areTagsEnabled': rules.areTagsEnabled,
         'app.areCategoriesEnabled': rules.areCategoriesEnabled
       }
-    }),
-    AcsVersionManagerService
+    })
   ]
 })
 export class ContentServiceExtensionModule {}

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -69,6 +69,7 @@ import { SearchResultsRowComponent } from './components/search/search-results-ro
 import { BulkActionsDropdownComponent } from './components/bulk-actions-dropdown/bulk-actions-dropdown.component';
 import { AgentsButtonComponent } from './components/knowledge-retrieval/search-ai/agents-button/agents-button.component';
 import { SaveSearchSidenavComponent } from './components/search/search-save/sidenav/save-search-sidenav.component';
+import { AcsVersionManagerService } from './services/acs-version-manager.service';
 
 @NgModule({
   imports: [ContentModule.forRoot(), AppStoreModule, HammerModule],
@@ -134,6 +135,7 @@ import { SaveSearchSidenavComponent } from './components/search/search-save/side
         isSmartFolder: rules.isSmartFolder,
         isMultiSelection: rules.isMultiselection,
         canPrintFile: rules.canPrintFile,
+        isSavedSearchAvailable: rules.isSavedSearchAvailable,
 
         'app.selection.canDelete': rules.canDeleteSelection,
         'app.selection.canDownload': rules.canDownloadSelection,
@@ -165,7 +167,8 @@ import { SaveSearchSidenavComponent } from './components/search/search-save/side
         'app.areTagsEnabled': rules.areTagsEnabled,
         'app.areCategoriesEnabled': rules.areCategoriesEnabled
       }
-    })
+    }),
+    AcsVersionManagerService
   ]
 })
 export class ContentServiceExtensionModule {}

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -26,7 +26,7 @@
               <div class="aca-content__advanced-filters--header">
                 <p>{{ 'APP.BROWSE.SEARCH.ADVANCED_FILTERS' | translate }}</p>
                 <div class="aca-content__advanced-filters--header--action-buttons">
-                  @if('isSavedSearchAvailable' | isFeatureSupportedInCurrentAcs ) {
+                  @if('isSavedSearchAvailable' | isFeatureSupportedInCurrentAcs | async) {
                     <button
                       *ngIf="initialSavedSearch !== undefined else saveSearchButton"
                       mat-button

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -26,7 +26,7 @@
               <div class="aca-content__advanced-filters--header">
                 <p>{{ 'APP.BROWSE.SEARCH.ADVANCED_FILTERS' | translate }}</p>
                 <div class="aca-content__advanced-filters--header--action-buttons">
-                  @if('isSavedSearchAvailable' | IsFeatureSupportedInCurrentAcs ) {
+                  @if('isSavedSearchAvailable' | isFeatureSupportedInCurrentAcs ) {
                     <button
                       *ngIf="initialSavedSearch !== undefined else saveSearchButton"
                       mat-button
@@ -38,7 +38,6 @@
                       {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
                       <mat-icon iconPositionEnd>keyboard_arrow_down</mat-icon>
                     </button>
-                  }
                   <mat-menu #saveSearchOptionsMenu="matMenu">
                     <button
                       mat-menu-item
@@ -68,6 +67,7 @@
                       {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
                     </button>
                   </ng-template>
+                }
                   <button
                     mat-button
                     adf-reset-search

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.html
@@ -26,17 +26,19 @@
               <div class="aca-content__advanced-filters--header">
                 <p>{{ 'APP.BROWSE.SEARCH.ADVANCED_FILTERS' | translate }}</p>
                 <div class="aca-content__advanced-filters--header--action-buttons">
-                  <button
-                    *ngIf="initialSavedSearch !== undefined else saveSearchButton"
-                    mat-button
-                    [disabled]="!encodedQuery"
-                    class="aca-content__save-search-action"
-                    title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}"
-                    [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate "
-                    [matMenuTriggerFor]="saveSearchOptionsMenu">
-                    {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
-                    <mat-icon iconPositionEnd>keyboard_arrow_down</mat-icon>
-                  </button>
+                  @if('isSavedSearchAvailable' | IsFeatureSupportedInCurrentAcs ) {
+                    <button
+                      *ngIf="initialSavedSearch !== undefined else saveSearchButton"
+                      mat-button
+                      [disabled]="!encodedQuery"
+                      class="aca-content__save-search-action"
+                      title="{{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}"
+                      [attr.aria-label]="'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate "
+                      [matMenuTriggerFor]="saveSearchOptionsMenu">
+                      {{ 'APP.BROWSE.SEARCH.SAVE_SEARCH.ACTION_BUTTON' | translate }}
+                      <mat-icon iconPositionEnd>keyboard_arrow_down</mat-icon>
+                    </button>
+                  }
                   <mat-menu #saveSearchOptionsMenu="matMenu">
                     <button
                       mat-menu-item

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
@@ -24,6 +24,7 @@
 
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { SearchResultsComponent } from './search-results.component';
+import { Pipe, PipeTransform } from '@angular/core';
 import { AppConfigService, NotificationService, TranslationService } from '@alfresco/adf-core';
 import { Store } from '@ngrx/store';
 import { NavigateToFolder } from '@alfresco/aca-shared/store';
@@ -32,7 +33,7 @@ import { SavedSearchesService, SearchQueryBuilderService } from '@alfresco/adf-c
 import { ActivatedRoute, Event, NavigationStart, Params, Router } from '@angular/router';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { AppTestingModule } from '../../../testing/app-testing.module';
-import { AppExtensionService, AppService } from '@alfresco/aca-shared';
+import { AppService } from '@alfresco/aca-shared';
 import { MatSnackBarModule, MatSnackBarRef } from '@angular/material/snack-bar';
 import { Buffer } from 'buffer';
 import { testHeader } from '../../../testing/document-base-page-utils';
@@ -41,6 +42,13 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatMenuHarness } from '@angular/material/menu/testing';
+
+@Pipe({ name: 'isFeatureSupportedInCurrentAcs', standalone: true })
+class MockIsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
+  transform() {
+    return of(true);
+  }
+}
 
 describe('SearchComponent', () => {
   let component: SearchResultsComponent;
@@ -112,6 +120,12 @@ describe('SearchComponent', () => {
       ]
     });
 
+    TestBed.overrideComponent(SearchResultsComponent, {
+      add: {
+        imports: [MockIsFeatureSupportedInCurrentAcsPipe]
+      }
+    });
+
     config = TestBed.inject(AppConfigService);
     store = TestBed.inject(Store);
     queryBuilder = TestBed.inject(SearchQueryBuilderService);
@@ -131,13 +145,6 @@ describe('SearchComponent', () => {
     component = fixture.componentInstance;
 
     spyOn(queryBuilder, 'update').and.stub();
-
-    // Mock AppExtensionService methods
-    spyOn(AppExtensionService.prototype, 'isFeatureSupported').and.returnValue(true);
-    spyOn(AppExtensionService.prototype, 'getCreateActions').and.returnValue(of([]));
-    spyOn(AppExtensionService.prototype, 'getAllowedToolbarActions').and.returnValue(of([]));
-    spyOn(AppExtensionService.prototype, 'getBulkActions').and.returnValue(of([]));
-    spyOn(AppExtensionService.prototype, 'getViewerToolbarActions').and.returnValue(of([]));
 
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
@@ -31,7 +31,7 @@ import { NavigateToFolder } from '@alfresco/aca-shared/store';
 import { Pagination, SearchRequest } from '@alfresco/js-api';
 import { SavedSearchesService, SearchQueryBuilderService } from '@alfresco/adf-content-services';
 import { ActivatedRoute, Event, NavigationStart, Params, Router } from '@angular/router';
-import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
+import { BehaviorSubject, Observable, of, Subject, throwError } from 'rxjs';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 import { AppService } from '@alfresco/aca-shared';
 import { MatSnackBarModule, MatSnackBarRef } from '@angular/material/snack-bar';
@@ -43,9 +43,9 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 
-@Pipe({ name: 'isFeatureSupportedInCurrentAcs', standalone: true })
+@Pipe({ name: 'isFeatureSupportedInCurrentAcs' })
 class MockIsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
-  transform() {
+  transform(): Observable<boolean> {
     return of(true);
   }
 }

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
@@ -32,7 +32,7 @@ import { SavedSearchesService, SearchQueryBuilderService } from '@alfresco/adf-c
 import { ActivatedRoute, Event, NavigationStart, Params, Router } from '@angular/router';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { AppTestingModule } from '../../../testing/app-testing.module';
-import { AppService } from '@alfresco/aca-shared';
+import { AppExtensionService, AppService } from '@alfresco/aca-shared';
 import { MatSnackBarModule, MatSnackBarRef } from '@angular/material/snack-bar';
 import { Buffer } from 'buffer';
 import { testHeader } from '../../../testing/document-base-page-utils';
@@ -131,6 +131,13 @@ describe('SearchComponent', () => {
     component = fixture.componentInstance;
 
     spyOn(queryBuilder, 'update').and.stub();
+
+    // Mock AppExtensionService methods
+    spyOn(AppExtensionService.prototype, 'isFeatureSupported').and.returnValue(true);
+    spyOn(AppExtensionService.prototype, 'getCreateActions').and.returnValue(of([]));
+    spyOn(AppExtensionService.prototype, 'getAllowedToolbarActions').and.returnValue(of([]));
+    spyOn(AppExtensionService.prototype, 'getBulkActions').and.returnValue(of([]));
+    spyOn(AppExtensionService.prototype, 'getViewerToolbarActions').and.returnValue(of([]));
 
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -88,6 +88,7 @@ import { SaveSearchDirective } from '../search-save/directive/save-search.direct
 import { combineLatest, of } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatMenuModule } from '@angular/material/menu';
+import { IsFeatureSupportedInCurrentAcsPipe } from '../../../pipes/is-feature-supported.pipe';
 
 @Component({
   imports: [
@@ -121,7 +122,8 @@ import { MatMenuModule } from '@angular/material/menu';
     ViewerToolbarComponent,
     BulkActionsDropdownComponent,
     SearchAiInputContainerComponent,
-    SaveSearchDirective
+    SaveSearchDirective,
+    IsFeatureSupportedInCurrentAcsPipe
   ],
   selector: 'aca-search-results',
   templateUrl: './search-results.component.html',

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { IsFeatureSupportedInCurrentAcsPipe } from './is-feature-supported.pipe';
+
+class MockAppExtensionService {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isFeatureSupported(_feature: string) {
+    return true;
+  }
+}
+
+describe('IsFeatureSupportedInCurrentAcsPipe', () => {
+  it('should create an instance', () => {
+    const pipe = new IsFeatureSupportedInCurrentAcsPipe(new MockAppExtensionService() as any);
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should call isFeatureSupported in AppExtensionService', () => {
+    const service = new MockAppExtensionService();
+    spyOn(service, 'isFeatureSupported').and.returnValue(false);
+    const pipe = new IsFeatureSupportedInCurrentAcsPipe(service as any);
+    expect(pipe.transform('someFeature')).toBe(false);
+    expect(service.isFeatureSupported).toHaveBeenCalledWith('someFeature');
+  });
+});

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
@@ -22,6 +22,7 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { of } from 'rxjs';
 import { IsFeatureSupportedInCurrentAcsPipe } from './is-feature-supported.pipe';
 
 class MockAppExtensionService {
@@ -32,16 +33,27 @@ class MockAppExtensionService {
 }
 
 describe('IsFeatureSupportedInCurrentAcsPipe', () => {
+  let serviceSpy: jasmine.SpyObj<MockAppExtensionService>;
+  let storeSpy: jasmine.SpyObj<any>;
+
+  beforeEach(() => {
+    serviceSpy = jasmine.createSpyObj('MockAppExtensionService', ['isFeatureSupported']);
+    storeSpy = jasmine.createSpyObj('Store', ['dispatch', 'select']);
+  });
+
   it('should create an instance', () => {
-    const pipe = new IsFeatureSupportedInCurrentAcsPipe(new MockAppExtensionService() as any);
+    const pipe = new IsFeatureSupportedInCurrentAcsPipe(serviceSpy as any, storeSpy);
     expect(pipe).toBeTruthy();
   });
 
-  it('should call isFeatureSupported in AppExtensionService', () => {
-    const service = new MockAppExtensionService();
-    spyOn(service, 'isFeatureSupported').and.returnValue(false);
-    const pipe = new IsFeatureSupportedInCurrentAcsPipe(service as any);
-    expect(pipe.transform('someFeature')).toBe(false);
-    expect(service.isFeatureSupported).toHaveBeenCalledWith('someFeature');
+  it('should call isFeatureSupported in AppExtensionService', (done) => {
+    serviceSpy.isFeatureSupported.and.returnValue(false);
+    storeSpy.select.and.returnValue(of('7.4.0'));
+    const pipe = new IsFeatureSupportedInCurrentAcsPipe(serviceSpy as any, storeSpy);
+    pipe.transform('someFeature').subscribe((result) => {
+      expect(result).toBe(false);
+      expect(serviceSpy.isFeatureSupported).toHaveBeenCalledWith('someFeature');
+      done();
+    });
   });
 });

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
@@ -24,32 +24,28 @@
 
 import { of } from 'rxjs';
 import { IsFeatureSupportedInCurrentAcsPipe } from './is-feature-supported.pipe';
-
-class MockAppExtensionService {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  isFeatureSupported(_feature: string) {
-    return true;
-  }
-}
+import { TestBed } from '@angular/core/testing';
+import { AppExtensionService } from '@alfresco/aca-shared';
+import { AppStore } from '@alfresco/aca-shared/store';
+import { Store } from '@ngrx/store';
 
 describe('IsFeatureSupportedInCurrentAcsPipe', () => {
-  let serviceSpy: jasmine.SpyObj<MockAppExtensionService>;
-  let storeSpy: jasmine.SpyObj<any>;
+  let serviceSpy: jasmine.SpyObj<AppExtensionService>;
+  let storeSpy: jasmine.SpyObj<Store<AppStore>>;
+  let pipe: IsFeatureSupportedInCurrentAcsPipe;
 
   beforeEach(() => {
-    serviceSpy = jasmine.createSpyObj('MockAppExtensionService', ['isFeatureSupported']);
+    serviceSpy = jasmine.createSpyObj('AppExtensionService', ['isFeatureSupported']);
     storeSpy = jasmine.createSpyObj('Store', ['dispatch', 'select']);
-  });
-
-  it('should create an instance', () => {
-    const pipe = new IsFeatureSupportedInCurrentAcsPipe(serviceSpy as any, storeSpy);
-    expect(pipe).toBeTruthy();
+    TestBed.configureTestingModule({
+      providers: [IsFeatureSupportedInCurrentAcsPipe, { provide: AppExtensionService, useValue: serviceSpy }, { provide: Store, useValue: storeSpy }]
+    });
+    pipe = TestBed.inject(IsFeatureSupportedInCurrentAcsPipe);
   });
 
   it('should call isFeatureSupported in AppExtensionService', (done) => {
     serviceSpy.isFeatureSupported.and.returnValue(false);
     storeSpy.select.and.returnValue(of('7.4.0'));
-    const pipe = new IsFeatureSupportedInCurrentAcsPipe(serviceSpy as any, storeSpy);
     pipe.transform('someFeature').subscribe((result) => {
       expect(result).toBe(false);
       expect(serviceSpy.isFeatureSupported).toHaveBeenCalledWith('someFeature');

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AppExtensionService } from '@alfresco/aca-shared';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'IsFeatureSupportedInCurrentAcs'
+})
+export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
+  constructor(private appExtensionsService: AppExtensionService) {}
+
+  transform(evaluatorId: string) {
+    return this.appExtensionsService.isFeatureSupported(evaluatorId);
+  }
+}

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -29,7 +29,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'IsFeatureSupportedInCurrentAcs'
 })
 export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
-  constructor(private appExtensionsService: AppExtensionService) {}
+  constructor(private readonly appExtensionsService: AppExtensionService) {}
 
   transform(evaluatorId: string) {
     return this.appExtensionsService.isFeatureSupported(evaluatorId);

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -26,7 +26,7 @@ import { AppExtensionService } from '@alfresco/aca-shared';
 import { Pipe, PipeTransform } from '@angular/core';
 import { AppStore, getCurrentACSVersion } from '@alfresco/aca-shared/store';
 import { Store } from '@ngrx/store';
-import { map } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 @Pipe({
   name: 'isFeatureSupportedInCurrentAcs'
@@ -34,10 +34,10 @@ import { map } from 'rxjs';
 export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
   constructor(
     private readonly appExtensionsService: AppExtensionService,
-    private store: Store<AppStore>
+    private readonly store: Store<AppStore>
   ) {}
 
-  transform(evaluatorId: string) {
+  transform(evaluatorId: string): Observable<boolean> {
     return this.store.select(getCurrentACSVersion).pipe(map(() => this.appExtensionsService.isFeatureSupported(evaluatorId)));
   }
 }

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -24,14 +24,20 @@
 
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { Pipe, PipeTransform } from '@angular/core';
+import { AppStore, getCurrentACSVersion } from '../../../../aca-shared/store/src/public-api';
+import { Store } from '@ngrx/store';
+import { map } from 'rxjs';
 
 @Pipe({
   name: 'isFeatureSupportedInCurrentAcs'
 })
 export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
-  constructor(private readonly appExtensionsService: AppExtensionService) {}
+  constructor(
+    private readonly appExtensionsService: AppExtensionService,
+    private store: Store<AppStore>
+  ) {}
 
   transform(evaluatorId: string) {
-    return this.appExtensionsService.isFeatureSupported(evaluatorId);
+    return this.store.select(getCurrentACSVersion).pipe(map(() => this.appExtensionsService.isFeatureSupported(evaluatorId)));
   }
 }

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -24,7 +24,7 @@
 
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { Pipe, PipeTransform } from '@angular/core';
-import { AppStore, getCurrentACSVersion } from '@alfresco/aca-shared/store';
+import { AppStore, getRepositoryStatus } from '@alfresco/aca-shared/store';
 import { Store } from '@ngrx/store';
 import { map, Observable } from 'rxjs';
 
@@ -38,6 +38,6 @@ export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
   ) {}
 
   transform(evaluatorId: string): Observable<boolean> {
-    return this.store.select(getCurrentACSVersion).pipe(map(() => this.appExtensionsService.isFeatureSupported(evaluatorId)));
+    return this.store.select(getRepositoryStatus).pipe(map(() => this.appExtensionsService.isFeatureSupported(evaluatorId)));
   }
 }

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -26,7 +26,7 @@ import { AppExtensionService } from '@alfresco/aca-shared';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'IsFeatureSupportedInCurrentAcs'
+  name: 'isFeatureSupportedInCurrentAcs'
 })
 export class IsFeatureSupportedInCurrentAcsPipe implements PipeTransform {
   constructor(private readonly appExtensionsService: AppExtensionService) {}

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -24,7 +24,7 @@
 
 import { AppExtensionService } from '@alfresco/aca-shared';
 import { Pipe, PipeTransform } from '@angular/core';
-import { AppStore, getCurrentACSVersion } from '../../../../aca-shared/store/src/public-api';
+import { AppStore, getCurrentACSVersion } from '@alfresco/aca-shared/store';
 import { Store } from '@ngrx/store';
 import { map } from 'rxjs';
 

--- a/projects/aca-content/src/public-api.ts
+++ b/projects/aca-content/src/public-api.ts
@@ -33,3 +33,4 @@ export * from './lib/services/content-url.service';
 export * from './lib/services/content-management.service';
 export * from './lib/components/info-drawer/comments-tab/external-node-permission-comments-tab.service';
 export * from './lib/utils/aca-search-utils';
+export * from './lib/pipes/is-feature-supported.pipe';

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1255,10 +1255,12 @@ describe('isVersionCompatible', () => {
   });
 
   it('handles versions with different number of segments', () => {
+    const versionDiffMinor = '25.1.0.1';
+    const versionDiffPatch = '25.0.1.1';
     expect(isVersionCompatible('25.1', '25.1.0')).toBe(true);
     expect(isVersionCompatible('25.1.1', '25.1')).toBe(true);
-    expect(isVersionCompatible('25.1.0.1', '25.1.0')).toBe(true);
-    expect(isVersionCompatible('25.0.1.1', '25.1.0')).toBe(false);
+    expect(isVersionCompatible(versionDiffMinor, '25.1.0')).toBe(true);
+    expect(isVersionCompatible(versionDiffPatch, '25.1.0')).toBe(false);
   });
 });
 

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1208,52 +1208,52 @@ describe('Versions compatibility', () => {
   }
 
   describe('isSavedSearchAvailable', () => {
-    it('returns true if ACS version is equal to minimal version', () => {
+    it('should return true if ACS version is equal to minimal version', () => {
       expect(isSavedSearchAvailable(makeContext('25.1.0'))).toBe(true);
     });
 
-    it('returns true if ACS version is greater than minimal version', () => {
+    it('should return true if ACS version is greater than minimal version', () => {
       expect(isSavedSearchAvailable(makeContext('25.2.0'))).toBe(true);
       expect(isSavedSearchAvailable(makeContext('26.0.0'))).toBe(true);
     });
 
-    it('returns false if ACS version is less than minimal version', () => {
+    it('should return false if ACS version is less than minimal version', () => {
       expect(isSavedSearchAvailable(makeContext('24.4.0'))).toBe(false);
       expect(isSavedSearchAvailable(makeContext('25.0.9'))).toBe(false);
     });
 
-    it('returns false if ACS version is missing', () => {
+    it('should return false if ACS version is missing', () => {
       expect(isSavedSearchAvailable(makeContext())).toBe(false);
       expect(isSavedSearchAvailable({ repository: {} } as any)).toBe(false);
     });
   });
 
   describe('createVersionRule', () => {
-    it('returns true if version is equal to minimal version', () => {
+    it('should return true if version is equal to minimal version', () => {
       const rule = createVersionRule('25.1.0');
       expect(rule(makeContext('25.1.0'))).toBe(true);
     });
 
-    it('returns true if version is greater than minimal version', () => {
+    it('should return true if version is greater than minimal version', () => {
       const rule = createVersionRule('25.1.0');
       expect(rule(makeContext('25.2.0'))).toBe(true);
       expect(rule(makeContext('26.0.0'))).toBe(true);
       expect(rule(makeContext('25.1.1'))).toBe(true);
     });
 
-    it('returns false if version is less than minimal version', () => {
+    it('should return false if version is less than minimal version', () => {
       const rule = createVersionRule('25.1.0');
       expect(rule(makeContext('25.0.9'))).toBe(false);
       expect(rule(makeContext('24.9.0'))).toBe(false);
     });
 
-    it('returns false if version is missing', () => {
+    it('should return false if version is missing', () => {
       const rule = createVersionRule('25.1.0');
       expect(rule(makeContext())).toBe(false);
       expect(rule({ repository: {} } as any)).toBe(false);
     });
 
-    it('handles versions with different number of segments', () => {
+    it('should handle versions with different number of segments', () => {
       const rule = createVersionRule('25.1.0');
       expect(rule(makeContext('25.1'))).toBe(true);
       expect(rule(makeContext('25.1.1'))).toBe(true);

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1223,13 +1223,8 @@ describe('Versions compatibility', () => {
     });
 
     it('returns false if ACS version is missing', () => {
-      expect(isSavedSearchAvailable(makeContext(undefined))).toBe(false);
+      expect(isSavedSearchAvailable(makeContext())).toBe(false);
       expect(isSavedSearchAvailable({ repository: {} } as any)).toBe(false);
-    });
-
-    it('handles version strings with extra text', () => {
-      expect(isSavedSearchAvailable(makeContext('25.1.0 (r12345-b1)'))).toBe(true);
-      expect(isSavedSearchAvailable(makeContext('24.9.0 (r12345-b1)'))).toBe(false);
     });
   });
 
@@ -1254,14 +1249,8 @@ describe('Versions compatibility', () => {
 
     it('returns false if version is missing', () => {
       const rule = createVersionRule('25.1.0');
-      expect(rule(makeContext(undefined))).toBe(false);
+      expect(rule(makeContext())).toBe(false);
       expect(rule({ repository: {} } as any)).toBe(false);
-    });
-
-    it('handles version strings with extra text', () => {
-      const rule = createVersionRule('25.1.0');
-      expect(rule(makeContext('25.1.0 (r12345-b1)'))).toBe(true);
-      expect(rule(makeContext('24.9.0 (r12345-b1)'))).toBe(false);
     });
 
     it('handles versions with different number of segments', () => {

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1255,8 +1255,8 @@ describe('isVersionCompatible', () => {
   });
 
   it('handles versions with different number of segments', () => {
-    const versionDiffMinor = '25.1.0.1';
-    const versionDiffPatch = '25.0.1.1';
+    const versionDiffMinor = '25.1.0.1-beta';
+    const versionDiffPatch = '25.0.1.1-rc';
     expect(isVersionCompatible('25.1', '25.1.0')).toBe(true);
     expect(isVersionCompatible('25.1.1', '25.1')).toBe(true);
     expect(isVersionCompatible(versionDiffMinor, '25.1.0')).toBe(true);

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import * as app from './app.rules';
-import { getFileExtension } from './app.rules';
+import { getFileExtension, isSavedSearchAvailable, isVersionCompatible } from './app.rules';
 import { TestRuleContext } from './test-rule-context';
 import { NodeEntry, RepositoryInfo, StatusInfo } from '@alfresco/js-api';
 import { ProfileState } from '@alfresco/adf-extensions';
@@ -1195,6 +1195,70 @@ describe('app.evaluators', () => {
       context.selection.first = { entry: { isFolder: true, aspectNames: ['smf:systemConfigSmartFolder'] } } as any;
       expect(app.isSmartFolder(context)).toBeTrue();
     });
+  });
+});
+
+describe('isSavedSearchAvailable', () => {
+  function makeContext(versionDisplay: string | undefined) {
+    return {
+      repository: {
+        version: versionDisplay ? { display: versionDisplay } : undefined
+      }
+    } as any;
+  }
+
+  it('returns true if ACS version is equal to minimal version', () => {
+    expect(isSavedSearchAvailable(makeContext('25.1.0'))).toBe(true);
+  });
+
+  it('returns true if ACS version is greater than minimal version', () => {
+    expect(isSavedSearchAvailable(makeContext('25.2.0'))).toBe(true);
+    expect(isSavedSearchAvailable(makeContext('26.0.0'))).toBe(true);
+  });
+
+  it('returns false if ACS version is less than minimal version', () => {
+    expect(isSavedSearchAvailable(makeContext('24.4.0'))).toBe(false);
+    expect(isSavedSearchAvailable(makeContext('25.0.9'))).toBe(false);
+  });
+
+  it('returns false if ACS version is missing', () => {
+    expect(isSavedSearchAvailable(makeContext(undefined))).toBe(false);
+    expect(isSavedSearchAvailable({ repository: {} } as any)).toBe(false);
+  });
+
+  it('handles version strings with extra text', () => {
+    expect(isSavedSearchAvailable(makeContext('25.1.0 (r12345-b1)'))).toBe(true);
+    expect(isSavedSearchAvailable(makeContext('24.9.0 (r12345-b1)'))).toBe(false);
+  });
+});
+
+describe('isVersionCompatible', () => {
+  it('returns true if current version is equal to minimal version', () => {
+    expect(isVersionCompatible('25.1.0', '25.1.0')).toBe(true);
+  });
+
+  it('returns true if current version is greater than minimal version', () => {
+    expect(isVersionCompatible('25.2.0', '25.1.0')).toBe(true);
+    expect(isVersionCompatible('26.0.0', '25.1.0')).toBe(true);
+    expect(isVersionCompatible('25.1.1', '25.1.0')).toBe(true);
+  });
+
+  it('returns false if current version is less than minimal version', () => {
+    expect(isVersionCompatible('25.0.9', '25.1.0')).toBe(false);
+    expect(isVersionCompatible('24.9.0', '25.1.0')).toBe(false);
+  });
+
+  it('returns false if any version is missing', () => {
+    expect(isVersionCompatible('', '25.1.0')).toBe(false);
+    expect(isVersionCompatible('25.1.0', '')).toBe(false);
+    expect(isVersionCompatible('', '')).toBe(false);
+  });
+
+  it('handles versions with different number of segments', () => {
+    expect(isVersionCompatible('25.1', '25.1.0')).toBe(true);
+    expect(isVersionCompatible('25.1.1', '25.1')).toBe(true);
+    expect(isVersionCompatible('25.1.0.1', '25.1.0')).toBe(true);
+    expect(isVersionCompatible('25.0.1.1', '25.1.0')).toBe(false);
   });
 });
 

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -483,6 +483,48 @@ export function canOpenWithOffice(context: AcaRuleContext): boolean {
   return context.permissions.check(file, ['update']);
 }
 
+/**
+ * Checks if user savedSearches are supported by current ACS version.
+ * JSON ref: `isSavedSearchAvailable`
+ */
+export const isSavedSearchAvailable = createVersionRule('25.1.0');
+
+/**
+ * Partially applies minimal version of a feature against a core compatibility evaluation.
+ * @param minimalVersion The minimal version to check against.
+ */
+function createVersionRule(minimalVersion: string): (context: RuleContext) => boolean {
+  return (context: RuleContext): boolean => {
+    const acsVersion = context.repository.version?.display?.split(' ')[0];
+    return isVersionCompatible(acsVersion, minimalVersion);
+  };
+}
+
+function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
+  if (!currentVersion || !minimalVersion) {
+    return false;
+  }
+
+  const currentParts = currentVersion.split('.').map(Number);
+  const minimalParts = minimalVersion.split('.').map(Number);
+  const maxLength = Math.max(currentParts.length, minimalParts.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const currentSegment = i < currentParts.length ? currentParts[i] : 0;
+    const minimalSegment = i < minimalParts.length ? minimalParts[i] : 0;
+
+    if (currentSegment > minimalSegment) {
+      return true;
+    }
+
+    if (currentSegment < minimalSegment) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function isSmartFolder(context: RuleContext): boolean {
   if (!context.selection?.isEmpty) {
     const node = context.selection.first;

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -500,7 +500,7 @@ export function createVersionRule(minimalVersion: string): (context: RuleContext
   };
 }
 
-export function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
+function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
   if (!currentVersion || !minimalVersion) {
     return false;
   }
@@ -510,8 +510,8 @@ export function isVersionCompatible(currentVersion: string, minimalVersion: stri
   const maxLength = Math.max(currentParts.length, minimalParts.length);
 
   for (let i = 0; i < maxLength; i++) {
-    const currentSegment = i < currentParts.length ? currentParts[i] : 0;
-    const minimalSegment = i < minimalParts.length ? minimalParts[i] : 0;
+    const currentSegment = currentParts[i] ?? 0;
+    const minimalSegment = minimalParts[i] ?? 0;
 
     if (currentSegment > minimalSegment) {
       return true;

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -493,14 +493,14 @@ export const isSavedSearchAvailable = createVersionRule('25.1.0');
  * Partially applies minimal version of a feature against a core compatibility evaluation.
  * @param minimalVersion The minimal version to check against.
  */
-function createVersionRule(minimalVersion: string): (context: RuleContext) => boolean {
+export function createVersionRule(minimalVersion: string): (context: RuleContext) => boolean {
   return (context: RuleContext): boolean => {
     const acsVersion = context.repository.version?.display?.split(' ')[0];
     return isVersionCompatible(acsVersion, minimalVersion);
   };
 }
 
-function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
+export function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
   if (!currentVersion || !minimalVersion) {
     return false;
   }

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -1697,4 +1697,10 @@ describe('AppExtensionService', () => {
 
     service.bulkActionExecuted();
   });
+
+  it('should call evaluateRule on isFeatureSupported', () => {
+    const evaluateRuleSpy = spyOn(extensions, 'evaluateRule').and.returnValue(true);
+    service.isFeatureSupported('someFeature');
+    expect(evaluateRuleSpy).toHaveBeenCalledWith('someFeature', service);
+  });
 });

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -592,4 +592,8 @@ export class AppExtensionService implements RuleContext {
   bulkActionExecuted(): void {
     this.bulkActionExecuted$.next();
   }
+
+  isFeatureSupported(feature: string) {
+    return this.extensions.evaluateRule(feature, this);
+  }
 }

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -593,7 +593,7 @@ export class AppExtensionService implements RuleContext {
     this.bulkActionExecuted$.next();
   }
 
-  isFeatureSupported(feature: string) {
+  isFeatureSupported(feature: string): boolean {
     return this.extensions.evaluateRule(feature, this);
   }
 }


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-10035

25.08 UPD:
- utilizing existing rules/extensions mechanism for managing supported version;
- adds new evaluator with helper functions
- adds pipe as alternative approach for hiding components
- extends AppExtensionService to support manual evaluator call


introduces:
1. AcsVersionManagerService: checks minimal version with current
2. IsFeatureAvailablePipe
4. configuration-based approach adding "acs-version-manger" prop in app.config