### PR TITLE
[ACS-11860] Update license-header from 2005-2025 to 2005-2026

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,7 +59,7 @@
           "error",
           [
             "/*!",
-            " * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.",
+            " * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.",
             " *",
             " * Alfresco Example Content Application",
             " *",

--- a/app/src/app/app.components.spec.ts
+++ b/app/src/app/app.components.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/app/app.components.ts
+++ b/app/src/app/app.components.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/app/app.config.ts
+++ b/app/src/app/app.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/app/components/login/app-login.component.ts
+++ b/app/src/app/components/login/app-login.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/app/extensions.module.ts
+++ b/app/src/app/extensions.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/environments/environment.e2e.ts
+++ b/app/src/environments/environment.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/environments/environment.interface.ts
+++ b/app/src/environments/environment.interface.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/environments/environment.release.ts
+++ b/app/src/environments/environment.release.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/environments/environment.ts
+++ b/app/src/environments/environment.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/polyfills.ts
+++ b/app/src/polyfills.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/test.ts
+++ b/app/src/test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/app/src/typings.d.ts
+++ b/app/src/typings.d.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/authentication/playwright.config.ts
+++ b/e2e/playwright/authentication/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/authentication/src/tests/general.e2e.ts
+++ b/e2e/playwright/authentication/src/tests/general.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/authentication/src/tests/login.e2e.ts
+++ b/e2e/playwright/authentication/src/tests/login.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/authentication/src/tests/logout.e2e.ts
+++ b/e2e/playwright/authentication/src/tests/logout.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/copy-move-actions/playwright.config.ts
+++ b/e2e/playwright/copy-move-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/copy-move-actions/src/tests/copy-move-repository.e2e.ts
+++ b/e2e/playwright/copy-move-actions/src/tests/copy-move-repository.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/copy-move-actions/src/tests/copy.e2e.ts
+++ b/e2e/playwright/copy-move-actions/src/tests/copy.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/copy-move-actions/src/tests/destination-picker-dialog.e2e.ts
+++ b/e2e/playwright/copy-move-actions/src/tests/destination-picker-dialog.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/copy-move-actions/src/tests/move.e2e.ts
+++ b/e2e/playwright/copy-move-actions/src/tests/move.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-actions/playwright.config.ts
+++ b/e2e/playwright/create-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-actions/src/tests/create-file-from-template.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-file-from-template.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-actions/src/tests/create-folder-from-template.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-folder-from-template.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-actions/src/tests/create-folder.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-folder.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-actions/src/tests/create-library.e2e.ts
+++ b/e2e/playwright/create-actions/src/tests/create-library.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-link-actions/playwright.config.ts
+++ b/e2e/playwright/create-link-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-link-actions/src/tests/create-link.e2e.ts
+++ b/e2e/playwright/create-link-actions/src/tests/create-link.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-link-actions/src/tests/link-actions.e2e.ts
+++ b/e2e/playwright/create-link-actions/src/tests/link-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/create-link-actions/src/tests/link-permissions.e2e.ts
+++ b/e2e/playwright/create-link-actions/src/tests/link-permissions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/delete-actions/playwright.config.ts
+++ b/e2e/playwright/delete-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/delete-actions/src/tests/delete-undo-delete.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/delete-undo-delete.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/delete-actions/src/tests/permanently-delete.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/permanently-delete.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/delete-actions/src/tests/restore-repository.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/restore-repository.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/delete-actions/src/tests/restore.e2e.ts
+++ b/e2e/playwright/delete-actions/src/tests/restore.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/edit-actions/playwright.config.ts
+++ b/e2e/playwright/edit-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/edit-actions/src/tests/edit-folder.e2e.ts
+++ b/e2e/playwright/edit-actions/src/tests/edit-folder.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
+++ b/e2e/playwright/edit-actions/src/tests/edit-offline.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/favorite-actions/playwright.config.ts
+++ b/e2e/playwright/favorite-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/favorite-actions/src/tests/mark-favorite.e2e.ts
+++ b/e2e/playwright/favorite-actions/src/tests/mark-favorite.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-information-actions/playwright.config.ts
+++ b/e2e/playwright/folder-information-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-information-actions/src/tests/folder-information.e2e.ts
+++ b/e2e/playwright/folder-information-actions/src/tests/folder-information.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-rules/playwright.config.ts
+++ b/e2e/playwright/folder-rules/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-rules/src/tests/create-rules.e2e.ts
+++ b/e2e/playwright/folder-rules/src/tests/create-rules.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-rules/src/tests/delete-view-rules.e2e.ts
+++ b/e2e/playwright/folder-rules/src/tests/delete-view-rules.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-rules/src/tests/transform-rules.e2e.ts
+++ b/e2e/playwright/folder-rules/src/tests/transform-rules.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/folder-rules/src/tests/update-rules.e2e.ts
+++ b/e2e/playwright/folder-rules/src/tests/update-rules.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/playwright.config.ts
+++ b/e2e/playwright/info-drawer/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/comments.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/comments.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/edit-mode.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/edit-mode.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/file-folder-properties.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/file-folder-properties.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/file-preview.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/file-preview.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/general.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/general.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/info-drawer-repository.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/info-drawer-repository.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/info-drawer/src/tests/library-properties.e2e.ts
+++ b/e2e/playwright/info-drawer/src/tests/library-properties.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/library-actions/playwright.config.ts
+++ b/e2e/playwright/library-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/library-actions/src/tests/favorite-libraries-actions.e2e.ts
+++ b/e2e/playwright/library-actions/src/tests/favorite-libraries-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/library-actions/src/tests/my-libraries-actions.e2e.ts
+++ b/e2e/playwright/library-actions/src/tests/my-libraries-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/library-actions/src/tests/search-page-lib-actions.e2e.ts
+++ b/e2e/playwright/library-actions/src/tests/search-page-lib-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/playwright.config.ts
+++ b/e2e/playwright/list-views/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/empty-list.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/empty-list.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/favorites.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/favorites.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/file-libraries.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/file-libraries.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/generic-errors.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/generic-errors.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/permissions.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/permissions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/personal-files.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/personal-files.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/recent-files.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/recent-files.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/shared-files.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/shared-files.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/sort-list.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/sort-list.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/trash-admin.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/trash-admin.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/list-views/src/tests/trash.e2e.ts
+++ b/e2e/playwright/list-views/src/tests/trash.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/playwright.config.ts
+++ b/e2e/playwright/navigation/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/src/tests/breadcrumb-admin.e2e.ts
+++ b/e2e/playwright/navigation/src/tests/breadcrumb-admin.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/src/tests/breadcrumb.e2e.ts
+++ b/e2e/playwright/navigation/src/tests/breadcrumb.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/src/tests/repository-breadcrumb.e2e.ts
+++ b/e2e/playwright/navigation/src/tests/repository-breadcrumb.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/src/tests/sidebar.e2e.ts
+++ b/e2e/playwright/navigation/src/tests/sidebar.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/navigation/src/tests/single-click.e2e.ts
+++ b/e2e/playwright/navigation/src/tests/single-click.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/pagination/playwright.config.ts
+++ b/e2e/playwright/pagination/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/pagination/src/tests/multiple-pages-files.e2e.ts
+++ b/e2e/playwright/pagination/src/tests/multiple-pages-files.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/playwright.config.ts
+++ b/e2e/playwright/search/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-categories.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-categories.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-date.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-date.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-general.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-general.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-location.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-location.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-logic.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-logic.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-properties.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-properties.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-filters-tags.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-filters-tags.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-highlighting.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-highlighting.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-input.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-input.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-results-files-folders.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-results-files-folders.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-results-general.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-results-general.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-results-libraries.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-results-libraries.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/search/src/tests/search-sorting.e2e.ts
+++ b/e2e/playwright/search/src/tests/search-sorting.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/share-action/playwright.config.ts
+++ b/e2e/playwright/share-action/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/share-file.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
+++ b/e2e/playwright/share-action/src/tests/share/unshare-file-search-results.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/playwright.config.ts
+++ b/e2e/playwright/smoke-test/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/src/tests/login/login.e2e.ts
+++ b/e2e/playwright/smoke-test/src/tests/login/login.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/src/tests/repository/repository-smoke.e2e.ts
+++ b/e2e/playwright/smoke-test/src/tests/repository/repository-smoke.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/src/tests/search/personal-files.ts
+++ b/e2e/playwright/smoke-test/src/tests/search/personal-files.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/src/tests/search/search-results-general.e2e.ts
+++ b/e2e/playwright/smoke-test/src/tests/search/search-results-general.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/smoke-test/src/tests/viewer/viewer.e2e.ts
+++ b/e2e/playwright/smoke-test/src/tests/viewer/viewer.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/playwright.config.ts
+++ b/e2e/playwright/special-permissions-actions-available/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/src/tests/folders-actions.e2e.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/folders-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/src/tests/other-permissions.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/other-permissions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/src/tests/repository-permissions.e2e.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/repository-permissions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/src/tests/special-permissions-actions.e2e.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/special-permissions-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/special-permissions-actions-available/src/tests/viewer.ts
+++ b/e2e/playwright/special-permissions-actions-available/src/tests/viewer.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/upload-download-actions/playwright.config.ts
+++ b/e2e/playwright/upload-download-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/upload-download-actions/src/tests/download.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/download.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/upload-download-actions/src/tests/upload-new-version.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/upload-new-version.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/upload-download-actions/src/tests/upload.e2e.ts
+++ b/e2e/playwright/upload-download-actions/src/tests/upload.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer-actions/playwright.config.ts
+++ b/e2e/playwright/viewer-actions/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer-actions/src/tests/viewer-action.e2e.ts
+++ b/e2e/playwright/viewer-actions/src/tests/viewer-action.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/playwright.config.ts
+++ b/e2e/playwright/viewer/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer-file-types.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer-file-types.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer-protected.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer-protected.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer-useraction.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer-useraction.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer-version-actions.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer-version-actions.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer-zoom-functionality.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer-zoom-functionality.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/e2e/playwright/viewer/src/tests/viewer.e2e.ts
+++ b/e2e/playwright/viewer/src/tests/viewer.e2e.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/license-header-aca.txt
+++ b/license-header-aca.txt
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/about/src/about.component.ts
+++ b/projects/aca-content/about/src/about.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/about/src/aca-about.module.ts
+++ b/projects/aca-content/about/src/aca-about.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/about/src/dev-mode.tokens.ts
+++ b/projects/aca-content/about/src/dev-mode.tokens.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/about/src/package-json.token.ts
+++ b/projects/aca-content/about/src/package-json.token.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/about/src/public-api.ts
+++ b/projects/aca-content/about/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/assets/i18n/ar.json
+++ b/projects/aca-content/assets/i18n/ar.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. والشركات التابعة لها. كل الحقوق محفوظة.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. والشركات التابعة لها. كل الحقوق محفوظة.",
         "TITLE": "مساحة العمل",
         "ABOUT": {
             "VERSION": "الإصدار:",

--- a/projects/aca-content/assets/i18n/ar.json
+++ b/projects/aca-content/assets/i18n/ar.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. والشركات التابعة لها. كل الحقوق محفوظة.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. والشركات التابعة لها. كل الحقوق محفوظة.",
         "TITLE": "مساحة العمل",
         "ABOUT": {
             "VERSION": "الإصدار:",

--- a/projects/aca-content/assets/i18n/cs.json
+++ b/projects/aca-content/assets/i18n/cs.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "2005-2025 Hyland Software, Inc. a její přidružené společnosti. Všechna práva vyhrazena.",
+        "COPYRIGHT": "2005-2026 Hyland Software, Inc. a její přidružené společnosti. Všechna práva vyhrazena.",
         "TITLE": "Pracovní prostor",
         "ABOUT": {
             "VERSION": "Verze:",

--- a/projects/aca-content/assets/i18n/cs.json
+++ b/projects/aca-content/assets/i18n/cs.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "2005-2026 Hyland Software, Inc. a její přidružené společnosti. Všechna práva vyhrazena.",
+        "COPYRIGHT": "2005-2025 Hyland Software, Inc. a její přidružené společnosti. Všechna práva vyhrazena.",
         "TITLE": "Pracovní prostor",
         "ABOUT": {
             "VERSION": "Verze:",

--- a/projects/aca-content/assets/i18n/da.json
+++ b/projects/aca-content/assets/i18n/da.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og deres associerede selskaber. Alle rettigheder forbeholdes.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og deres associerede selskaber. Alle rettigheder forbeholdes.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/da.json
+++ b/projects/aca-content/assets/i18n/da.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og deres associerede selskaber. Alle rettigheder forbeholdes.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og deres associerede selskaber. Alle rettigheder forbeholdes.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/de.json
+++ b/projects/aca-content/assets/i18n/de.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.",
+        "COPYRIGHT": "© 2005-2026 Hyland, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/de.json
+++ b/projects/aca-content/assets/i18n/de.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.",
+        "COPYRIGHT": "© 2005-2025 Hyland, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/es.json
+++ b/projects/aca-content/assets/i18n/es.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versión:",

--- a/projects/aca-content/assets/i18n/es.json
+++ b/projects/aca-content/assets/i18n/es.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versión:",

--- a/projects/aca-content/assets/i18n/fi.json
+++ b/projects/aca-content/assets/i18n/fi.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005- 2025 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
+        "COPYRIGHT": "© 2005- 2026 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versio:",

--- a/projects/aca-content/assets/i18n/fi.json
+++ b/projects/aca-content/assets/i18n/fi.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005- 2026 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versio:",

--- a/projects/aca-content/assets/i18n/fi.json
+++ b/projects/aca-content/assets/i18n/fi.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
+        "COPYRIGHT": "© 2005- 2025 Hyland Software, Inc. ja sen tytäryhtiöt. Kaikki oikeudet pidätetään.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versio:",

--- a/projects/aca-content/assets/i18n/fr.json
+++ b/projects/aca-content/assets/i18n/fr.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. et ses filiales. Tous droits réservés.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. et ses filiales. Tous droits réservés.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version :",

--- a/projects/aca-content/assets/i18n/fr.json
+++ b/projects/aca-content/assets/i18n/fr.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. et ses filiales. Tous droits réservés.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. et ses filiales. Tous droits réservés.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version :",

--- a/projects/aca-content/assets/i18n/it.json
+++ b/projects/aca-content/assets/i18n/it.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versione:",

--- a/projects/aca-content/assets/i18n/it.json
+++ b/projects/aca-content/assets/i18n/it.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versione:",

--- a/projects/aca-content/assets/i18n/ja.json
+++ b/projects/aca-content/assets/i18n/ja.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. および関連会社。無断転載禁止。",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. および関連会社。無断転載禁止。",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "バージョン:",

--- a/projects/aca-content/assets/i18n/ja.json
+++ b/projects/aca-content/assets/i18n/ja.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. および関連会社。無断転載禁止。",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. および関連会社。無断転載禁止。",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "バージョン:",

--- a/projects/aca-content/assets/i18n/nb.json
+++ b/projects/aca-content/assets/i18n/nb.json
@@ -1,6 +1,6 @@
 {
   "APP": {
-    "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og samarbeidspartnere. Alle rettigheter forbeholdt.",
+    "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og samarbeidspartnere. Alle rettigheter forbeholdt.",
     "TITLE": "Workspace",
     "ABOUT": {
       "VERSION": "Versjon:",

--- a/projects/aca-content/assets/i18n/nb.json
+++ b/projects/aca-content/assets/i18n/nb.json
@@ -1,6 +1,6 @@
 {
   "APP": {
-    "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og samarbeidspartnere. Alle rettigheter forbeholdt.",
+    "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og samarbeidspartnere. Alle rettigheter forbeholdt.",
     "TITLE": "Workspace",
     "ABOUT": {
       "VERSION": "Versjon:",

--- a/projects/aca-content/assets/i18n/nl.json
+++ b/projects/aca-content/assets/i18n/nl.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versie:",

--- a/projects/aca-content/assets/i18n/nl.json
+++ b/projects/aca-content/assets/i18n/nl.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versie:",

--- a/projects/aca-content/assets/i18n/no.json
+++ b/projects/aca-content/assets/i18n/no.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og samarbeidspartnere. Med enerett.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og samarbeidspartnere. Med enerett.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versjon:",

--- a/projects/aca-content/assets/i18n/no.json
+++ b/projects/aca-content/assets/i18n/no.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. og samarbeidspartnere. Med enerett.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. og samarbeidspartnere. Med enerett.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versjon:",

--- a/projects/aca-content/assets/i18n/pl.json
+++ b/projects/aca-content/assets/i18n/pl.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. i jej podmioty stowarzyszone. Wszelkie prawa zastrzeżone.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. i jej podmioty stowarzyszone. Wszelkie prawa zastrzeżone.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Wersja:",

--- a/projects/aca-content/assets/i18n/pl.json
+++ b/projects/aca-content/assets/i18n/pl.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. i jej podmioty stowarzyszone. Wszelkie prawa zastrzeżone.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. i jej podmioty stowarzyszone. Wszelkie prawa zastrzeżone.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Wersja:",

--- a/projects/aca-content/assets/i18n/pt-BR.json
+++ b/projects/aca-content/assets/i18n/pt-BR.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. e seus afiliados. Todos os direitos reservados.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. e seus afiliados. Todos os direitos reservados.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versão:",

--- a/projects/aca-content/assets/i18n/pt-BR.json
+++ b/projects/aca-content/assets/i18n/pt-BR.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. e seus afiliados. Todos os direitos reservados.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. e seus afiliados. Todos os direitos reservados.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Versão:",

--- a/projects/aca-content/assets/i18n/ru.json
+++ b/projects/aca-content/assets/i18n/ru.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. и ее филиалы. Все права защищены.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. и ее филиалы. Все права защищены.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Версия:",

--- a/projects/aca-content/assets/i18n/ru.json
+++ b/projects/aca-content/assets/i18n/ru.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. и ее филиалы. Все права защищены.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. и ее филиалы. Все права защищены.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Версия:",

--- a/projects/aca-content/assets/i18n/sv.json
+++ b/projects/aca-content/assets/i18n/sv.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. och dess dotterbolag. Alla rättigheter förbehålles.",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. och dess dotterbolag. Alla rättigheter förbehålles.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/sv.json
+++ b/projects/aca-content/assets/i18n/sv.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. och dess dotterbolag. Alla rättigheter förbehålles.",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. och dess dotterbolag. Alla rättigheter förbehålles.",
         "TITLE": "Workspace",
         "ABOUT": {
             "VERSION": "Version:",

--- a/projects/aca-content/assets/i18n/zh-CN.json
+++ b/projects/aca-content/assets/i18n/zh-CN.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. 及其附属公司。保留所有权利。",
+        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. 及其附属公司。保留所有权利。",
         "TITLE": "工作区",
         "ABOUT": {
             "VERSION": "版本：",

--- a/projects/aca-content/assets/i18n/zh-CN.json
+++ b/projects/aca-content/assets/i18n/zh-CN.json
@@ -1,6 +1,6 @@
 {
     "APP": {
-        "COPYRIGHT": "© 2005-2025 Hyland Software, Inc. 及其附属公司。保留所有权利。",
+        "COPYRIGHT": "© 2005-2026 Hyland Software, Inc. 及其附属公司。保留所有权利。",
         "TITLE": "工作区",
         "ABOUT": {
             "VERSION": "版本：",

--- a/projects/aca-content/folder-rules/src/folder-rules.module.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/folder-rules.rules.spec.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.rules.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/folder-rules.rules.ts
+++ b/projects/aca-content/folder-rules/src/folder-rules.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/manage-rules/manage-rules.smart-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/action-parameter-constraints.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/action-parameter-constraints.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/actions.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/actions.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/conditions.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/conditions.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/node.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/node.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/rule-sets.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/rule-sets.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/rules.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/rules.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/mock/security-marks.mock.ts
+++ b/projects/aca-content/folder-rules/src/mock/security-marks.mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/action-parameter-constraint.model.ts
+++ b/projects/aca-content/folder-rules/src/model/action-parameter-constraint.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule-action.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule-action.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule-composite-condition.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule-composite-condition.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule-grouping-item.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule-grouping-item.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule-set.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule-set.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule-simple-condition.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule-simple-condition.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/model/rule.model.ts
+++ b/projects/aca-content/folder-rules/src/model/rule.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/public-api.ts
+++ b/projects/aca-content/folder-rules/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action-list.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/actions/rule-action.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-composite-condition.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-condition-comparators.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-condition-comparators.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-condition-fields.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-condition-fields.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/conditions/rule-simple-condition.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/edit-rule-dialog.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/options/rule-options.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/rule-details.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/triggers/rule-triggers.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/validators/rule-actions.validator.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/validators/rule-actions.validator.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/validators/rule-actions.validator.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/validators/rule-actions.validator.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/validators/rule-composite-condition.validator.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/validators/rule-composite-condition.validator.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-details/validators/rule-composite-condition.validator.ts
+++ b/projects/aca-content/folder-rules/src/rule-details/validators/rule-composite-condition.validator.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-grouping/rule-list-grouping.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list-item/rule-list-item.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-list/rule-list/rule-list.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.spec.ts
+++ b/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.ts
+++ b/projects/aca-content/folder-rules/src/rule-set-picker/rule-set-picker.smart-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/actions.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/actions.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/actions.service.ts
+++ b/projects/aca-content/folder-rules/src/services/actions.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rule-sets.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/folder-rules.service.spec.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rules.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/folder-rules/src/services/folder-rules.service.ts
+++ b/projects/aca-content/folder-rules/src/services/folder-rules.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/actions/aos.actions.ts
+++ b/projects/aca-content/ms-office/src/actions/aos.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/aos-extension.module.ts
+++ b/projects/aca-content/ms-office/src/aos-extension.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/aos-extension.service.spec.ts
+++ b/projects/aca-content/ms-office/src/aos-extension.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/aos-extension.service.ts
+++ b/projects/aca-content/ms-office/src/aos-extension.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/effects/aos.effects.spec.ts
+++ b/projects/aca-content/ms-office/src/effects/aos.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/effects/aos.effects.ts
+++ b/projects/aca-content/ms-office/src/effects/aos.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/ms-office/src/public-api.ts
+++ b/projects/aca-content/ms-office/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/aca-content.module.ts
+++ b/projects/aca-content/src/lib/aca-content.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/aca-content.routes.ts
+++ b/projects/aca-content/src/lib/aca-content.routes.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
+++ b/projects/aca-content/src/lib/components/bulk-actions-dropdown/bulk-actions-dropdown.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/index.ts
+++ b/projects/aca-content/src/lib/components/common/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/language-picker/language-picker.component.ts
+++ b/projects/aca-content/src/lib/components/common/language-picker/language-picker.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/location-link/location-link.component.spec.ts
+++ b/projects/aca-content/src/lib/components/common/location-link/location-link.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/location-link/location-link.component.ts
+++ b/projects/aca-content/src/lib/components/common/location-link/location-link.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/logout/logout.component.spec.ts
+++ b/projects/aca-content/src/lib/components/common/logout/logout.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/logout/logout.component.ts
+++ b/projects/aca-content/src/lib/components/common/logout/logout.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.spec.ts
+++ b/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
+++ b/projects/aca-content/src/lib/components/common/toggle-shared/toggle-shared.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/common/user-info/user-info.component.ts
+++ b/projects/aca-content/src/lib/components/common/user-info/user-info.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/base-context-menu.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-item.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-outside-event.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-outside-event.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-outside-event.directive.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-outside-event.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu-overlay.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu-overlay.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/context-menu.service.ts
+++ b/projects/aca-content/src/lib/components/context-menu/context-menu.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu-actions.token.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu-actions.token.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
+++ b/projects/aca-content/src/lib/components/context-menu/custom-context-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/direction.token.ts
+++ b/projects/aca-content/src/lib/components/context-menu/direction.token.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/context-menu/interfaces.ts
+++ b/projects/aca-content/src/lib/components/context-menu/interfaces.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/details/details.component.spec.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/details/details.component.ts
+++ b/projects/aca-content/src/lib/components/details/details.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.spec.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/datatable-cell-badges/datatable-cell-badges.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.spec.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/name-column/name-column.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/dl-custom-components/tags-column/tags-column.component.ts
+++ b/projects/aca-content/src/lib/components/dl-custom-components/tags-column/tags-column.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.spec.ts
+++ b/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.ts
+++ b/projects/aca-content/src/lib/components/favorite-libraries/favorite-libraries.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/favorites/favorites.component.spec.ts
+++ b/projects/aca-content/src/lib/components/favorites/favorites.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/favorites/favorites.component.ts
+++ b/projects/aca-content/src/lib/components/favorites/favorites.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/files/files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/files/files.component.ts
+++ b/projects/aca-content/src/lib/components/files/files.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/home/home.component.spec.ts
+++ b/projects/aca-content/src/lib/components/home/home.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/home/home.component.ts
+++ b/projects/aca-content/src/lib/components/home/home.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/comments-tab.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/comments-tab/external-node-permission-comments-tab.service.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/comments-tab/external-node-permission-comments-tab.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-form.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/library-metadata-tab/library-metadata-tab.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/metadata-tab/metadata-tab.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.spec.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.ts
+++ b/projects/aca-content/src/lib/components/info-drawer/versions-tab/versions-tab.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/knowledge-discovery/knowledge-discovery-sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/knowledge-discovery/knowledge-discovery-sidenav.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/knowledge-discovery/knowledge-discovery-sidenav.component.ts
+++ b/projects/aca-content/src/lib/components/knowledge-discovery/knowledge-discovery-sidenav.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/libraries-base/libraries-base.component.spec.ts
+++ b/projects/aca-content/src/lib/components/libraries-base/libraries-base.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/libraries-base/libraries-base.component.ts
+++ b/projects/aca-content/src/lib/components/libraries-base/libraries-base.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/libraries/libraries.component.spec.ts
+++ b/projects/aca-content/src/lib/components/libraries/libraries.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/libraries/libraries.component.ts
+++ b/projects/aca-content/src/lib/components/libraries/libraries.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/library-list/library-list.component.spec.ts
+++ b/projects/aca-content/src/lib/components/library-list/library-list.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/library-list/library-list.component.ts
+++ b/projects/aca-content/src/lib/components/library-list/library-list.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/recent-files/recent-files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/recent-files/recent-files.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/recent-files/recent-files.component.ts
+++ b/projects/aca-content/src/lib/components/recent-files/recent-files.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/repository-view/repository-view.component.ts
+++ b/projects/aca-content/src/lib/components/repository-view/repository-view.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/index.ts
+++ b/projects/aca-content/src/lib/components/search/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-action-menu/search-action-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-execution.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-execution.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-execution.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-execution.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-filter.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-filter.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-filter.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-filter.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-in-menu/search-in-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-in-menu/search-in-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-in-menu/search-in-menu.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-in-menu/search-in-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-input/search-input.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-query-builder.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-query-builder.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-query-builder.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-query-builder.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-libraries-results/search-libraries-results.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-navigation.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-navigation.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-results-row/search-results-row.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results-row/search-results-row.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-results-row/search-results-row.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results-row/search-results-row.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-results/search-results.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/delete/saved-search-delete-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/edit/saved-search-edit-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-directive-dialog-data.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/save-search-directive-dialog-data.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/saved-search-form.interface.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/saved-search-form.interface.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/dialog/unique-search-name-validator.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/directive/save-search.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/directive/save-search.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/directive/save-search.directive.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/directive/save-search.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/saved-searches-list-ui.service.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/saved-searches-list-ui.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/saved-searches-list-ui.service.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/saved-searches-list-ui.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-list-schema.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/smart-list/saved-searches-smart-list.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/list/ui-list/saved-searches-list.ui-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.ts
+++ b/projects/aca-content/src/lib/components/search/search-save/sidenav/save-search-sidenav.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/shared-files/shared-files.component.spec.ts
+++ b/projects/aca-content/src/lib/components/shared-files/shared-files.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/shared-files/shared-files.component.ts
+++ b/projects/aca-content/src/lib/components/shared-files/shared-files.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.spec.ts
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
+++ b/projects/aca-content/src/lib/components/shared-link-view/shared-link-view.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/button-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/expand-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/action.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/action.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/action.directive.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/action.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/active-link.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/active-link.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/active-link.directive.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/active-link.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/expansion-panel.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/expansion-panel.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/expansion-panel.directive.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/expansion-panel.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/menu-panel.directive.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/menu-panel.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/directives/menu-panel.directive.ts
+++ b/projects/aca-content/src/lib/components/sidenav/directives/menu-panel.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/index.ts
+++ b/projects/aca-content/src/lib/components/sidenav/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.spec.ts
+++ b/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.ts
+++ b/projects/aca-content/src/lib/components/sidenav/user-menu/user-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/index.ts
+++ b/projects/aca-content/src/lib/components/toolbar/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-edit-offline/toggle-edit-offline.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite-library/toggle-favorite-library.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-favorite/toggle-favorite.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-info-drawer/toggle-info-drawer.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-button.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/toggle-join-library/toggle-join-library.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.spec.ts
+++ b/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
+++ b/projects/aca-content/src/lib/components/toolbar/view-node/view-node.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/trashcan/trashcan.component.spec.ts
+++ b/projects/aca-content/src/lib/components/trashcan/trashcan.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/trashcan/trashcan.component.ts
+++ b/projects/aca-content/src/lib/components/trashcan/trashcan.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/upload-files-dialog/upload-files-dialog.component.ts
+++ b/projects/aca-content/src/lib/components/upload-files-dialog/upload-files-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.spec.ts
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/components/view-profile/view-profile.guard.ts
+++ b/projects/aca-content/src/lib/components/view-profile/view-profile.guard.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-details/node-information.component.spec.ts
+++ b/projects/aca-content/src/lib/dialogs/node-details/node-information.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-details/node-information.component.ts
+++ b/projects/aca-content/src/lib/dialogs/node-details/node-information.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-location-references/node-location-references.component.spec.ts
+++ b/projects/aca-content/src/lib/dialogs/node-location-references/node-location-references.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-location-references/node-location-references.component.ts
+++ b/projects/aca-content/src/lib/dialogs/node-location-references/node-location-references.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.spec.ts
+++ b/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.ts
+++ b/projects/aca-content/src/lib/dialogs/node-template/create-from-template.dialog.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/directives/document-list.directive.spec.ts
+++ b/projects/aca-content/src/lib/directives/document-list.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/directives/document-list.directive.ts
+++ b/projects/aca-content/src/lib/directives/document-list.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/mock/libraries-mock.ts
+++ b/projects/aca-content/src/lib/mock/libraries-mock.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
+++ b/projects/aca-content/src/lib/pipes/is-feature-supported.pipe.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/content-management.service.spec.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/content-management.service.ts
+++ b/projects/aca-content/src/lib/services/content-management.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/content-url.service.spec.ts
+++ b/projects/aca-content/src/lib/services/content-url.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/content-url.service.ts
+++ b/projects/aca-content/src/lib/services/content-url.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/node-actions.service.spec.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/node-actions.service.ts
+++ b/projects/aca-content/src/lib/services/node-actions.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/node-template.service.spec.ts
+++ b/projects/aca-content/src/lib/services/node-template.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/node-template.service.ts
+++ b/projects/aca-content/src/lib/services/node-template.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/saved-searches-context.service.spec.ts
+++ b/projects/aca-content/src/lib/services/saved-searches-context.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/services/saved-searches-context.service.ts
+++ b/projects/aca-content/src/lib/services/saved-searches-context.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/app-store.module.ts
+++ b/projects/aca-content/src/lib/store/app-store.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects.ts
+++ b/projects/aca-content/src/lib/store/effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/app.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/app.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/contextmenu.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/contextmenu.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/contextmenu.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/contextmenu.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/download.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/download.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/download.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/download.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/favorite.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/favorite.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/favorite.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/favorite.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/library.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/library.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/library.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/library.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/node.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/node.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/node.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/node.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/search.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/search.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/search.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/search.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/template.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/template.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/template.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/template.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/upload.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/upload.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/viewer.effects.spec.ts
+++ b/projects/aca-content/src/lib/store/effects/viewer.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/effects/viewer.effects.ts
+++ b/projects/aca-content/src/lib/store/effects/viewer.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/initial-state.ts
+++ b/projects/aca-content/src/lib/store/initial-state.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/store/reducers/app.reducer.ts
+++ b/projects/aca-content/src/lib/store/reducers/app.reducer.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/testing/app-testing.module.ts
+++ b/projects/aca-content/src/lib/testing/app-testing.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/testing/document-base-page-utils.ts
+++ b/projects/aca-content/src/lib/testing/document-base-page-utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/testing/test-utils.ts
+++ b/projects/aca-content/src/lib/testing/test-utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/utils/aca-search-utils.spec.ts
+++ b/projects/aca-content/src/lib/utils/aca-search-utils.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/lib/utils/aca-search-utils.ts
+++ b/projects/aca-content/src/lib/utils/aca-search-utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/src/public-api.ts
+++ b/projects/aca-content/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/test.ts
+++ b/projects/aca-content/test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
+++ b/projects/aca-content/viewer/src/lib/components/preview/preview.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/components/preview/preview.component.ts
+++ b/projects/aca-content/viewer/src/lib/components/preview/preview.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.spec.ts
+++ b/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.ts
+++ b/projects/aca-content/viewer/src/lib/components/viewer/viewer.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/services/viewer.service.spec.ts
+++ b/projects/aca-content/viewer/src/lib/services/viewer.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/services/viewer.service.ts
+++ b/projects/aca-content/viewer/src/lib/services/viewer.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/lib/viewer.module.ts
+++ b/projects/aca-content/viewer/src/lib/viewer.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/public-api.ts
+++ b/projects/aca-content/viewer/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-content/viewer/src/test.ts
+++ b/projects/aca-content/viewer/src/test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/api-client-factory.ts
+++ b/projects/aca-playwright-shared/src/api/api-client-factory.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/categories-api.ts
+++ b/projects/aca-playwright-shared/src/api/categories-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/favorites-api.ts
+++ b/projects/aca-playwright-shared/src/api/favorites-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/file-actions.ts
+++ b/projects/aca-playwright-shared/src/api/file-actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/index.ts
+++ b/projects/aca-playwright-shared/src/api/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/node-content-tree.ts
+++ b/projects/aca-playwright-shared/src/api/node-content-tree.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/nodes-api.ts
+++ b/projects/aca-playwright-shared/src/api/nodes-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/people-api-models.ts
+++ b/projects/aca-playwright-shared/src/api/people-api-models.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/queries-api.ts
+++ b/projects/aca-playwright-shared/src/api/queries-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/rules-api.ts
+++ b/projects/aca-playwright-shared/src/api/rules-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/search-api.ts
+++ b/projects/aca-playwright-shared/src/api/search-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/shared-links-api.ts
+++ b/projects/aca-playwright-shared/src/api/shared-links-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/sites-api.ts
+++ b/projects/aca-playwright-shared/src/api/sites-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/tags-api.ts
+++ b/projects/aca-playwright-shared/src/api/tags-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/api/trashcan-api.ts
+++ b/projects/aca-playwright-shared/src/api/trashcan-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/base-config/global-variables.ts
+++ b/projects/aca-playwright-shared/src/base-config/global-variables.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/base-config/global.setup.ts
+++ b/projects/aca-playwright-shared/src/base-config/global.setup.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/base-config/index.ts
+++ b/projects/aca-playwright-shared/src/base-config/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/base-config/playwright.config.ts
+++ b/projects/aca-playwright-shared/src/base-config/playwright.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/base-config/report-portal.config.ts
+++ b/projects/aca-playwright-shared/src/base-config/report-portal.config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/fixtures/index.ts
+++ b/projects/aca-playwright-shared/src/fixtures/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/fixtures/page-initialization.ts
+++ b/projects/aca-playwright-shared/src/fixtures/page-initialization.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/models/custom-config.ts
+++ b/projects/aca-playwright-shared/src/models/custom-config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/models/index.ts
+++ b/projects/aca-playwright-shared/src/models/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/models/test-file.model.ts
+++ b/projects/aca-playwright-shared/src/models/test-file.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/models/user-model.ts
+++ b/projects/aca-playwright-shared/src/models/user-model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/aca-header.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/aca-header.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/actions-dropdown.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/actions-dropdown.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/base.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/base.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/breadcrumb/breadcrumb.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/conditions.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/conditions.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/data-table.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dataTable/mat-menu.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dataTable/mat-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/datetime-picker/datetime-picker.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/datetime-picker/datetime-picker.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-confirm-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-confirm-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-folder-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-folder-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-library-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/adf-library-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/content-node-selector-dialog.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/content-node-selector-dialog.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/create-from-template-dialog-component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/create-from-template-dialog-component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/delete-trash-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/delete-trash-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/edit-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/edit-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/folder-information-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/folder-information-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/link-rules.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/link-rules.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/manage-versions-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/manage-versions-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/password-overlay-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/password-overlay-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/share-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/share-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/upload-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/upload-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/upload-new-version-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/upload-new-version-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/dialogs/viewer-overlay-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/dialogs/viewer-overlay-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/edit-mode.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/edit-mode.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/error.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/error.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/manageRules/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/manageRules/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules-dialog.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules-dialog.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules-toolbar.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules-toolbar.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/manageRules/manage-rules.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/pagination.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/pagination.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-categories.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-categories.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-date.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-date.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-location.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-location.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-logic.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-logic.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-properties.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-properties.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-tags.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-filters/search-filters-tags.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-in-dialog.components.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-in-dialog.components.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-input.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-input.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-menu-card.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-menu-card.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/search/search-sorting-picker.components.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/search/search-sorting-picker.components.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/sidenav.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/sidenav.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/snackBar/snack-bar.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/snackBar/snack-bar.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/components/viewer.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/viewer.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/base.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/base.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/favorites-libraries.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/favorites-libraries.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/favorites.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/favorites.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/index.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/login.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/login.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/my-libraries.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/my-libraries.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/nodes.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/nodes.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/personal-files.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/personal-files.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/recent-files.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/recent-files.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/search.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/search.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/shared.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/shared.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/pages/trash.page.ts
+++ b/projects/aca-playwright-shared/src/page-objects/pages/trash.page.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/page-objects/playwright-base.ts
+++ b/projects/aca-playwright-shared/src/page-objects/playwright-base.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/public-api.ts
+++ b/projects/aca-playwright-shared/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/resources/index.ts
+++ b/projects/aca-playwright-shared/src/resources/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/resources/test-data/index.ts
+++ b/projects/aca-playwright-shared/src/resources/test-data/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/resources/test-data/test-data-files-folders.ts
+++ b/projects/aca-playwright-shared/src/resources/test-data/test-data-files-folders.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/resources/test-data/test-data-permissions.ts
+++ b/projects/aca-playwright-shared/src/resources/test-data/test-data-permissions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/resources/test-files/index.ts
+++ b/projects/aca-playwright-shared/src/resources/test-files/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/api.ts
+++ b/projects/aca-playwright-shared/src/utils/api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/config.ts
+++ b/projects/aca-playwright-shared/src/utils/config.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/error-strings.ts
+++ b/projects/aca-playwright-shared/src/utils/error-strings.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/exclude-tests.ts
+++ b/projects/aca-playwright-shared/src/utils/exclude-tests.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/index.ts
+++ b/projects/aca-playwright-shared/src/utils/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/library-errors.ts
+++ b/projects/aca-playwright-shared/src/utils/library-errors.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/logger.ts
+++ b/projects/aca-playwright-shared/src/utils/logger.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/paths.ts
+++ b/projects/aca-playwright-shared/src/utils/paths.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/repository-test-data.ts
+++ b/projects/aca-playwright-shared/src/utils/repository-test-data.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/state-helper.ts
+++ b/projects/aca-playwright-shared/src/utils/state-helper.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/timeouts.ts
+++ b/projects/aca-playwright-shared/src/utils/timeouts.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-playwright-shared/src/utils/utils.ts
+++ b/projects/aca-playwright-shared/src/utils/utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/app.rules.spec.ts
+++ b/projects/aca-shared/rules/src/app.rules.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/app.rules.ts
+++ b/projects/aca-shared/rules/src/app.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/navigation.rules.spec.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/navigation.rules.ts
+++ b/projects/aca-shared/rules/src/navigation.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/public-api.ts
+++ b/projects/aca-shared/rules/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/repository.rules.ts
+++ b/projects/aca-shared/rules/src/repository.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/test-rule-context.ts
+++ b/projects/aca-shared/rules/src/test-rule-context.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/user.rules.spec.ts
+++ b/projects/aca-shared/rules/src/user.rules.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/rules/src/user.rules.ts
+++ b/projects/aca-shared/rules/src/user.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/adf-extensions/extensions-data-loader.guard.spec.ts
+++ b/projects/aca-shared/src/lib/adf-extensions/extensions-data-loader.guard.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/adf-extensions/extensions-data-loader.guard.ts
+++ b/projects/aca-shared/src/lib/adf-extensions/extensions-data-loader.guard.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.service.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
+++ b/projects/aca-shared/src/lib/components/document-base-page/document-base-page.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/generic-error/generic-error.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/generic-error/generic-error.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/generic-error/generic-error.component.ts
+++ b/projects/aca-shared/src/lib/components/generic-error/generic-error.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
+++ b/projects/aca-shared/src/lib/components/info-drawer/info-drawer.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/locked-by/locked-by.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/locked-by/locked-by.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/locked-by/locked-by.component.ts
+++ b/projects/aca-shared/src/lib/components/locked-by/locked-by.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
+++ b/projects/aca-shared/src/lib/components/open-in-app/open-in-app.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout-content.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout-content.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout-error.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout-error.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout-header.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout-header.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/page-layout/page-layout.module.ts
+++ b/projects/aca-shared/src/lib/components/page-layout/page-layout.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-action/toolbar-action.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-action/toolbar-action.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-action/toolbar-action.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-action/toolbar-action.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-button/toolbar-button.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu-item/toolbar-menu-item.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar-menu/toolbar-menu.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/components/toolbar/toolbar.component.ts
+++ b/projects/aca-shared/src/lib/components/toolbar/toolbar.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/constants/index.ts
+++ b/projects/aca-shared/src/lib/constants/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/constants/mime-types.ts
+++ b/projects/aca-shared/src/lib/constants/mime-types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
+++ b/projects/aca-shared/src/lib/directives/contextmenu/contextmenu.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/directives/pagination.directive.spec.ts
+++ b/projects/aca-shared/src/lib/directives/pagination.directive.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/directives/pagination.directive.ts
+++ b/projects/aca-shared/src/lib/directives/pagination.directive.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/models/types.ts
+++ b/projects/aca-shared/src/lib/models/types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/models/viewer.rules.ts
+++ b/projects/aca-shared/src/lib/models/viewer.rules.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/routing/plugin-enabled.guard.spec.ts
+++ b/projects/aca-shared/src/lib/routing/plugin-enabled.guard.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
+++ b/projects/aca-shared/src/lib/routing/plugin-enabled.guard.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/routing/shared.guard.spec.ts
+++ b/projects/aca-shared/src/lib/routing/shared.guard.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/routing/shared.guard.ts
+++ b/projects/aca-shared/src/lib/routing/shared.guard.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/aca-file-auto-download.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/aca-file-auto-download.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
+++ b/projects/aca-shared/src/lib/services/aca-mobile-app-switcher.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app-hook.service.ts
+++ b/projects/aca-shared/src/lib/services/app-hook.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app-settings.service.ts
+++ b/projects/aca-shared/src/lib/services/app-settings.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/app.service.ts
+++ b/projects/aca-shared/src/lib/services/app.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/auto-download.service.ts
+++ b/projects/aca-shared/src/lib/services/auto-download.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/content-api.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/content-api.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/content-api.service.ts
+++ b/projects/aca-shared/src/lib/services/content-api.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/navigation-history.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/navigation-history.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/navigation-history.service.ts
+++ b/projects/aca-shared/src/lib/services/navigation-history.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/node-permission.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/node-permission.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/node-permission.service.ts
+++ b/projects/aca-shared/src/lib/services/node-permission.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/router.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/router.extension.service.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/router.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/router.extension.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/services/user-profile.service.ts
+++ b/projects/aca-shared/src/lib/services/user-profile.service.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/testing/lib-testing-module.ts
+++ b/projects/aca-shared/src/lib/testing/lib-testing-module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/utils/node.utils.ts
+++ b/projects/aca-shared/src/lib/utils/node.utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/lib/utils/note.utils.spec.ts
+++ b/projects/aca-shared/src/lib/utils/note.utils.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/src/public-api.ts
+++ b/projects/aca-shared/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/app-action-types.ts
+++ b/projects/aca-shared/store/src/actions/app-action-types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/app.actions.ts
+++ b/projects/aca-shared/store/src/actions/app.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/context-menu-action-types.ts
+++ b/projects/aca-shared/store/src/actions/context-menu-action-types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/contextmenu.actions.ts
+++ b/projects/aca-shared/store/src/actions/contextmenu.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/library.actions.ts
+++ b/projects/aca-shared/store/src/actions/library.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/metadata-aspect.actions.ts
+++ b/projects/aca-shared/store/src/actions/metadata-aspect.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/node.actions.ts
+++ b/projects/aca-shared/store/src/actions/node.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/router-action-types.ts
+++ b/projects/aca-shared/store/src/actions/router-action-types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/router.actions.ts
+++ b/projects/aca-shared/store/src/actions/router.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/search.actions.ts
+++ b/projects/aca-shared/store/src/actions/search.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/template-action-types.ts
+++ b/projects/aca-shared/store/src/actions/template-action-types.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/template.actions.ts
+++ b/projects/aca-shared/store/src/actions/template.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/upload.actions.ts
+++ b/projects/aca-shared/store/src/actions/upload.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/actions/viewer.actions.ts
+++ b/projects/aca-shared/store/src/actions/viewer.actions.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/effects/router.effects.spec.ts
+++ b/projects/aca-shared/store/src/effects/router.effects.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/effects/router.effects.ts
+++ b/projects/aca-shared/store/src/effects/router.effects.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/models/delete-status.model.ts
+++ b/projects/aca-shared/store/src/models/delete-status.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/models/deleted-node-info.model.ts
+++ b/projects/aca-shared/store/src/models/deleted-node-info.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/models/modal-configuration.ts
+++ b/projects/aca-shared/store/src/models/modal-configuration.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/models/node-info.model.ts
+++ b/projects/aca-shared/store/src/models/node-info.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/models/search-option.model.ts
+++ b/projects/aca-shared/store/src/models/search-option.model.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/public-api.ts
+++ b/projects/aca-shared/store/src/public-api.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/selectors/app.selectors.ts
+++ b/projects/aca-shared/store/src/selectors/app.selectors.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/states/app.state.ts
+++ b/projects/aca-shared/store/src/states/app.state.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/utils/node-path.utils.spec.ts
+++ b/projects/aca-shared/store/src/utils/node-path.utils.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/store/src/utils/node-path.utils.ts
+++ b/projects/aca-shared/store/src/utils/node-path.utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *

--- a/projects/aca-shared/test.ts
+++ b/projects/aca-shared/test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
  *
  * Alfresco Example Content Application
  *


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-11860

This PR updates the license header from 2005-2025 to 2005-2026. No logic, or formatting is modified in this PR 