### PR TITLE
Proxy: remove dependency on ADF cli, cleanup

### DIFF
--- a/app/proxy.conf.js
+++ b/app/proxy.conf.js
@@ -1,26 +1,18 @@
-require('@alfresco/adf-cli/tooling').dotenvConfig({ path: process.env.ENV_FILE });
-
 const { BASE_URL } = process.env;
+console.log('Using backend URL: ' + BASE_URL || 'unknown');
 
 module.exports = {
-    "/alfresco": {
-        "target": BASE_URL,
-        "secure": false,
-        "pathRewrite": {
-            "^/alfresco/alfresco": ""
-        },
-        "changeOrigin": true,
-        'logLevel': 'debug',
-        onProxyReq: function(request) {
-          if(request["method"] !== "GET")
-          request.setHeader("origin", BASE_URL);
-        },
-        // workaround for REPO-2260
-        onProxyRes: function (proxyRes) {
-          const header = proxyRes.headers['www-authenticate'];
-          if (header?.startsWith('Basic')) {
-              proxyRes.headers['www-authenticate'] = 'x' + header;
-          }
+  '/alfresco': {
+    target: BASE_URL,
+    secure: false,
+    pathRewrite: {
+      '^/alfresco/alfresco': ''
+    },
+    changeOrigin: true,
+    onProxyReq: (request) => {
+      if (request['method'] !== 'GET') {
+        request.setHeader('origin', BASE_URL);
       }
     }
+  }
 };


### PR DESCRIPTION
- remove the need for ADF CLI and `require`
- remove unnecessary workarounds