### PR TITLE
[ACS-8427] Fix search behaviour on closing

### DIFF
--- a/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
@@ -50,7 +50,7 @@ describe('SearchNavigationService', () => {
     expect(routerNavigate).not.toHaveBeenCalledWith([service.previousRoute]);
   });
 
-  it('should navigate to saved route when exitSearch function is called', () => {
+  it('should navigate to saved route when navigateBack function is called', () => {
     const routerNavigateByUrl = spyOn(router, 'navigateByUrl');
     service.saveRoute('/personal-files');
     service.navigateBack();

--- a/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
@@ -51,11 +51,20 @@ describe('SearchNavigationService', () => {
   });
 
   it('should navigate to saved route when exitSearch function is called', () => {
-    const routerNavigate = spyOn(router, 'navigate');
+    const routerNavigateByUrl = spyOn(router, 'navigateByUrl');
     service.saveRoute('/personal-files');
     service.navigateBack();
 
-    expect(routerNavigate).toHaveBeenCalledWith([service.previousRoute]);
+    expect(routerNavigateByUrl).toHaveBeenCalledWith(service.previousRoute);
+  });
+
+  it('should navigate to saved route including query params when exitSearch function is called', () => {
+    const routerNavigateByUrl = spyOn(router, 'navigateByUrl');
+    const savedRoute = '/personal-files/details/some-node-id?location=%2Fpersonal-files';
+    service.saveRoute(savedRoute);
+    service.navigateBack();
+
+    expect(routerNavigateByUrl).toHaveBeenCalledWith(savedRoute);
   });
 
   it('should navigate to Search when navigateToSearch function is called', () => {

--- a/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
@@ -58,7 +58,7 @@ describe('SearchNavigationService', () => {
     expect(routerNavigateByUrl).toHaveBeenCalledWith(service.previousRoute);
   });
 
-  it('should navigate to saved route including query params when exitSearch function is called', () => {
+  it('should navigate to saved route including query params when navigateBack function is called', () => {
     const routerNavigateByUrl = spyOn(router, 'navigateByUrl');
     const savedRoute = '/personal-files/details/some-node-id?location=%2Fpersonal-files';
     service.saveRoute(savedRoute);

--- a/projects/aca-content/src/lib/components/search/search-navigation.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.ts
@@ -52,7 +52,7 @@ export class SearchNavigationService {
 
   navigateBack(): void {
     if (this.previousRoute) {
-      this.router.navigate([this.previousRoute]);
+      this.router.navigateByUrl(this.previousRoute);
     } else {
       this.router.navigate(['/personal-files']);
     }


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-8427

This PR fixes an issue where the loading animation would continue indefinitely when a user navigated to the expanded details panel, opened the search bar, and then closed it. This fixes the routing behaviour previous route is expected to be a string instead of an array. 