### PR TITLE
Fix local ACS E2E deploys failing after acs-deployment's reindexing hook change

### DIFF
--- a/.github/actions/deploy-local-acs/action.yml
+++ b/.github/actions/deploy-local-acs/action.yml
@@ -24,6 +24,13 @@ inputs:
       chart's standard values.yaml instead.
     required: false
     default: 'latest'
+  helm_install_timeout:
+    description: >-
+      Timeout for the Helm install to wait for the chart's resources and
+      hooks (e.g. the search reindexing job) to become ready, in Helm's
+      duration format (e.g. '5m', '10m').
+    required: false
+    default: '10m'
 
 runs:
   using: "composite"
@@ -170,6 +177,7 @@ runs:
       shell: bash
       env:
         ACS_VERSION_INPUT: ${{ inputs.acs_deployment_version }}
+        HELM_INSTALL_TIMEOUT: ${{ inputs.helm_install_timeout }}
       run: |
         [ "$ACS_VERSION_INPUT" = "master" ] && chart_values="pre-release_values.yaml" || chart_values="values.yaml"
         for attempt in 1 2 3; do
@@ -185,6 +193,7 @@ runs:
           sleep "$sleep_s"
         done
         helm install acs acs-deployment/helm/alfresco-content-services \
+          --timeout "$HELM_INSTALL_TIMEOUT" \
           --set global.search.sharedSecret="$(openssl rand -hex 24)" \
           --values "acs-deployment/helm/alfresco-content-services/${chart_values}" \
           --values acs-deployment/test/enterprise-integration-test-values.yaml \

--- a/.github/actions/deploy-local-acs/action.yml
+++ b/.github/actions/deploy-local-acs/action.yml
@@ -26,9 +26,9 @@ inputs:
     default: 'latest'
   helm_install_timeout:
     description: >-
-      Timeout for the Helm install to wait for the chart's resources and
-      hooks (e.g. the search reindexing job) to become ready, in Helm's
-      duration format (e.g. '5m', '10m').
+      Timeout for the Helm install to wait for the chart's hooks (e.g. the
+      search reindexing job) and, via --wait, its Deployments, StatefulSets
+      and PVCs to become ready, in Helm's duration format (e.g. '5m', '10m').
     required: false
     default: '10m'
 
@@ -193,14 +193,12 @@ runs:
           sleep "$sleep_s"
         done
         helm install acs acs-deployment/helm/alfresco-content-services \
+          --wait \
           --timeout "$HELM_INSTALL_TIMEOUT" \
           --set global.search.sharedSecret="$(openssl rand -hex 24)" \
           --values "acs-deployment/helm/alfresco-content-services/${chart_values}" \
           --values acs-deployment/test/enterprise-integration-test-values.yaml \
           --values .github/acs-deployment-values-override.yaml
-
-    - name: Wait for pods to be ready
-      uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@v18.21.0
 
     - name: Report deployed ACS versions
       if: always()


### PR DESCRIPTION
## Summary
acs-deployment recently changed the search reindexing job to run as a Helm post-install hook instead of a plain, concurrent Job (Alfresco/acs-deployment#1575), so that its Newman tests only start once reindexing has actually finished. That surfaced two problems in this repo's local ACS deploy step used for E2E: the reindexing hook can take longer than Helm's default 5-minute install timeout, failing `helm install` outright, and the follow-up "wait for pods to be ready" step, which ran `kubectl wait --for=condition=Ready --all=true pods`, could never succeed once the reindexing pod had completed, since a terminated pod's Ready condition stays false forever.

The `deploy-local-acs` action now exposes a configurable `helm_install_timeout` input (default `10m`) and passes it, together with `--wait`, straight to `helm install`, mirroring how acs-deployment's own CI now waits for the post-install hook alongside its Deployments, StatefulSets and PVCs. The separate `kubectl-wait` step that waited for every pod is removed, since it's both redundant with `--wait` and incompatible with a completed hook Job's pod.

## Test plan
- [x] E2E Playwright matrix (local ACS deploy) passes
- [x] Existing callers (`e2e-playwright-reusable.yml`, `pull-request.yml`) keep working unchanged since they rely on the new default