### PR TITLE
[ACS-12385] Fix en-AU collision

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,6 +79,29 @@ jobs:
             echo "only-e2e-changes=true" >> $GITHUB_OUTPUT
           fi
 
+  protect-en-source:
+    name: 'Validate / Protect English source (en.json)'
+    # en.json is the source-of-truth and must only change via manual developer
+    # edits. Automated Crowdin sync PRs must never modify it (see ACS-12322).
+    if: ${{ github.event_name == 'pull_request' && github.head_ref == 'automated-translations-update' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fail if automated Crowdin PR modifies en.json
+        run: |
+          CHANGED_EN=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '(^|/)i18n/en\.json$' || true)
+          if [ -n "$CHANGED_EN" ]; then
+            echo "::error::Automated Crowdin PR must not modify the English source (en.json). Offending file(s):"
+            echo "$CHANGED_EN"
+            echo "This usually means a Crowdin target language (e.g. en-AU) collides with the 'en' two_letters_code. Fix crowdin.yml languages_mapping instead of merging this change."
+            exit 1
+          fi
+          echo "OK: no en.json source file modified by the automated Crowdin PR."
+
   build:
     name: 'build'
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -90,8 +90,11 @@ jobs:
           fetch-depth: 0
 
       - name: Fail if automated Crowdin PR modifies en.json
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          CHANGED_EN=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '(^|/)i18n/en\.json$' || true)
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          CHANGED_EN=$(git diff --name-only "$BASE_SHA"...HEAD | grep -E '(^|/)i18n/en\.json$' || true)
           if [ -n "$CHANGED_EN" ]; then
             echo "::error::Automated Crowdin PR must not modify the English source (en.json). Offending file(s):"
             echo "$CHANGED_EN"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,8 +81,6 @@ jobs:
 
   protect-en-source:
     name: 'Validate / Protect English source (en.json)'
-    # en.json is the source-of-truth and must only change via manual developer
-    # edits. Automated Crowdin sync PRs must never modify it (see ACS-12322).
     if: ${{ github.event_name == 'pull_request' && github.head_ref == 'automated-translations-update' }}
     runs-on: ubuntu-latest
     steps:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,14 @@
     "source": "/**/**/i18n/en.json",
     "translation": "/%original_path%/%two_letters_code%.%file_extension%",
     "export_only_approved": "true",
-    "update_option": "update_without_changes"
+    "update_option": "update_without_changes",
+    # Regional English variants share the "en" two_letters_code with the en.json
+    # source. Map them to their full locale so they export to their own files
+    # (e.g. en-AU.json) instead of overwriting the English source-of-truth.
+    "languages_mapping": {
+      "two_letters_code": {
+        "en-AU": "en-AU"
+      }
+    }
   }
 ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,9 +9,7 @@
     "translation": "/%original_path%/%two_letters_code%.%file_extension%",
     "export_only_approved": "true",
     "update_option": "update_without_changes",
