### PR TITLE
[AAE-46943] Rename git signing secret/vars to HXPS_GIT_*

### DIFF
--- a/.github/workflows/pull-from-crowdin.yml
+++ b/.github/workflows/pull-from-crowdin.yml
@@ -18,9 +18,9 @@ jobs:
           localization_branch_name: automated-translations-update
           pull_request_title: "GH Auto: Automated Update of Translations from Crowdin"
           pull_request_base_branch_name: develop
-          github_user_name: ${{ vars.HXP_GIT_USERNAME }}
-          github_user_email: ${{ vars.HXP_GIT_EMAIL }}
-          gpg_private_key: ${{ secrets.HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
+          github_user_name: ${{ vars.HXPS_GIT_USERNAME }}
+          github_user_email: ${{ vars.HXPS_GIT_EMAIL }}
+          gpg_private_key: ${{ secrets.HXPS_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}


### PR DESCRIPTION
**JIRA ticket link or changeset's description**

https://hyland.atlassian.net/browse/AAE-46943

Follow-up to the merged PR #5222. Renames the Crowdin commit-signing secret and git identity variables to the final org-level names:
- secret `HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY` -> `HXPS_GIT_COMMIT_SIGNING_PRIVATE_KEY`
- vars `HXP_GIT_USERNAME` / `HXP_GIT_EMAIL` -> `HXPS_GIT_USERNAME` / `HXPS_GIT_EMAIL`

CI/workflow configuration change only.