### PR TITLE
[MNT-25612] ADW Metadata Drawer ignores read‑only presets (readOnlyAspects / readOnlyProperties)

### DIFF
--- a/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
+++ b/projects/aca-playwright-shared/src/page-objects/components/adf-info-drawer.component.ts
@@ -86,7 +86,7 @@ export class AdfInfoDrawerComponent extends BaseComponent {
   public generalInfoAccordion = this.getChild('[data-automation-id="adf-metadata-group-properties"]');
   public generalInfoProperties = this.generalInfoAccordion.locator('.adf-property');
   public generalInfoEditButton = this.getChild('[data-automation-id="meta-data-general-info-edit"]');
-  public exifInfoAccordion = this.getChild('[data-automation-id="adf-metadata-group-APP.CONTENT_METADATA.EXIF_GROUP_TITLE"]');
+  public exifInfoAccordion = this.getChild('[data-automation-id="adf-metadata-group-APP.CONTENT_METADATA.EXIF_GROUP_TITLE"]').first();
   public exifInfoProperties = this.exifInfoAccordion.locator('.adf-property');
   public generalInfoNameField = this.getChild('[data-automation-id="card-textitem-value-properties.cm:name"]');
   public generalInfoTitleField = this.getChild('[data-automation-id="card-textitem-value-properties.cm:title"]');

--- a/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.spec.ts
@@ -128,6 +128,75 @@ describe('AppExtensionService', () => {
       expect(service.contentMetadata).toBeDefined();
     });
 
+    it('should keep content metadata preset settings defined in app.config.json', () => {
+      appConfigService.config['content-metadata'] = {
+        presets: {
+          custom: [
+            {
+              id: 'app.content.metadata.customSetting',
+              readOnlyProperties: ['cm:name', 'cm:title'],
+              readOnlyAspects: ['cm:titled']
+            }
+          ]
+        }
+      };
+
+      applyConfig({
+        ...defaultConfigMock,
+        features: {
+          'content-metadata-presets': [
+            {
+              id: 'app.content.metadata.custom',
+              custom: [
+                {
+                  id: 'app.content.metadata.customSetting',
+                  includeAll: true,
+                  exclude: ['cm:versionable']
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const custom = appConfigService.config['content-metadata'].presets.custom;
+
+      expect(custom.length).toBe(1);
+      expect(custom[0].includeAll).toBeTrue();
+      expect(custom[0].exclude).toEqual(['cm:versionable']);
+      expect(custom[0].readOnlyProperties).toEqual(['cm:name', 'cm:title']);
+      expect(custom[0].readOnlyAspects).toEqual(['cm:titled']);
+    });
+
+    it('should not lose extension preset blocks that app.config.json does not override', () => {
+      appConfigService.config['content-metadata'] = {
+        presets: {
+          custom: [{ id: 'app.content.metadata.customSetting', readOnlyProperties: ['cm:name'] }]
+        }
+      };
+
+      applyConfig({
+        ...defaultConfigMock,
+        features: {
+          'content-metadata-presets': [
+            {
+              id: 'app.content.metadata.custom',
+              custom: [
+                { id: 'app.content.metadata.customSetting', includeAll: true },
+                { id: 'app.content.metadata.exifGroup', title: 'EXIF', items: [{ aspect: 'exif:exif', properties: '*' }] }
+              ]
+            }
+          ]
+        }
+      });
+
+      const custom = appConfigService.config['content-metadata'].presets.custom;
+
+      expect(custom.length).toBe(2);
+      expect(custom[0].readOnlyProperties).toEqual(['cm:name']);
+      expect(custom[1].id).toBe('app.content.metadata.exifGroup');
+    });
+
     it('should merge two arrays based on [id] keys', () => {
       const left = [
         {

--- a/projects/aca-shared/src/lib/services/app.extension.service.ts
+++ b/projects/aca-shared/src/lib/services/app.extension.service.ts
@@ -309,10 +309,14 @@ export class AppExtensionService implements RuleContext {
       return null;
     }
 
-    let presets = {};
-    presets = this.filterDisabled(mergeObjects(presets, ...elements));
-
     const metadata = this.appConfig.config['content-metadata'] || {};
+
+    let presets = mergeObjects({}, ...elements);
+    if (metadata.presets) {
+      presets = mergeObjects(presets, metadata.presets);
+    }
+    presets = this.filterDisabled(presets);
+
     metadata.presets = presets;
 
     this.appConfig.config['content-metadata'] = metadata;


### PR DESCRIPTION
**JIRA ticket link or changeset's description**
https://hyland.atlassian.net/browse/MNT-25612