### PR TITLE
AAE-46783: Rename org secrets to HXPS_GIT_*

### DIFF
--- a/.github/workflows/pull-from-crowdin.yml
+++ b/.github/workflows/pull-from-crowdin.yml
@@ -18,9 +18,9 @@ jobs:
           localization_branch_name: automated-translations-update
           pull_request_title: "GH Auto: Automated Update of Translations from Crowdin"
           pull_request_base_branch_name: develop
-          github_user_name: ${{ vars.HXP_GIT_USERNAME }}
-          github_user_email: ${{ vars.HXP_GIT_EMAIL }}
-          gpg_private_key: ${{ secrets.HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
+          github_user_name: ${{ vars.HXPS_GIT_USERNAME }}
+          github_user_email: ${{ vars.HXPS_GIT_EMAIL }}
+          gpg_private_key: ${{ secrets.HXPS_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}


### PR DESCRIPTION
Rename org-level signing variables/secrets from `HXP_GIT_*` to `HXPS_GIT_*` to match updated Alfresco org configuration.

Made with [Cursor](https://cursor.com)