### PR TITLE
[ACS-9765] Records Management lib and its content action restrictions

### DIFF
--- a/projects/aca-content/assets/app.extensions.json
+++ b/projects/aca-content/assets/app.extensions.json
@@ -987,7 +987,8 @@
                 "!app.navigation.isTrashcan",
                 "!app.navigation.isLibraries",
                 "app.selection.notEmpty",
-                "app.selection.canDelete"
+                "app.selection.canDelete",
+                "!app.selection.isRmaSystemContainer"
           ]
         }
       },
@@ -1003,7 +1004,8 @@
           "visible": [
             "app.selection.notEmpty",
             "!app.navigation.isTrashcan",
-            "!app.navigation.isLibraries"
+            "!app.navigation.isLibraries",
+            "!app.selection.isRmaSystemContainer"
           ]
         }
       },

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -153,6 +153,7 @@ import { IsFeatureSupportedInCurrentAcsPipe } from './pipes/is-feature-supported
         'app.selection.folder': rules.hasFolderSelected,
         'app.selection.folder.canUpdate': rules.canUpdateSelectedFolder,
         'app.selection.displayedKnowledgeRetrievalButton': rules.canDisplayKnowledgeRetrievalButton,
+        'app.selection.isRmaSystemContainer': rules.isRmaSystemContainer,
 
         'app.navigation.folder.canCreate': rules.canCreateFolder,
         'app.navigation.isTrashcan': rules.isTrashcan,

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -33,7 +33,12 @@ import {
   LibraryStatusColumnComponent,
   TrashcanNameColumnComponent
 } from '@alfresco/adf-content-services';
-import { DocumentBasePageService, ExtensionsDataLoaderGuard, provideContentAppExtensions } from '@alfresco/aca-shared';
+import {
+  DocumentBasePageService,
+  ExtensionsDataLoaderGuard,
+  EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE,
+  provideContentAppExtensions
+} from '@alfresco/aca-shared';
 import * as rules from '@alfresco/aca-shared/rules';
 import { AppStoreModule } from './store/app-store.module';
 import { provideAppExtensions, provideExtensions } from '@alfresco/adf-extensions';
@@ -66,6 +71,7 @@ import { SHELL_NAVBAR_MIN_WIDTH, ShellLayoutComponent } from '@alfresco/adf-core
 import { UserMenuComponent } from './components/sidenav/user-menu/user-menu.component';
 import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 import { SearchResultsRowComponent } from './components/search/search-results-row/search-results-row.component';
+import { AcaNodePermissionCommentsService } from './services/aca-node-permission-comments.service';
 import { BulkActionsDropdownComponent } from './components/bulk-actions-dropdown/bulk-actions-dropdown.component';
 import { AgentsButtonComponent } from './components/knowledge-retrieval/search-ai/agents-button/agents-button.component';
 import { SaveSearchSidenavComponent } from './components/search/search-save/sidenav/save-search-sidenav.component';
