### PR TITLE
[ACS-10229] Specify role for workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -38,6 +38,5 @@
   },
   "cacheDirectory": "nxcache",
   "useInferencePlugins": false,
-  "useLegacyCache": true,
-  "analytics": false
+  "useLegacyCache": true
 }

--- a/nx.json
+++ b/nx.json
@@ -38,5 +38,6 @@
   },
   "cacheDirectory": "nxcache",
   "useInferencePlugins": false,
-  "useLegacyCache": true
+  "useLegacyCache": true,
+  "analytics": false
 }

--- a/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.html
+++ b/projects/aca-content/src/lib/components/sidenav/components/sidenav-header.component.html
@@ -14,12 +14,12 @@
       />
     </button>
 
-    <div
+    <a
       class="aca-sidenav-header-title-text"
       data-automation-id="app-sidenav-header-title-text"
       [routerLink]="landingPage">
       {{ appName | translate }}
-    </div>
+    </a>
 
     <aca-toolbar [items]="actions" />
   </div>

--- a/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
+++ b/projects/aca-content/src/lib/components/sidenav/sidenav.component.scss
@@ -40,6 +40,7 @@
         font-weight: 400;
         font-size: var(--theme-body-1-font-size);
         cursor: pointer;
+        text-decoration: none;
       }
 
       .adf-notification-history-menu_button {


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/ACS-10229

Previously the `Workspace` title in the sidenav header was a <div> with routerLink, so it was focusable and navigable but exposed `no role to assistive technologies`. Screen readers announced only the text, not its purpose.