### PR TITLE
[ACS-11861] Revert "ACS-11861 Sharable link redirects to Login Page (…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "katex": "^0.16.21",
         "material-icons": "^1.13.12",
         "mermaid": "^11.15.0",
-        "minimatch-browser": "^1.0.0",
         "ngx-markdown": "19.1.1",
         "pdfjs-dist": "5.1.91",
         "prismjs": "^1.30.0",
@@ -12904,6 +12903,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -21175,34 +21175,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch-browser/-/minimatch-browser-1.0.0.tgz",
-      "integrity": "sha512-xET0irkHzT47f9h16H6ZVZw9lFZ33pK5DD5Pt0Gt/PcXAlevXjCz8zzM859gIWEDcD2yjKa31dGfwlKgk/12NQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimatch-browser/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/minimatch-browser/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -70,8 +70,6 @@
     "katex": "^0.16.21",
     "material-icons": "^1.13.12",
     "mermaid": "^11.15.0",
-    "minimatch": "^10.2.5",
-    "minimatch-browser": "^1.0.0",
     "ngx-markdown": "19.1.1",
     "pdfjs-dist": "5.1.91",
     "prismjs": "^1.30.0",

--- a/projects/aca-shared/src/lib/services/app.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.service.spec.ts
@@ -25,7 +25,6 @@
 import { AppService } from './app.service';
 import { TestBed } from '@angular/core/testing';
 import {
-  AppConfigService,
   AuthenticationService,
   NoopTranslateModule,
   NotificationService,
@@ -75,9 +74,12 @@ describe('AppService', () => {
   let appSettingsService: AppSettingsService;
   let userProfileService: UserProfileService;
   let notificationService: NotificationService;
+  let queryParams: { [key: string]: string };
   let loadUserProfileSpy: jasmine.Spy;
 
   beforeEach(() => {
+    queryParams = {};
+
     TestBed.configureTestingModule({
       imports: [NoopTranslateModule, MatDialogModule, MatSnackBarModule],
       providers: [
@@ -106,7 +108,7 @@ describe('AppService', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
-              queryParams: {}
+              queryParams
             }
           }
         },
@@ -235,7 +237,6 @@ describe('AppService', () => {
   });
 
   describe('Init with unauthorized api error', () => {
-    let appConfigService: AppConfigService;
     let router: Router;
     let matDialog: MatDialog;
     let alfrescoApiService: AlfrescoApiService;
@@ -246,7 +247,6 @@ describe('AppService', () => {
     const setupUnauthorizedErrorListener = (currentUrl: string): void => {
       spyOn(auth, 'isLoggedIn').and.returnValue(false);
       spyOn(alfrescoApiService, 'isExcludedErrorListener').and.returnValue(false);
-      spyOn(appConfigService, 'get').and.callFake((key: string, defaultValue?: any) => (key === 'oauth2.publicUrls' ? ['/public/**'] : defaultValue));
       spyOnProperty(router, 'url', 'get').and.returnValue(currentUrl);
       closeAllSpy = spyOn(matDialog, 'closeAll');
       navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
@@ -264,13 +264,12 @@ describe('AppService', () => {
     };
 
     beforeEach(() => {
-      appConfigService = TestBed.inject(AppConfigService);
       router = TestBed.inject(Router);
       matDialog = TestBed.inject(MatDialog);
       alfrescoApiService = TestBed.inject(AlfrescoApiService);
     });
 
-    it('should navigate to login on 401 for non-public url when user is logged out', () => {
+    it('should navigate to login on 401 when user is logged out', () => {
       setupUnauthorizedErrorListener('/private/page');
 
       apiErrorListener({ status: 401, response: { req: { url: '/api/private' } } });
@@ -281,13 +280,16 @@ describe('AppService', () => {
       });
     });
 
-    it('should not navigate to login on 401 for public url when user is logged out', () => {
-      setupUnauthorizedErrorListener('/public/home');
+    it('should navigate to login with redirectUrl from query params when provided', () => {
+      setupUnauthorizedErrorListener('/private/page');
+      queryParams['redirectUrl'] = '/from-query-param';
 
-      apiErrorListener({ status: 401, response: { req: { url: '/api/public' } } });
+      apiErrorListener({ status: 401, response: { req: { url: '/api/private' } } });
 
-      expect(closeAllSpy).not.toHaveBeenCalled();
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(closeAllSpy).toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith(['/login'], {
+        queryParams: { redirectUrl: '/from-query-param' }
+      });
     });
   });
 

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -145,7 +145,7 @@ export class AppService implements ShellAppService {
           redirectUrl = this.router.url;
         }
 
-        void this.router.navigate(['/login'], {
+        this.router.navigate(['/login'], {
           queryParams: { redirectUrl }
         });
       }
@@ -177,7 +177,7 @@ export class AppService implements ShellAppService {
     this.ready$.subscribe((isReady) => {
       if (isReady) {
         this.loadRepositoryStatus();
-        void this.loadUserProfile();
+        this.loadUserProfile();
         setTimeout(() => {
           this.openMobileAppDialog();
         });

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -52,7 +52,6 @@ import { ShellAppService } from '@alfresco/adf-core/shell';
 import { AppSettingsService } from './app-settings.service';
 import { UserProfileService } from './user-profile.service';
 import { MatDialog } from '@angular/material/dialog';
-import { minimatch } from 'minimatch';
 
 @Injectable({
   providedIn: 'root'
@@ -133,22 +132,22 @@ export class AppService implements ShellAppService {
 
   init(): void {
     this.alfrescoApiService.getInstance().on('error', (error: { status: number; response: any }) => {
-      if (error.status === 401 && !this.alfrescoApiService.isExcludedErrorListener(error?.response?.req?.url)) {
-        const publicUrls: string[] = this.config.get('oauth2.publicUrls', []);
-        const isPublicUrl = publicUrls.some((pattern) => minimatch(this.router.url, pattern));
+      const shouldNavigateToLogin =
+        error.status === 401 &&
+        !this.alfrescoApiService.isExcludedErrorListener(error?.response?.req?.url) &&
+        !this.authenticationService.isLoggedIn();
 
-        if (!this.authenticationService.isLoggedIn() && !isPublicUrl) {
-          this.matDialog.closeAll();
+      if (shouldNavigateToLogin) {
+        this.matDialog.closeAll();
 
-          let redirectUrl = this.activatedRoute.snapshot.queryParams['redirectUrl'];
-          if (!redirectUrl) {
-            redirectUrl = this.router.url;
-          }
-
-          this.router.navigate(['/login'], {
-            queryParams: { redirectUrl }
-          });
+        let redirectUrl = this.activatedRoute.snapshot.queryParams['redirectUrl'];
+        if (!redirectUrl) {
+          redirectUrl = this.router.url;
         }
+
+        void this.router.navigate(['/login'], {
+          queryParams: { redirectUrl }
+        });
       }
     });
 
@@ -178,7 +177,7 @@ export class AppService implements ShellAppService {
     this.ready$.subscribe((isReady) => {
       if (isReady) {
         this.loadRepositoryStatus();
-        this.loadUserProfile();
+        void this.loadUserProfile();
         setTimeout(() => {
           this.openMobileAppDialog();
         });


### PR DESCRIPTION
…#5206)"

This reverts commit 804824ebb00c5f8ae8dc9713e5a2f5afdb65ebe7.

**JIRA ticket link or changeset's description**

The root cause is calling protected APIs in ADW being unauthorized. 
fix is in 
https://github.com/Alfresco/alfresco-applications/pull/1606


UPD: removes mini match-browser dependency; refactors if logic branches; updates UTs