@@ -85,6 +91,11 @@ import { IsFeatureSupportedInCurrentAcsPipe } from './pipes/is-feature-supported
     {
       provide: MAT_DIALOG_DEFAULT_OPTIONS,
       useValue: { closeOnNavigation: true, hasBackdrop: true, autoFocus: true }
+    },
+    {
+      provide: EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE,
+      useClass: AcaNodePermissionCommentsService,
+      multi: true
     },
     provideExtensions({
       authGuards: {

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
@@ -42,7 +42,7 @@ describe('CommentsTabComponent', () => {
       imports: [NoopTranslateModule, CommentsTabComponent],
       providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
-        { provide: EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE, useValue: [{ canAddComments: () => canAddComment }] },
+        { provide: EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE, useValue: { canAddComments: () => canAddComment }, multi: true },
         { provide: AuthenticationService, useValue: { onLogout: of({}) } }
       ]
     });

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
@@ -24,11 +24,10 @@
 
 import { CommentsTabComponent } from './comments-tab.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NodePermissionService } from '@alfresco/aca-shared';
+import { EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE, NodePermissionService } from '@alfresco/aca-shared';
 import { Node } from '@alfresco/js-api';
 import { of } from 'rxjs';
 import { AuthenticationService, NoopTranslateModule } from '@alfresco/adf-core';
-import { ExternalNodePermissionCommentsTabService } from '@alfresco/aca-content';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
 
 describe('CommentsTabComponent', () => {
@@ -43,7 +42,7 @@ describe('CommentsTabComponent', () => {
       imports: [NoopTranslateModule, CommentsTabComponent],
       providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
-        { provide: ExternalNodePermissionCommentsTabService, useValue: { canAddComments: () => canAddComment } },
+        { provide: EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE, useValue: [{ canAddComments: () => canAddComment }] },
         { provide: AuthenticationService, useValue: { onLogout: of({}) } }
       ]
     });

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
@@ -22,12 +22,16 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input, OnInit, Optional, ViewEncapsulation } from '@angular/core';
+import { Component, Inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { isLocked, NodePermissionService } from '@alfresco/aca-shared';
+import {
+  EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE,
+  ExternalNodePermissionCommentsTabService,
+  isLocked,
+  NodePermissionService
+} from '@alfresco/aca-shared';
 import { MatCardModule } from '@angular/material/card';
 import { NodeCommentsComponent } from '@alfresco/adf-content-services';
-import { ExternalNodePermissionCommentsTabService } from './external-node-permission-comments-tab.service';
 
 @Component({
   imports: [MatCardModule, NodeCommentsComponent],
@@ -47,7 +51,8 @@ export class CommentsTabComponent implements OnInit {
 
   constructor(
     private readonly permission: NodePermissionService,
-    @Optional() private readonly externalPermissionNodeService: ExternalNodePermissionCommentsTabService
+    @Inject(EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE)
+    private readonly externalPermissionNodeService: ExternalNodePermissionCommentsTabService[]
   ) {}
 
   ngOnInit(): void {
@@ -56,8 +61,8 @@ export class CommentsTabComponent implements OnInit {
     }
     if (this.node.isFolder || (this.node.isFile && !isLocked({ entry: this.node }))) {
       this.canUpdateNode = this.permission.check(this.node, ['update']);
-      if (this.externalPermissionNodeService) {
-        this.canUpdateNode &&= this.externalPermissionNodeService.canAddComments(this.node);
+      if (this.externalPermissionNodeService?.length) {
+        this.canUpdateNode &&= this.externalPermissionNodeService.every((service) => service.canAddComments(this.node));
       }
     }
   }

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
@@ -58,12 +58,9 @@ export class CommentsTabComponent implements OnInit {
   ngOnInit(): void {
     if (!this.node) {
       this.canUpdateNode = false;
-    }
-    if (this.node.isFolder || (this.node.isFile && !isLocked({ entry: this.node }))) {
-      this.canUpdateNode = this.permission.check(this.node, ['update']);
-      if (this.externalPermissionNodeService?.length) {
-        this.canUpdateNode &&= this.externalPermissionNodeService.every((service) => service.canAddComments(this.node));
-      }
+    } else if (this.node.isFolder || (this.node.isFile && !isLocked({ entry: this.node }))) {
+      this.canUpdateNode =
+        this.permission.check(this.node, ['update']) && this.externalPermissionNodeService.every((service) => service.canAddComments(this.node));
     }
   }
 }

--- a/projects/aca-content/src/lib/services/aca-node-permission-comments.service.spec.ts
+++ b/projects/aca-content/src/lib/services/aca-node-permission-comments.service.spec.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Node } from '@alfresco/js-api';
+import { AcaNodePermissionCommentsService } from './aca-node-permission-comments.service';
+
+describe('AcaNodePermissionCommentsService', () => {
+  let service: AcaNodePermissionCommentsService;
+
+  beforeEach(() => {
+    service = new AcaNodePermissionCommentsService();
+  });
+
+  it('should return false when node type is blacklisted', () => {
+    const node = { nodeType: 'rma:hold', aspectNames: [] } as Node;
+
+    expect(service.canAddComments(node)).toBeFalse();
+  });
+
+  it('should return false when node has a blacklisted aspect', () => {
+    const node = { nodeType: 'cm:content', aspectNames: ['rma:frozen'] } as Node;
+
+    expect(service.canAddComments(node)).toBeFalse();
+  });
+
+  it('should return false when node has both blacklisted type and aspect', () => {
+    const node = { nodeType: 'rma:hold', aspectNames: ['rma:frozen'] } as Node;
+
+    expect(service.canAddComments(node)).toBeFalse();
+  });
+
+  it('should return true when node type and aspects are not blacklisted', () => {
+    const node = { nodeType: 'cm:content', aspectNames: ['cm:titled'] } as Node;
+
+    expect(service.canAddComments(node)).toBeTrue();
+  });
+
+  it('should return true when aspectNames is missing and node type is allowed', () => {
+    const node = { nodeType: 'cm:content' } as Node;
+
+    expect(service.canAddComments(node)).toBeTrue();
+  });
+});

--- a/projects/aca-content/src/lib/services/aca-node-permission-comments.service.ts
+++ b/projects/aca-content/src/lib/services/aca-node-permission-comments.service.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Node } from '@alfresco/js-api';
+import { ExternalNodePermissionCommentsTabService } from '@alfresco/aca-shared';
+
+type DenyRule = (node: Node) => boolean;
+
+export class AcaNodePermissionCommentsService implements ExternalNodePermissionCommentsTabService {
+  private readonly blacklistedTypes = new Set<string>(['rma:hold']);
+  private readonly blacklistedAspects = new Set<string>(['rma:frozen']);
+
+  private readonly denyRules: ReadonlyArray<DenyRule> = [(node) => this.hasBlacklistedAspect(node), (node) => this.hasBlacklistedType(node)];
+
+  canAddComments(node: Node): boolean {
+    return this.denyRules.every((rule) => !rule(node));
+  }
+
+  private hasBlacklistedAspect(node: Node): boolean {
+    return (node.aspectNames ?? []).some((aspect) => this.blacklistedAspects.has(aspect));
+  }
+
+  private hasBlacklistedType(node: Node): boolean {
+    return this.blacklistedTypes.has(node.nodeType ?? '');
+  }
+}

--- a/projects/aca-content/src/lib/services/node-actions.service.spec.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.spec.ts
@@ -118,7 +118,7 @@ describe('NodeActionsService', () => {
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: of
       } as unknown as MatDialogRef<any>);
-      const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
+      const contentEntities = [new TestNode(), { entry: { nodeId: '1234', nodeType: 'cm:content' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
       const isSelectionValid = dialog.open['calls'].argsFor(0)[1].data.isSelectionValid({
@@ -136,7 +136,7 @@ describe('NodeActionsService', () => {
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: of
       } as unknown as MatDialogRef<any>);
-      const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
+      const contentEntities = [new TestNode(), { entry: { nodeId: '1234', nodeType: 'cm:content' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
       const isSelectionValid = dialog.open['calls'].argsFor(0)[1].data.isSelectionValid({
@@ -154,7 +154,7 @@ describe('NodeActionsService', () => {
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: of
       } as unknown as MatDialogRef<any>);
-      const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
+      const contentEntities = [new TestNode(), { entry: { nodeId: '1234', nodeType: 'cm:content' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
       const isSelectionValid = dialog.open['calls'].argsFor(0)[1].data.isSelectionValid({
@@ -173,7 +173,7 @@ describe('NodeActionsService', () => {
       spyOn(dialog, 'open').and.returnValue({
         afterClosed: of
       } as unknown as MatDialogRef<any>);
-      const contentEntities = [new TestNode(), { entry: { nodeId: '1234' } }];
+      const contentEntities = [new TestNode(), { entry: { nodeId: '1234', nodeType: 'cm:content' } }];
       service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
 
       const isSelectionValid = dialog.open['calls'].argsFor(0)[1].data.isSelectionValid({
@@ -186,6 +186,51 @@ describe('NodeActionsService', () => {
       });
 
       expect(isSelectionValid).toBe(true);
+    });
+
+    it('should invalidate selection if destination is an RMA system folder', () => {
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as unknown as MatDialogRef<any>);
+      const contentEntities = [new TestNode(), { entry: { nodeId: '1234', nodeType: 'rma:holdContainer' } }];
+      service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
+
+      const isSelectionValid = dialog.open['calls'].argsFor(0)[1].data.isSelectionValid({
+        name: 'rma-hold-container',
+        isFile: false,
+        isFolder: true,
+        path: { elements: [{}, {}] },
+        nodeType: 'rma:holdContainer',
+        allowableOperations: ['create']
+      });
+
+      expect(isSelectionValid).toBe(false);
+    });
+
+    it('should hide search and site dropdown when at least one selected node is RMA-related', () => {
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as unknown as MatDialogRef<any>);
+
+      const contentEntities = [new TestNode('regular-folder-id', false), new TestNode('rma-folder-id', false, 'rma-folder', [], 'rma:holdContainer')];
+      service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
+
+      const dialogConfig = dialog.open['calls'].argsFor(0)[1].data;
+      expect(dialogConfig.showSearch).toBe(false);
+      expect(dialogConfig.showDropdownSiteList).toBe(false);
+    });
+
+    it('should show search and site dropdown when selected nodes are not RMA-related', () => {
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: of
+      } as unknown as MatDialogRef<any>);
+
+      const contentEntities = [new TestNode('folder-a-id', false), new TestNode('folder-b-id', false)];
+      service.getContentNodeSelection(NodeAction.CHOOSE, contentEntities as NodeEntry[]);
+
+      const dialogConfig = dialog.open['calls'].argsFor(0)[1].data;
+      expect(dialogConfig.showSearch).toBe(true);
+      expect(dialogConfig.showDropdownSiteList).toBe(true);
     });
   });
 
@@ -399,7 +444,7 @@ describe('NodeActionsService', () => {
         return { componentInstance: {}, afterClosed: of } as unknown as MatDialogRef<any>;
       });
 
-      service.copyNodes([{ entry: { id: 'entry-id', name: 'entry-name' } }]);
+      service.copyNodes([{ entry: { id: 'entry-id', name: 'entry-name', nodeType: 'cm:content' } }]);
 
       expect(spyOnBatchOperation).toHaveBeenCalled();
       expect(dialogData).toBeDefined();
@@ -421,7 +466,7 @@ describe('NodeActionsService', () => {
         return { componentInstance: {}, afterClosed: of } as unknown as MatDialogRef<any>;
       });
 
-      service.copyNodes([{ entry: { id: 'entry-id' } }]);
+      service.copyNodes([{ entry: { id: 'entry-id', nodeType: 'cm:content' } }]);
 
       expect(spyOnBatchOperation).toHaveBeenCalled();
       expect(dialogData).toBeDefined();

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -37,7 +37,7 @@ import {
   ContentService
 } from '@alfresco/adf-content-services';
 import { NodeEntry, Node, SitePaging, NodeChildAssociationPaging, NodeChildAssociationEntry, NodesApi, Site, SitePagingList } from '@alfresco/js-api';
-import { ContentApiService } from '@alfresco/aca-shared';
+import { ContentApiService, isRmaContent, isRmaSystemFolder } from '@alfresco/aca-shared';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 
 type BatchOperationType = Extract<NodeAction, 'COPY' | 'MOVE'>;
@@ -170,6 +170,7 @@ export class NodeActionsService {
 
   getContentNodeSelection(action: NodeAction, contentEntities: NodeEntry[], focusedElementOnCloseSelector?: string): Subject<Node[]> {
     const currentParentFolderId = this.getEntryParentId(contentEntities[0].entry);
+    const isRmaRelated = contentEntities.some((node) => isRmaContent(node.entry));
 
     const customDropdown = new SitePaging({
       list: {
@@ -205,7 +206,9 @@ export class NodeActionsService {
       isSelectionValid: this.canCopyMoveInsideIt.bind(this),
       breadcrumbTransform: this.customizeBreadcrumb.bind(this),
       select: new Subject<Node[]>(),
-      excludeSiteContent: ContentNodeDialogService.nonDocumentSiteContent
+      excludeSiteContent: ContentNodeDialogService.nonDocumentSiteContent,
+      showSearch: !isRmaRelated,
+      showDropdownSiteList: !isRmaRelated
     };
 
     this.dialog
@@ -239,7 +242,7 @@ export class NodeActionsService {
   }
 
   private canCopyMoveInsideIt(entry: Node): boolean {
-    return this.hasEntityCreatePermission(entry) && !this.isSite(entry);
+    return this.hasEntityCreatePermission(entry) && !this.isSite(entry) && !isRmaSystemFolder(entry);
   }
 
   private hasEntityCreatePermission(entry: Node): boolean {

--- a/projects/aca-content/src/public-api.ts
+++ b/projects/aca-content/src/public-api.ts
@@ -31,6 +31,5 @@ export * from './lib/aca-content.routes';
 export * from './lib/store/initial-state';
 export * from './lib/services/content-url.service';
 export * from './lib/services/content-management.service';
-export * from './lib/components/info-drawer/comments-tab/external-node-permission-comments-tab.service';
 export * from './lib/utils/aca-search-utils';
 export * from './lib/pipes/is-feature-supported.pipe';

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -23,7 +23,14 @@
  */
 
 import * as app from './app.rules';
-import { createVersionRule, getFileExtension, isPreferencesApiAvailable, isNodeInfoAvailable, isBulkActionsAvailable } from './app.rules';
+import {
+  createVersionRule,
+  getFileExtension,
+  isPreferencesApiAvailable,
+  isNodeInfoAvailable,
+  isBulkActionsAvailable,
+  isRmaSystemContainer
+} from './app.rules';
 import { TestRuleContext } from './test-rule-context';
 import { NodeEntry, RepositoryInfo, StatusInfo } from '@alfresco/js-api';
 import { ProfileState, RuleContext } from '@alfresco/adf-extensions';
@@ -858,42 +865,39 @@ describe('app.evaluators', () => {
   });
 
   describe('canCreateFolder', () => {
-    it('should return false when content service is disabled', () => {
-      context.appConfig = { get: () => false } as any;
-      expect(app.canCreateFolder(context)).toBeFalse();
-    });
-
     it('should return false when user is outside personal files or libraries', () => {
-      context.appConfig = { get: () => true } as any;
       context.navigation.url = '/favorite/test';
       expect(app.canCreateFolder(context)).toBeFalse();
     });
 
     it('should return false when current folder does not exist', () => {
-      context.appConfig = { get: () => true } as any;
       context.navigation.url = '/personal-files/test';
       context.navigation.currentFolder = null;
       expect(app.canCreateFolder(context)).toBeFalse();
     });
 
     it('should return false when permission check fails', () => {
-      context.appConfig = { get: () => true } as any;
       context.navigation.url = '/personal-files/test';
       context.navigation.currentFolder = {} as any;
       context.permissions = { check: () => false };
       expect(app.canCreateFolder(context)).toBeFalse();
     });
 
-    it('should return true when permission requirements are met', () => {
-      context.appConfig = { get: () => true } as any;
+    it('should return true when permission requirements are met and current folder is not rma restricted one', () => {
       context.navigation.url = '/personal-files/test';
-      context.navigation.currentFolder = {} as any;
+      context.navigation.currentFolder = { nodeType: 'rma:filePlan' } as any;
       context.permissions = { check: () => true };
       expect(app.canCreateFolder(context)).toBeTrue();
     });
 
+    it('should return false when permission requirements are met BUT current folder is rma restricted one', () => {
+      context.navigation.url = '/personal-files/test';
+      context.navigation.currentFolder = { nodeType: 'rma:hold' } as any;
+      context.permissions = { check: () => true };
+      expect(app.canCreateFolder(context)).toBeFalse();
+    });
+
     it('should verify is user has create permission on current folder', () => {
-      context.appConfig = { get: () => true } as any;
       context.navigation.url = '/personal-files/test';
       context.navigation.currentFolder = { allowableOperations: ['create'] } as any;
       spyOn(context.permissions, 'check');
@@ -1313,6 +1317,31 @@ describe('Versions compatibility', () => {
       expect(rule(makeContext('25.1.1'))).toBe(true);
       expect(rule(makeContext('25.1.0.1-beta'))).toBe(true);
       expect(rule(makeContext('25.0.1.1-rc'))).toBe(false);
+    });
+  });
+
+  describe('isRmaSystemContainer', () => {
+    const prepareRuleContext = (nodeType: string | string[]): RuleContext => {
+      const nodes = Array.isArray(nodeType) ? nodeType.map((type) => ({ entry: { nodeType: type } })) : [{ entry: { nodeType } }];
+      return {
+        selection: {
+          nodes
+        }
+      } as RuleContext;
+    };
+
+    it('should return false when node is not rma system container', () => {
+      expect(isRmaSystemContainer(prepareRuleContext('rma:filePlan'))).toBeFalse();
+    });
+
+    it('should return true when node is rma system container', () => {
+      expect(isRmaSystemContainer(prepareRuleContext('rma:holdContainer'))).toBeTrue();
+      expect(isRmaSystemContainer(prepareRuleContext('rma:transferContainer'))).toBeTrue();
+      expect(isRmaSystemContainer(prepareRuleContext('rma:unfiledRecordContainer'))).toBeTrue();
+    });
+
+    it('should return true when at least one selected node is an rma system container', () => {
+      expect(isRmaSystemContainer(prepareRuleContext(['cm:folder', 'rma:transferContainer']))).toBeTrue();
     });
   });
 });

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -27,6 +27,7 @@ import { RuleContext } from '@alfresco/adf-extensions';
 import * as navigation from './navigation.rules';
 import * as repository from './repository.rules';
 import { isAdmin } from './user.rules';
+import { isRmaRestrictedCreateFolder, isRmaSystemFolder } from '@alfresco/aca-shared';
 
 /* cspell:disable */
 export const supportedExtensions = {
@@ -197,7 +198,7 @@ export function canCreateFolder(context: AcaRuleContext): boolean {
     const { currentFolder } = context.navigation;
 
     if (currentFolder) {
-      return context.permissions.check(currentFolder, ['create']);
+      return context.permissions.check(currentFolder, ['create']) && !isRmaRestrictedCreateFolder(currentFolder);
     }
   }
   return false;
@@ -364,7 +365,7 @@ export function canUploadVersion(context: RuleContext): boolean {
 export const canPrintFile = (context: RuleContext): boolean => {
   const nodeEntry = context.selection.file.entry;
   const mediaMimeTypes = ['video/mp4', 'video/webm', 'video/ogg', 'audio/mpeg', 'audio/mp3', 'audio/ogg', 'audio/wav'];
-  return !mediaMimeTypes.includes(nodeEntry.content.mimeType);
+  return !mediaMimeTypes.includes(nodeEntry.content?.mimeType);
 };
 
 /**
@@ -511,6 +512,14 @@ export function createVersionRule(minimalVersion: string): (context: RuleContext
     return isVersionCompatible(acsVersion, minimalVersion);
   };
 }
+
+/**
+ * Checks if the folder is a Records Management site's system folder
+ * JSON ref: `app.selection.isRmaSystemContainer`
+ */
+export const isRmaSystemContainer = (context: RuleContext): boolean => {
+  return context.selection.nodes.some((node) => isRmaSystemFolder(node.entry));
+};
 
 function isVersionCompatible(currentVersion: string, minimalVersion: string): boolean {
   if (!currentVersion || !minimalVersion) {

--- a/projects/aca-shared/src/lib/models/external-nodes-permission-comments.interface.ts
+++ b/projects/aca-shared/src/lib/models/external-nodes-permission-comments.interface.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Node } from '@alfresco/js-api';
+
+export interface ExternalNodePermissionCommentsTabService {
+  canAddComments(node: Node): boolean;
+}

--- a/projects/aca-shared/src/lib/utils/external-node-comments-permissions.token.ts
+++ b/projects/aca-shared/src/lib/utils/external-node-comments-permissions.token.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Alfresco Example Content Application
+ *
+ * This file is part of the Alfresco Example Content Application.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail. Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * The Alfresco Example Content Application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Alfresco Example Content Application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { InjectionToken } from '@angular/core';
+import { ExternalNodePermissionCommentsTabService } from '../models/external-nodes-permission-comments.interface';
+
+export const EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE = new InjectionToken<ExternalNodePermissionCommentsTabService[]>(
+  'ExternalNodePermissionCommentsTabService'
+);

--- a/projects/aca-shared/src/lib/utils/external-node-comments-permissions.token.ts
+++ b/projects/aca-shared/src/lib/utils/external-node-comments-permissions.token.ts
@@ -26,5 +26,9 @@ import { InjectionToken } from '@angular/core';
 import { ExternalNodePermissionCommentsTabService } from '../models/external-nodes-permission-comments.interface';
 
 export const EXTERNAL_NODE_PERMISSION_COMMENTS_TAB_SERVICE = new InjectionToken<ExternalNodePermissionCommentsTabService[]>(
-  'ExternalNodePermissionCommentsTabService'
+  'ExternalNodePermissionCommentsTabService',
+  {
+    providedIn: 'root',
+    factory: () => []
+  }
 );

--- a/projects/aca-shared/src/lib/utils/node.utils.ts
+++ b/projects/aca-shared/src/lib/utils/node.utils.ts
@@ -24,6 +24,15 @@
 
 import { Node } from '@alfresco/js-api';
 
+const RMA_NODE_TYPES = {
+  hold: 'rma:hold',
+  holdContainer: 'rma:holdContainer',
+  transferContainer: 'rma:transferContainer',
+  unfiledRecordContainer: 'rma:unfiledRecordContainer'
+} as const;
+
+type RmaNodeType = (typeof RMA_NODE_TYPES)[keyof typeof RMA_NODE_TYPES];
+
 export function isLocked(node: { entry: Node }): boolean {
   if (node?.entry) {
     const { entry } = node;
@@ -43,3 +52,22 @@ export function isLibrary(node: { entry: Node | any }): boolean {
     return false;
   }
 }
+
+const hasNodeType =
+  (type: RmaNodeType) =>
+  (node: Node): boolean =>
+    node.nodeType === type;
+
+const isRmaHoldsContainer = hasNodeType(RMA_NODE_TYPES.holdContainer);
+const isRmaHold = hasNodeType(RMA_NODE_TYPES.hold);
+const isRmaTransferContainer = hasNodeType(RMA_NODE_TYPES.transferContainer);
+const isRmaUnfiledRecordsContainer = hasNodeType(RMA_NODE_TYPES.unfiledRecordContainer);
+
+export const isRmaSystemFolder = (node: Node): boolean =>
+  isRmaHoldsContainer(node) || isRmaTransferContainer(node) || isRmaUnfiledRecordsContainer(node);
+
+export const isRmaRestrictedCreateFolder = (node: Node): boolean => isRmaHold(node) || isRmaTransferContainer(node) || isRmaHoldsContainer(node);
+
+export const isRmaContent = (node: Node): boolean => {
+  return node.nodeType.startsWith('rma:');
+};

--- a/projects/aca-shared/src/lib/utils/note.utils.spec.ts
+++ b/projects/aca-shared/src/lib/utils/note.utils.spec.ts
@@ -22,9 +22,12 @@
  * from Hyland Software. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isLibrary, isLocked } from './node.utils';
+import { isLibrary, isLocked, isRmaContent, isRmaSystemFolder } from './node.utils';
+import { Node } from '@alfresco/js-api';
 
 describe('NodeUtils', () => {
+  const prepareNode = (nodeType: string): Node => ({ nodeType }) as Node;
+
   describe('isLocked', () => {
     it('should return [false] if entry is not defined', () => {
       expect(isLocked(null)).toBeFalse();
@@ -109,6 +112,46 @@ describe('NodeUtils', () => {
           }
         })
       ).toBeTrue();
+    });
+  });
+
+  describe('isRmaSystemFolder', () => {
+    it('should return [true] for rma:holdContainer', () => {
+      expect(isRmaSystemFolder(prepareNode('rma:holdContainer'))).toBeTrue();
+    });
+
+    it('should return [true] for rma:transferContainer', () => {
+      expect(isRmaSystemFolder(prepareNode('rma:transferContainer'))).toBeTrue();
+    });
+
+    it('should return [true] for rma:unfiledRecordContainer', () => {
+      expect(isRmaSystemFolder(prepareNode('rma:unfiledRecordContainer'))).toBeTrue();
+    });
+
+    it('should return [false] for non RMA system folder node type', () => {
+      expect(isRmaSystemFolder(prepareNode('rma:hold'))).toBeFalse();
+    });
+
+    it('should return [false] for unknown node type', () => {
+      expect(isRmaSystemFolder(prepareNode('unknown'))).toBeFalse();
+    });
+  });
+
+  describe('isRmaContent', () => {
+    it('should return [true] for node type starting with rma:', () => {
+      expect(isRmaContent(prepareNode('rma:hold'))).toBeTrue();
+      expect(isRmaContent(prepareNode('rma:holdContainer'))).toBeTrue();
+      expect(isRmaContent(prepareNode('rma:transferContainer'))).toBeTrue();
+      expect(isRmaContent(prepareNode('rma:unfiledRecordContainer'))).toBeTrue();
+      expect(isRmaContent(prepareNode('rma:whatever'))).toBeTrue();
+    });
+
+    it('should return [false] for node type not starting with rma:', () => {
+      expect(isRmaContent(prepareNode('cm:content'))).toBeFalse();
+    });
+
+    it('should return false when nodeType is missing', () => {
+      expect(isRmaContent({} as any)).toBeFalse();
     });
   });
 });

--- a/projects/aca-shared/src/lib/utils/note.utils.spec.ts
+++ b/projects/aca-shared/src/lib/utils/note.utils.spec.ts
@@ -149,9 +149,5 @@ describe('NodeUtils', () => {
     it('should return [false] for node type not starting with rma:', () => {
       expect(isRmaContent(prepareNode('cm:content'))).toBeFalse();
     });
-
-    it('should return false when nodeType is missing', () => {
-      expect(isRmaContent({} as any)).toBeFalse();
-    });
   });
 });

--- a/projects/aca-shared/src/public-api.ts
+++ b/projects/aca-shared/src/public-api.ts
@@ -46,6 +46,7 @@ export * from './lib/directives/pagination.directive';
 
 export * from './lib/models/types';
 export * from './lib/models/viewer.rules';
+export * from './lib/models/external-nodes-permission-comments.interface';
 
 export * from './lib/routing/shared.guard';
 export * from './lib/routing/plugin-enabled.guard';
@@ -64,6 +65,7 @@ export * from './lib/services/navigation-history.service';
 export * from './lib/testing/lib-testing-module';
 
 export * from './lib/utils/node.utils';
+export * from './lib/utils/external-node-comments-permissions.token';
 
 export * from './lib/validators/no-whitespace.validator';
 export * from './lib/validators/no-leading-trailing-operators.validator';


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-9765

key changes:

- new app rule to hide/show move/copy action for rma system folders
- set of util functions to identify rma-related entities
- injection token for commenting service with multi flag to make possible adding on ADW side its own