-    # Regional English variants share the "en" two_letters_code with the en.json
-    # source. Map them to their full locale so they export to their own files
-    # (e.g. en-AU.json) instead of overwriting the English source-of-truth.
+
     "languages_mapping": {
       "two_letters_code": {
         "en-AU": "en-AU"

--- a/projects/aca-content/assets/i18n/en.json
+++ b/projects/aca-content/assets/i18n/en.json
@@ -10,12 +10,12 @@
                 "NAME": "Name",
                 "VERSION": "Version",
                 "VENDOR": "Vendor",
-                "LICENSE": "Licence",
+                "LICENSE": "License",
                 "RUNTIME": "Runtime",
                 "DESCRIPTION": "Description"
             },
             "LICENSE": {
-                "TITLE": "Licence",
+                "TITLE": "License",
                 "PROPERTY": "Property",
                 "VALUE": "Value"
             },
@@ -134,8 +134,8 @@
                         "TEXT": "Join libraries to upload, view, and share files."
                     },
                     "FAVORITE_LIBRARIES": {
-                        "TITLE": "No Favourite Libraries",
-                        "TEXT": "Favourite a library that you want to find easily later."
+                        "TITLE": "No Favorite Libraries",
+                        "TEXT": "Favorite a library that you want to find easily later."
                     },
                     "ALL_LIBRARIES": {
                         "TITLE": "No library found",
@@ -151,10 +151,10 @@
                         }
                     },
                     "FAVORITE_LIBRARIES": {
-                        "TITLE": "Favourite Libraries",
+                        "TITLE": "Favorite Libraries",
                         "SIDENAV_LINK": {
-                            "LABEL": "Favourite Libraries",
-                            "TOOLTIP": "Access my favourite libraries"
+                            "LABEL": "Favorite Libraries",
+                            "TOOLTIP": "Access my favorite libraries"
                         }
                     },
                     "ALL_LIBRARIES": {
@@ -194,14 +194,14 @@
                 }
             },
             "FAVORITES": {
-                "TITLE": "Favourites",
+                "TITLE": "Favorites",
                 "SIDENAV_LINK": {
-                    "LABEL": "Favourites",
-                    "TOOLTIP": "View your favourite files and folders"
+                    "LABEL": "Favorites",
+                    "TOOLTIP": "View your favorite files and folders"
                 },
                 "EMPTY_STATE": {
-                    "TITLE": "No favourite files or folders",
-                    "TEXT": "Favourite items that you want to easily find later."
+                    "TITLE": "No favorite files or folders",
+                    "TEXT": "Favorite items that you want to easily find later."
                 }
             },
             "TRASHCAN": {
@@ -301,9 +301,9 @@
             "UNDO": "Undo",
             "PERMISSIONS": "Permissions",
             "RESTORE": "Restore",
-            "FAVORITE": "Favourite",
-            "ADD_FAVORITE": "Add Favourite",
-            "REMOVE_FAVORITE": "Remove Favourite",
+            "FAVORITE": "Favorite",
+            "ADD_FAVORITE": "Add Favorite",
+            "REMOVE_FAVORITE": "Remove Favorite",
             "UNSHARE": "Unshare",
             "DETAILS": "View Details",
             "VERSIONS": "Manage Versions",
@@ -458,11 +458,11 @@
                 },
                 "LIBRARY_DELETED": "Library deleted",
                 "LEFT_LIBRARY": "You have left the library",
-                "FAVORITE_NODE_ADDED": "Added {{ name }} to favourites",
-                "FAVORITE_NODES_ADDED": "Added {{ number }} items to favourites",
-                "FAVORITE_NODE_REMOVED": "Removed {{ name }} from favourites",
-                "FAVORITE_NODES_REMOVED": "Removed {{ number }} items from favourites",
-                "FAVORITE_NODE_NOT_FOUND": "{{ name }} is not favourite"
+                "FAVORITE_NODE_ADDED": "Added {{ name }} to favorites",
+                "FAVORITE_NODES_ADDED": "Added {{ number }} items to favorites",
+                "FAVORITE_NODE_REMOVED": "Removed {{ name }} from favorites",
+                "FAVORITE_NODES_REMOVED": "Removed {{ number }} items from favorites",
+                "FAVORITE_NODE_NOT_FOUND": "{{ name }} is not favorite"
             }
         },
         "CONTENT_METADATA": {
@@ -517,7 +517,7 @@
             "CREATED": "Created",
             "MODIFIED": "Modified",
             "DONE": "Done",
-            "ERROR": "Something went wrong, please close this dialogue and try again"
+            "ERROR": "Something went wrong, please close this dialog and try again"
         },
         "ADDITIONAL_REFERENCES_DIALOG": {
             "TITLE": "Additional Reference Locations",


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-12385

American terms restored in en.json
`Licence` - `License`
`Favourite` - `Favorite`
`Dialogue` - `Dialog`

Added two_letters_code for en-AU