### PR TITLE
Allow the same term to be executed when search mode changes

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.spec.ts
@@ -196,6 +196,38 @@ describe('SearchInputComponent', () => {
       submitSearch('  hello  ');
       expect(searchExecutionService.execute).toHaveBeenCalledTimes(1);
     });
+
+    it('should re-execute search when the search mode changes but the term is unchanged', () => {
+      submitSearch('hello');
+      expect(searchExecutionService.execute).toHaveBeenCalledTimes(1);
+
+      queryBuilder.searchMode = 'formula';
+      submitSearch('hello');
+      expect(searchExecutionService.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('should track the current search mode as the last search mode after submit', () => {
+      queryBuilder.searchMode = 'formula';
+      submitSearch('hello');
+      expect(component.lastSearchMode).toBe('formula');
+    });
+
+    it('should not re-execute search when both the term and the search mode are unchanged', () => {
+      queryBuilder.searchMode = 'formula';
+      submitSearch('hello');
+      expect(searchExecutionService.execute).toHaveBeenCalledTimes(1);
+
+      submitSearch('hello');
+      expect(searchExecutionService.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ngOnInit', () => {
+    it('should initialize lastSearchMode from the queryBuilder search mode', () => {
+      queryBuilder.searchMode = 'formula';
+      component.ngOnInit();
+      expect(component.lastSearchMode).toBe('formula');
+    });
   });
 
   describe('onFiltersApplied', () => {

--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
@@ -73,6 +73,7 @@ export class SearchInputComponent implements OnInit, AfterViewInit, OnDestroy {
   has400LibraryError = false;
   searchedWord: string = null;
   lastSearchedWord: string = null;
+  lastSearchMode: 'regular' | 'formula' = 'regular';
   error = '';
 
   @ViewChild('searchInputField')
@@ -83,6 +84,7 @@ export class SearchInputComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     this.initSearchState();
     this.subscribeToRouteParams();
+    this.lastSearchMode = this.queryBuilder.searchMode;
 
     this.appHookService.library400Error.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.has400LibraryError = true;
@@ -113,9 +115,10 @@ export class SearchInputComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.error = '';
-    if (this.lastSearchedWord !== trimmedTerm) {
+    if (this.lastSearchedWord !== trimmedTerm || this.lastSearchMode !== this.queryBuilder.searchMode) {
       this.lastSearchedWord = trimmedTerm;
       this.searchedWord = trimmedTerm;
+      this.lastSearchMode = this.queryBuilder.searchMode;
       this.executeSearch();
     }
   }


### PR DESCRIPTION
When search mode changes user should be able to execute the search even with the same term.