### PR TITLE
[AAE-46943] Sign Crowdin translation PR commits with GPG

### DIFF
--- a/.github/workflows/pull-from-crowdin.yml
+++ b/.github/workflows/pull-from-crowdin.yml
@@ -18,6 +18,9 @@ jobs:
           localization_branch_name: automated-translations-update
           pull_request_title: "GH Auto: Automated Update of Translations from Crowdin"
           pull_request_base_branch_name: develop
+          github_user_name: ${{ vars.HXP_GIT_USERNAME }}
+          github_user_email: ${{ vars.HXP_GIT_EMAIL }}
+          gpg_private_key: ${{ secrets.HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}


### PR DESCRIPTION
**JIRA ticket link or changeset's description**

https://hyland.atlassian.net/browse/AAE-46943

Crowdin opens automated PRs (branch `automated-translations-update`) via the `pull-from-crowdin` workflow. With "Require signed commits" enforced, these unsigned commits are rejected.

This enables GPG commit signing on the Crowdin action by adding `gpg_private_key` and committing as the service account (`github_user_name`/`github_user_email` from repo/org variables), so commits verify and pass branch protection.

Requires `SERVICE_ACCOUNT_SIGNING_KEY` secret and `SERVICE_ACCOUNT_USERNAME` / `SERVICE_ACCOUNT_EMAIL` variables (being added at org level separately).

CI/workflow configuration change only. Validation: run `pull-from-crowdin` via workflow_dispatch after secrets land and confirm the resulting commit shows "Verified".